### PR TITLE
Service levels filtering

### DIFF
--- a/components/cal/filter.vue
+++ b/components/cal/filter.vue
@@ -139,6 +139,103 @@
         </aside>
       </div>
 
+      <!-- SERVICE LEVELS -->
+      <div v-if="activePanel === 'service-levels'">
+        <aside class="cal-service-levels menu">
+          <p class="menu-label">
+            Frequency
+          </p>
+
+          <o-field grouped>
+            <o-checkbox
+              v-model="frequencyUnderEnabled"
+              label="Avg. Frequency ≦"
+              :disabled="!stopDepartureLoadingComplete"
+            />
+            <div class="cal-input-width-80">
+              <o-input
+                v-model="frequencyUnder"
+                number
+                type="number"
+                :disabled="!stopDepartureLoadingComplete || !frequencyUnderEnabled"
+              />
+            </div>
+            <div>
+              minutes
+            </div>
+          </o-field>
+
+          <o-field grouped>
+            <o-checkbox
+              v-model="frequencyOverEnabled"
+              label="Avg. Frequency >"
+              :disabled="!stopDepartureLoadingComplete"
+            />
+            <div class="cal-input-width-80">
+              <o-input
+                v-model="frequencyOver"
+                number
+                type="number"
+                :disabled="!stopDepartureLoadingComplete || !frequencyOverEnabled"
+              />
+            </div>
+            <div>
+              minutes
+            </div>
+          </o-field>
+
+          <o-field>
+            <o-checkbox
+              v-model="calculateFequencyMode"
+              label="Calculate frequency based on single routes"
+              :disabled="true"
+            />
+          </o-field>
+
+          <p class="menu-label">
+            Fares
+          </p>
+
+          <o-field grouped>
+            <o-checkbox
+              v-model="maxFareEnabled"
+              label="Maximum fare $"
+              :disabled="true"
+            />
+            <div class="cal-input-width-80">
+              <o-input
+                v-model="maxFare"
+                number
+                type="number"
+                placeholder="0"
+                :disabled="true"
+              />
+            </div>
+          </o-field>
+
+          <o-field grouped>
+            <o-checkbox
+              v-model="minFareEnabled"
+              label="Minimum fare $"
+              :disabled="true"
+            />
+            <div class="cal-input-width-80">
+              <o-input
+                v-model="minFare"
+                number
+                type="number"
+                placeholder="0"
+                :disabled="true"
+              />
+            </div>
+          </o-field>
+          <p class="filter-legend">
+            * Fare filtering not yet implemented
+          </p>
+
+        </aside>
+      </div>
+
       <!-- LAYERS -->
       <div v-if="activePanel === 'transit-layers'">
         <aside class="menu">
