### PR TITLE
Add Filter Summary to report component

### DIFF
--- a/components/cal/report.vue
+++ b/components/cal/report.vue
@@ -6,7 +6,21 @@
 
     <div class="cal-report-options block">
       <div class="filter-detail">
-        Filter detail here (TBD)
+        <div v-if="dataDisplayMode === 'Agency'">
+          Showing agencies:
+        </div>
+        <div v-if="dataDisplayMode === 'Route'">
+          Showing routes:
+        </div>
+        <div v-if="dataDisplayMode === 'Stop'">
+          Showing stops:
+        </div>
+
+        <ul style="list-style: disc inside">
+          <li v-for="item of filterSummary" :key="item">
+            {{ item }}
+          </li>
+        </ul>
       </div>
 
       <div class="report-select">
@@ -135,6 +149,7 @@ import { type TableColumn } from './datagrid.vue'
 const props = defineProps<{
   stopFeatures: Stop[]
   routeFeatures: Route[]
+  filterSummary: string[]
 }>()
 
 const current = ref(1)

--- a/components/datetime.ts
+++ b/components/datetime.ts
@@ -11,11 +11,11 @@ export function parseDate(d: string): Date | null {
     return null
   }
 
-export function fmtDate(d: Date | null): string {
+export function fmtDate(d: Date | null, fmt?: string = dateFmt): string {
     if (!d) {
         return ''
     }
-    return format(d, dateFmt)
+    return format(d, fmt)
 }
 
 export function parseTime(d: string): Date | null {
@@ -25,11 +25,11 @@ export function parseTime(d: string): Date | null {
     return null
 }
 
-export function fmtTime(d: Date | null): string {
+export function fmtTime(d: Date | null, fmt?: string = timeFmt): string {
     if (!d) {
         return ''
     }
-    return format(d, timeFmt)
+    return format(d, fmt)
 }
 
 export function getLocalDateNoTime(): Date {


### PR DESCRIPTION
re: #43 

This generates a filter summary as a computed property to add plain-text descriptions of the established filters. 
For example, "• operating between 03/17/2025 and 03/24/2025"

This also adjusts the date/time formatter functions to accept an optional format argument to override the default format strings. These are used to display the dates and times in friendlier formats on the filter summary