### PR TITLE
Disable days of week checkboxes that fall outside the specified start/end date range

### DIFF
--- a/components/cal/filter.vue
+++ b/components/cal/filter.vue
@@ -81,9 +81,12 @@
 
           <ul>
             <li v-for="dowValue of dowValues" :key="dowValue">
-              <o-checkbox v-model="selectedDays" :native-value="dowValue" :disabled="!stopDepartureLoadingComplete">
-                {{ dowValue }}
-              </o-checkbox>
+              <o-checkbox
+                v-model="selectedDays"
+                :native-value="dowValue"
+                :label="dowValue"
+                :disabled="!stopDepartureLoadingComplete || !dowAvailable.has(dowValue)"
+              />
             </li>
           </ul>
 
@@ -386,6 +389,7 @@ import { type dow, dowValues, routeTypes, routeColorModes, dataDisplayModes, bas
 </script>
 
 <script setup lang="ts">
+import { eachDayOfInterval } from 'date-fns'
 import { fmtDate } from '../datetime'
 import { defineEmits } from 'vue'
 import { type Stop } from '../stop'
@@ -470,6 +474,18 @@ const knownAgencies = computed(() => {
     return Array.from(agencies).filter(a => a.toLowerCase().includes(sv))
   }
   return Array.from(agencies).toSorted((a, b) => a.localeCompare(b))
+})
+
+const dowAvailable = computed((): Set<string> => {
+  // JavaScript day of week starts on Sunday, this is different from dowValues
+  const jsDowValues: dow[] = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
+  const result = new Set<string>()
+  const range = eachDayOfInterval({ start: startDate.value, end: endDate.value })
+  for (const d of range) {
+    result.add(jsDowValues[d.getDay()])
+    if (result.size === 7) break // we got them all
+  }
+  return result
 })
 
 </script>


### PR DESCRIPTION
(re: #33)

This adds a computed `dowAvailable` property to generate a `Set<string>` of available date of week values,
and uses that to disable the checkbox if the day of week is out of range.