### PR TITLE
Add "Download as GeoJSON" button

### DIFF
--- a/components/cal/geojson-download.vue
+++ b/components/cal/geojson-download.vue
@@ -7,40 +7,32 @@
 </template>
 
 <script>
-import { stringify } from 'csv-stringify/browser/esm/sync'
+import stringify from '@aitodotai/json-stringify-pretty-compact'
 
-function dataToBlob (csvData) {
-  const keys = {}
-  if (csvData.length > 0) {
-    for (const k of Object.keys(csvData[0])) {
-      keys[k] = k
-    }
+function dataToBlob (features) {
+  const geojson = {
+    type: 'FeatureCollection',
+    features: features
   }
-  const data = stringify(
-    csvData,
-    {
-      header: true,
-      columns: keys
-    })
-  const blob = new Blob([data], { type: 'application/csv' })
+  const blob = new Blob([stringify(geojson, { maxLength: 100 })], { type: 'application/geo+json' })
   return blob
 }
 
 export default {
   props: {
-    buttonText: { type: String, default () { return 'Download as CSV' } },
+    buttonText: { type: String, default () { return 'Download as GeoJSON' } },
     disabled: { type: Boolean, default: false },
     filename: { type: String, default: 'export' },
-    data: { type: Array, default () { return [] } }
+    data: { type: Array, default () { return [] } },
   },
   methods: {
     async saveFile () {
       const blob = await dataToBlob(this.data)
       const e = document.createEvent('MouseEvents')
       const a = document.createElement('a')
-      a.download = this.$filters.sanitizeFilename(this.filename + '.csv')
+      a.download = this.$filters.sanitizeFilename(this.filename + '.geojson')
       a.href = window.URL.createObjectURL(blob)
-      a.dataset.downloadurl = ['text/csv', a.download, a.href].join(':')
+      a.dataset.downloadurl = ['application/geo+json', a.download, a.href].join(':')
       e.initEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null)
       a.dispatchEvent(e)
     }

--- a/components/cal/map-share.vue
+++ b/components/cal/map-share.vue
@@ -8,8 +8,8 @@
         Copy URL to Clipboard
       </o-button>
       <br><br>
-      <tl-geojson-downloader :features="displayFeatures" label="Download as GeoJSON" filename="export" :disabled="!stopDepartureLoadingComplete" />
-      <br><br>
+      <cal-geojson-download :data="exportFeatures" :disabled="!stopDepartureLoadingComplete" />
+      <br>
       <cal-csv-download :data="routeCsvData" button-text="Download routes as CSV" filename="routes" :disabled="!stopDepartureLoadingComplete" />
       <br>
       <cal-csv-download :data="stopCsvData" button-text="Download stops as CSV" filename="stops" :disabled="!stopDepartureLoadingComplete" />
@@ -32,7 +32,7 @@ const props = defineProps<{
   stopFeatures: Stop[]
   routeFeatures: Route[]
   agencyFeatures: Agency[]
-  displayFeatures: Feature[]
+  exportFeatures: Feature[]
   stopDepartureLoadingComplete: boolean
 }>()
 

--- a/components/cal/map.vue
+++ b/components/cal/map.vue
@@ -189,7 +189,9 @@ const agencyData = computed((): AgencyData[] => {
       const rid = rstop.route.route_id
       const aid = rstop.route.agency?.agency_id
       const aname = rstop.route.agency?.agency_name
-      if (!aid || !aname) continue // no valid agency listed for this stop?
+      if (!aid || !aname) {
+        continue // no valid agency listed for this stop?
+      }
 
       let adata = data.get(aid)
       if (!adata) { // first time seeing this agency
@@ -397,7 +399,9 @@ const displayFeatures = computed((): Feature[] => {
 
   // Gather routes
   for (const rp of props.routeFeatures) {
-    if (props.hideUnmarked && !rp.marked) continue // skip
+    if (props.hideUnmarked && !rp.marked) {
+      continue // skip both display and export
+    }
 
     const style = styleRules.find(rule => rule.match(rp))
     const displayFeature = {
@@ -420,15 +424,18 @@ const displayFeatures = computed((): Feature[] => {
     }
     forDisplay.push(displayFeature)
 
-    if (!rp.marked) continue
-    const exportFeature = structuredClone(displayFeature)
-    Object.assign(exportFeature.properties, routeToRouteCsv(rp))
-    forExport.push(exportFeature)
+    if (rp.marked) {
+      const exportFeature = structuredClone(displayFeature)
+      Object.assign(exportFeature.properties, routeToRouteCsv(rp))
+      forExport.push(exportFeature)
+    }
   }
 
   // Gather stops
   for (const sp of props.stopFeatures) {
-    if (props.hideUnmarked && !sp.marked) continue // skip
+    if (props.hideUnmarked && !sp.marked) {
+      continue // skip both display and export
+    }
 
     const style = styleRules.find(rule => rule.match(sp))
     const displayFeature = {
@@ -445,10 +452,11 @@ const displayFeatures = computed((): Feature[] => {
     }
     forDisplay.push(displayFeature)
 
-    if (!sp.marked) continue
-    const exportFeature = structuredClone(displayFeature)
-    Object.assign(exportFeature.properties, stopToStopCsv(sp))
-    forExport.push(exportFeature)
+    if (sp.marked) {
+      const exportFeature = structuredClone(displayFeature)
+      Object.assign(exportFeature.properties, stopToStopCsv(sp))
+      forExport.push(exportFeature)
+    }
   }
 
   emit('setDisplayFeatures', forDisplay)

--- a/components/cal/map.vue
+++ b/components/cal/map.vue
@@ -8,7 +8,7 @@
 
     <div v-if="showShareMenu" class="cal-map-share">
       <cal-map-share
-        :display-features="displayFeatures"
+        :export-features="exportFeatures"
         :stop-features="stopFeatures"
         :route-features="routeFeatures"
         :agency-features="agencyFeatures"
@@ -70,6 +70,7 @@ const props = defineProps<{
 
 const showShareMenu = ref(false)
 const toggleShareMenu = useToggle(showShareMenu)
+const exportFeatures = ref<Feature[]>([])
 
 //////////////////
 // Map geometries
@@ -462,6 +463,7 @@ const displayFeatures = computed((): Feature[] => {
   emit('setDisplayFeatures', forDisplay)
   emit('setExportFeatures', forExport)
 
+  exportFeatures.value = forExport
   return forDisplay
 })
 

--- a/components/cal/report.vue
+++ b/components/cal/report.vue
@@ -54,10 +54,17 @@
         <div><a title="Filter" role="button" @click="emit('clickFilterLink')">(change)</a></div>
       </div>
 
-      <cal-csv-download
-        :data="reportData"
-        :disabled="!stopDepartureLoadingComplete"
-      />
+      <div class="cal-report-download">
+        <cal-csv-download
+          :data="reportData"
+          :disabled="!stopDepartureLoadingComplete"
+        />
+
+        <cal-geojson-download
+          :data="exportFeatures"
+          :disabled="!stopDepartureLoadingComplete"
+        />
+      </div>
     </div>
 
     <div class="cal-report-total block">
@@ -147,12 +154,14 @@
 import { type Stop, type StopCsv, stopToStopCsv } from '../stop'
 import { type Route, type RouteCsv, routeToRouteCsv } from '../route'
 import { type Agency, type AgencyCsv, agencyToAgencyCsv } from '../agency'
+import { type Feature } from '../geom'
 import { type TableColumn } from './datagrid.vue'
 
 const props = defineProps<{
   stopFeatures: Stop[]
   routeFeatures: Route[]
   agencyFeatures: Agency[]
+  exportFeatures: Feature[]
   filterSummary: string[]
   stopDepartureLoadingComplete: boolean
 }>()
@@ -212,72 +221,74 @@ watch(dataDisplayMode, () => {
 
 </script>
 
-  <style scoped lang="scss">
-    .cal-report {
-      display:flex;
-      flex-direction:column;
-      background: var(--bulma-scheme-main);
-      height:100%;
-      width: calc(100vw - 100px);
-      padding-left:20px;
-      padding-right:20px;
-      > .cal-body {
-        > div, > article {
-          margin-bottom:10px;
-        }
+<style scoped lang="scss">
+  .cal-report {
+    display:flex;
+    flex-direction:column;
+    background: var(--bulma-scheme-main);
+    height:100%;
+    width: calc(100vw - 100px);
+    padding-left:20px;
+    padding-right:20px;
+    > .cal-body {
+      > div, > article {
+        margin-bottom:10px;
+      }
+    }
+  }
+
+  .cal-report-options {
+    display: flex;
+    flex: 0;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+
+    > .filter-detail {
+      flex: 0 1 60%;
+      align-self: stretch;
+      background-color: #ddd;
+      border: 1px solid #333;
+      padding: 5px;
+    }
+
+    > .report-select {
+      flex: 1 0 0;
+      align-self: stretch;
+      border: 1px solid #333;
+      padding: 5px;
+      margin: 0 15px;
+
+      > .which-report {
+        font-size: larger;
+        font-weight: bold;
       }
     }
 
-    .cal-report-options {
+    > .cal-report-download {
       display: flex;
-      flex: 0;
-      flex-flow: row nowrap;
-      justify-content: space-between;
-
-      > .filter-detail {
-        flex: 0 1 60%;
-        align-self: stretch;
-        background-color: #ddd;
-        border: 1px solid #333;
-        padding: 5px;
-      }
-
-      > .report-select {
-        flex: 1 0 0;
-        align-self: stretch;
-        border: 1px solid #333;
-        padding: 5px;
-        margin: 0 15px;
-
-        > .which-report {
-          font-size: larger;
-          font-weight: bold;
-        }
-      }
-
-      > .download {
-        flex: 0 1 10%;
-        align-self: center;
-      }
+      flex: 0 1 10%;
+      align-self: center;
+      flex-flow: column nowrap;
     }
+  }
 
-    .cal-report-total {
-      font-style: italic;
+  .cal-report-total {
+    font-style: italic;
+  }
+
+  .cal-report-table {
+    th, td {
+      padding: 2px 5px;
     }
-
-    .cal-report-table {
-      th, td {
-        padding: 2px 5px;
-      }
-      th {
-        background-color: #666;
-        color: #fff;
-      }
+    th {
+      background-color: #666;
+      color: #fff;
     }
+  }
 
-    .cal-report-footer {
-      font-style: italic;
-      text-align: end;
-    }
+  .cal-report-footer {
+    font-style: italic;
+    text-align: end;
+  }
 
-  </style>
+</style>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@aitodotai/json-stringify-pretty-compact": "^1.3.0",
     "csv-stringify": "^6.5.2",
     "nuxt": "^3.16.0",
     "tlv2-ui": "https://github.com/interline-io/tlv2-ui.git#commit=a146ee22b869d229890de2e398e51c05681412f2",

--- a/pages/tne.vue
+++ b/pages/tne.vue
@@ -118,14 +118,15 @@
             :stop-features="stopFeatures"
             :route-features="routeFeatures"
             :agency-features="agencyFeatures"
+            :export-features="exportFeatures"
             :filter-summary="filterSummary"
             :stop-departure-loading-complete="stopDepartureLoadingComplete"
             @click-filter-link="setTab({tab: 'filter', sub: 'data-display'})"
           />
         </div>
       </div>
-      <!-- This is a component for handling data flow -->
 
+      <!-- This is a component for handling data flow -->
       <cal-scenario
         v-model:frequency-under-enabled="frequencyUnderEnabled"
         v-model:frequency-under="frequencyUnder"
@@ -166,6 +167,7 @@
         :stop-departure-loading-complete="stopDepartureLoadingComplete"
         @set-bbox="bbox = $event"
         @set-map-extent="setMapExtent"
+        @set-export-features="exportFeatures = $event"
       />
     </template>
   </NuxtLayout>
@@ -173,7 +175,7 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { type Bbox, parseBbox, bboxString } from '../components/geom'
+import { type Bbox, type Feature, parseBbox, bboxString } from '../components/geom'
 import { fmtDate, fmtTime, parseDate, parseTime, getLocalDateNoTime } from '../components/datetime'
 import { navigateTo } from '#imports'
 import { type Stop } from '../components/stop'
@@ -553,10 +555,10 @@ const filterSummary = computed((): string[] => {
 // Event passing
 /////////////////////////
 
-// Stop features
 const stopFeatures = shallowRef<Stop[]>([])
 const routeFeatures = shallowRef<Route[]>([])
 const agencyFeatures = shallowRef<Agency[]>([])
+const exportFeatures = shallowRef<Feature[]>([])
 
 // Tab handling
 const activeTab = ref({ tab: 'query', sub: '' })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 8
   cacheKey: 10
 
+"@aitodotai/json-stringify-pretty-compact@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@aitodotai/json-stringify-pretty-compact@npm:1.3.0"
+  checksum: 10/ef923b2220bffd8f6cbda7e1f4634a8ab518b1002f32ba2e8327310eef6197320a8d6195b7f8126643cd1098277eba157bfcd8d72e6937d4a7cf98b34ad2dc25
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -4697,6 +4704,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "calact-network-analysis-tool@workspace:."
   dependencies:
+    "@aitodotai/json-stringify-pretty-compact": "npm:^1.3.0"
     csv-stringify: "npm:^6.5.2"
     nuxt: "npm:^3.16.0"
     tlv2-ui: "https://github.com/interline-io/tlv2-ui.git#commit=a146ee22b869d229890de2e398e51c05681412f2"


### PR DESCRIPTION
This PR adds the "Download as GeoJSON" button to the report screen, and includes the additional report properties with the GeoJSON features.
(closes #89)

![Screenshot 2025-04-30 at 10 31 27 PM](https://github.com/user-attachments/assets/6b2ec926-2d55-49be-b6e6-e26acef90adc)


This changes the `map.vue` `displayFeatures` computed property to generate the GeoJSON two ways:
- `forDisplay`: minimal properties + style, rendered via MapLibre
- `forExport`: expanded properties + style, includes the properties which are available by calling `routeToRouteCsv` and `stopToStopCsv`

When the features are computed, we now emit `setDisplayFeatures` and `setExportFeatures` events, so that other components outside of the map.vue component tree (like the report and download button components) can use them.

I mostly copied the existing `csv-download.vue` component, but adjusted it for GeoJSON.  I also added a slightly better stringifier function.  I've used this previously because it condenses the coordinates and properties a little better than just `JSON.stringify` would do.

I think this works pretty well!   I tested the file in geojson.io and everything looks intact:
![Screenshot 2025-04-30 at 10 26 43 PM](https://github.com/user-attachments/assets/9a8def67-d5f5-4782-8ec7-7a970b5520fe)