@@ -256,7 +353,8 @@ import { defineEmits } from 'vue'
 import { type Stop } from './scenario.vue'
 
 const menuItems = [
-  { icon: 'chart-bar', label: 'Timeframes', panel: 'timeframes' },
+  { icon: 'calendar-blank', label: 'Timeframes', panel: 'timeframes' },
+  { icon: 'chart-bar', label: 'Service Levels', panel: 'service-levels' },
   { icon: 'bus', label: 'Transit Layers', panel: 'transit-layers' },
   { icon: 'layers-outline', label: 'Map Display', panel: 'map' },
   { icon: 'cog', label: 'Settings', panel: 'settings' },
@@ -282,6 +380,15 @@ const selectedTimeOfDayMode = defineModel<string>('selectedTimeOfDayMode')
 const selectedRouteTypes = defineModel<string[]>('selectedRouteTypes')
 const selectedDays = defineModel<string[]>('selectedDays')
 const selectedAgencies = defineModel<string[]>('selectedAgencies')
+const frequencyUnderEnabled = defineModel<boolean>('frequencyUnderEnabled')
+const frequencyUnder = defineModel<number>('frequencyUnder')
+const frequencyOverEnabled = defineModel<boolean>('frequencyOverEnabled')
+const frequencyOver = defineModel<string>('freqencyOver')
+const calculateFrequencyMode = defineModel<string>('calculateFrequencyMode')
+const maxFareEnabled = defineModel<boolean>('maxFareEnabled')
+const maxFare = defineModel<string>('maxFare')
+const minFareEnabled = defineModel<boolean>('minFareEnabled')
+const minFare = defineModel<string>('minFare')
 const stopDepartureLoadingComplete = defineModel<boolean>('stopDepartureLoadingComplete')
 
 ///////////////////
@@ -361,6 +468,21 @@ const knownAgencies = computed(() => {
 
   > div {
     margin-bottom: unset;
+  }
+}
+
+.cal-service-levels {
+  .is-grouped div {
+    display: flex;
+    align-items: center;
+  }
+  .is-grouped .checkbox {
+    width: 185px;
+  }
+  .cal-input-width-80 {
+    max-width: 80px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
   }
 }
 

--- a/components/cal/filter.vue
+++ b/components/cal/filter.vue
@@ -236,7 +236,6 @@
           <p class="filter-legend">
             * Fare filtering not yet implemented
           </p>
-
         </aside>
       </div>
 

--- a/components/cal/filter.vue
+++ b/components/cal/filter.vue
@@ -140,7 +140,7 @@
       </div>
 
       <!-- SERVICE LEVELS -->
-      <div v-if="activePanel === 'service-levels'">
+      <div v-if="activeTab === 'service-levels'">
         <aside class="cal-service-levels menu">
           <p class="menu-label">
             Frequency
@@ -188,7 +188,7 @@
 
           <o-field>
             <o-checkbox
-              v-model="calculateFequencyMode"
+              v-model="calculateFrequencyMode"
               label="Calculate frequency based on single routes"
               :disabled="true"
             />
@@ -377,11 +377,11 @@ import { defineEmits } from 'vue'
 import { type Stop } from '../stop'
 
 const menuItems = [
-  { icon: 'calendar-blank', label: 'Timeframes', panel: 'timeframes' },
-  { icon: 'chart-bar', label: 'Service Levels', panel: 'service-levels' },
-  { icon: 'bus', label: 'Transit Layers', panel: 'transit-layers' },
-  { icon: 'layers-outline', label: 'Map Display', panel: 'map' },
-  { icon: 'cog', label: 'Settings', panel: 'settings' },
+  { icon: 'calendar-blank', label: 'Timeframes', tab: 'timeframes' },
+  { icon: 'chart-bar', label: 'Service Levels', tab: 'service-levels' },
+  { icon: 'bus', label: 'Transit Layers', tab: 'transit-layers' },
+  { icon: 'layers-outline', label: 'Data Display', tab: 'data-display' },
+  { icon: 'cog', label: 'Settings', tab: 'settings' },
 ]
 
 const props = defineProps<{
@@ -409,11 +409,11 @@ const frequencyUnderEnabled = defineModel<boolean>('frequencyUnderEnabled')
 const frequencyUnder = defineModel<number>('frequencyUnder')
 const frequencyOverEnabled = defineModel<boolean>('frequencyOverEnabled')
 const frequencyOver = defineModel<string>('freqencyOver')
-const calculateFrequencyMode = defineModel<string>('calculateFrequencyMode')
+const calculateFrequencyMode = defineModel<boolean>('calculateFrequencyMode')
 const maxFareEnabled = defineModel<boolean>('maxFareEnabled')
-const maxFare = defineModel<string>('maxFare')
+const maxFare = defineModel<number>('maxFare')
 const minFareEnabled = defineModel<boolean>('minFareEnabled')
-const minFare = defineModel<string>('minFare')
+const minFare = defineModel<number>('minFare')
 const stopDepartureLoadingComplete = defineModel<boolean>('stopDepartureLoadingComplete')
 const activeTab = defineModel<string>('activeTab')
 

--- a/components/cal/filter.vue
+++ b/components/cal/filter.vue
@@ -157,6 +157,7 @@
                 v-model="frequencyUnder"
                 number
                 type="number"
+                min="0"
                 :disabled="!stopDepartureLoadingComplete || !frequencyUnderEnabled"
               />
             </div>
@@ -176,6 +177,7 @@
                 v-model="frequencyOver"
                 number
                 type="number"
+                min="0"
                 :disabled="!stopDepartureLoadingComplete || !frequencyOverEnabled"
               />
             </div>
@@ -202,12 +204,13 @@
               label="Maximum fare $"
               :disabled="true"
             />
-            <div class="cal-input-width-80">
+            <div class="cal-input-width-100">
               <o-input
                 v-model="maxFare"
                 number
                 type="number"
-                placeholder="0"
+                min="0"
+                step="0.01"
                 :disabled="true"
               />
             </div>
@@ -219,12 +222,13 @@
               label="Minimum fare $"
               :disabled="true"
             />
-            <div class="cal-input-width-80">
+            <div class="cal-input-width-100">
               <o-input
                 v-model="minFare"
                 number
                 type="number"
-                placeholder="0"
+                min="0"
+                step="0.01"
                 :disabled="true"
               />
             </div>
@@ -481,6 +485,11 @@ const knownAgencies = computed(() => {
   }
   .cal-input-width-80 {
     max-width: 80px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+  }
+  .cal-input-width-100 {
+    max-width: 100px;
     border: 1px solid #ccc;
     border-radius: 5px;
   }

--- a/pages/tne.vue
+++ b/pages/tne.vue
@@ -412,7 +412,6 @@ const minFare = computed({
   }
 })
 
-
 /////////////////////////
 // Event passing
 /////////////////////////
@@ -476,7 +475,7 @@ async function resetFilters () {
     startTime: '',
     endTime: '',
     selectedAgencies: '',
-    //selectedDays: '',
+    // selectedDays: '',
     selectedRouteTypes: '',
     selectedDayOfWeekMode: '',
     selectedTimeOfDayMode: '',

--- a/pages/tne.vue
+++ b/pages/tne.vue
@@ -316,7 +316,7 @@ const selectedAgencies = computed({
 
 const selectedDays = computed({
   get () {
-    if (!route.query?.selectedDays) {
+    if (!route.query.hasOwnProperty('selectedDays')) {
       // if no `selectedDays` param present, check them all
       return dowValues.slice()
     } else {
@@ -476,7 +476,7 @@ async function resetFilters () {
     startTime: '',
     endTime: '',
     selectedAgencies: '',
-    selectedDays: '',
+    //selectedDays: '',
     selectedRouteTypes: '',
     selectedDayOfWeekMode: '',
     selectedTimeOfDayMode: '',
@@ -493,6 +493,10 @@ async function resetFilters () {
     unitSystem: '',
     baseMap: ''
   })
+  // Note, `selectedDays` is special, see note below.
+  // When clearing filters, it should removed, not set to ''
+  delete p.selectedDays
+
   await navigateTo({ replace: true, query: p })
 }
 
@@ -501,9 +505,13 @@ async function resetFilters () {
 //////////////////////
 
 function removeEmpty (v: Record<string, any>): Record<string, any> {
+  // Note, `selectedDays` is special - we want to allow it to be empty string ''.
+  // That means the user unchecked all the days.
+  // Removing it would re-check all the days.
+  // todo: improve?
   const r: Record<string, any> = {}
   for (const k in v) {
-    if (v[k]) {
+    if (v[k] || k === 'selectedDays') {
       r[k] = v[k]
     }
   }

--- a/pages/tne.vue
+++ b/pages/tne.vue
@@ -77,6 +77,7 @@
             @explore="setReady()"
           />
         </div>
+
         <div v-if="activeTab === 'filter'" class="cal-overlay">
           <cal-filter
             v-model:start-date="startDate"
@@ -91,6 +92,15 @@
             v-model:selected-agencies="selectedAgencies"
             v-model:selected-day-of-week-mode="selectedDayOfWeekMode"
             v-model:selected-time-of-day-mode="selectedTimeOfDayMode"
+            v-model:frequency-under-enabled="frequencyUnderEnabled"
+            v-model:frequency-under="frequencyUnder"
+            v-model:frequency-over-enabled="frequencyOverEnabled"
+            v-model:frequency-over="frequencyOver"
+            v-model:calculate-frequency-mode="calculateFrequencyMode"
+            v-model:max-fare-enabled="maxFareEnabled"
+            v-model:max-fare="maxFare"
+            v-model:min-fare-enabled="minFareEnabled"
+            v-model:min-fare="minFare"
             v-model:stop-departure-loading-complete="stopDepartureLoadingComplete"
             :bbox="bbox"
             :stop-features="stopFeatures"
@@ -321,6 +331,88 @@ const selectedDays = computed({
   }
 })
 
+const frequencyUnderEnabled = computed({
+  get () {
+    return route.query.frequencyUnderEnabled?.toString() === 'true'
+  },
+  set (v: boolean) {
+    setQuery({ ...route.query, frequencyUnderEnabled: v ? 'true' : '' })
+  }
+})
+
+const frequencyUnder = computed({
+  get () {
+    return parseInt(route.query.frequencyUnder?.toString() || '') || 0
+  },
+  set (v: number) {
+    setQuery({ ...route.query, frequencyUnder: v.toString() })
+  }
+})
+
+const frequencyOverEnabled = computed({
+  get () {
+    return route.query.frequencyOverEnabled?.toString() === 'true'
+  },
+  set (v: boolean) {
+    setQuery({ ...route.query, frequencyOverEnabled: v ? 'true' : '' })
+  }
+})
+
+const frequencyOver = computed({
+  get () {
+    return parseInt(route.query.frequencyOver?.toString() || '') || 0
+  },
+  set (v: number) {
+    setQuery({ ...route.query, frequencyOver: v.toString() })
+  }
+})
+
+const calculateFrequencyMode = computed({
+  get () {
+    return route.query.calculateFrequencyMode?.toString() === 'true'
+  },
+  set (v: boolean) {
+    setQuery({ ...route.query, calculateFrequencyMode: v ? 'true' : '' })
+  }
+})
+
+const maxFareEnabled = computed({
+  get () {
+    return route.query.maxFareEnabled?.toString() === 'true'
+  },
+  set (v: boolean) {
+    setQuery({ ...route.query, maxFareEnabled: v ? 'true' : '' })
+  }
+})
+
+const maxFare = computed({
+  get () {
+    return parseInt(route.query.maxFare?.toString() || '') || 0
+  },
+  set (v: number) {
+    setQuery({ ...route.query, maxFare: v.toString() })
+  }
+})
+
+const minFareEnabled = computed({
+  get () {
+    return route.query.minFareEnabled?.toString() === 'true'
+  },
+  set (v: string) {
+    setQuery({ ...route.query, minFareEnabled: v ? 'true' : '' })
+  }
+})
+
+const minFare = computed({
+  get () {
+    return parseInt(route.query.minFare?.toString() || '') || 0
+  },
+  set (v: string) {
+    setQuery({ ...route.query, minFare: v.toString() })
+  }
+})
+
+
 /////////////////////////
 // Event passing
 /////////////////////////
@@ -388,6 +480,15 @@ async function resetFilters () {
     selectedRouteTypes: '',
     selectedDayOfWeekMode: '',
     selectedTimeOfDayMode: '',
+    frequencyUnderEnabled: '',
+    frequencyUnder: '',
+    frequencyOverEnabled: '',
+    frequencyOver: '',
+    calculateFrequencyMode: '',
+    maxFareEnabled: '',
+    maxFare: '',
+    minFareEnabled: '',
+    minFare: '',
     colorKey: '',
     unitSystem: '',
     baseMap: ''


### PR DESCRIPTION
This adds the Service Levels filtering tab
(re: #46)

Also added back the special filtering rules (hasOwnProperty) to support `selectedDays` query param (re: #60)
The `selectedDays` param is special because we want it to allow it to be an empty string.
Empty string means the user unchecked all the days - in this situation we don't want to remove the param and restore all the checks.
