### PR TITLE
Add fields for selecting admin boundary type and boundaries

### DIFF
--- a/components/cal/map.vue
+++ b/components/cal/map.vue
@@ -50,8 +50,8 @@ import { type Agency } from '../agency'
 const route = useRoute()
 
 const emit = defineEmits<{
-  setBbox: [value: BBox]
-  setMapExtent: [value: BBox]
+  setBbox: [value: Bbox]
+  setMapExtent: [value: Bbox]
   setDisplayFeatures: [value: Feature[]]
   setExportFeatures: [value: Feature[]]
 }>()
@@ -61,6 +61,7 @@ const props = defineProps<{
   stopFeatures: Stop[]
   routeFeatures: Route[]
   agencyFeatures: Agency[]
+  selectedFeatures: Feature[]
   dataDisplayMode: string
   colorKey: string
   displayEditBboxMode?: boolean
@@ -391,6 +392,11 @@ const displayFeatures = computed((): Feature[] => {
   // Include bbox in display features
   for (const feature of bboxArea.value) {
     forDisplay.push(toRaw(feature))
+  }
+
+  // Include selected features in display features
+  for (const feature of props.selectedFeatures) {
+    forDisplay.push(feature)
   }
 
   // Gather routes

--- a/components/cal/query.vue
+++ b/components/cal/query.vue
@@ -34,6 +34,26 @@
       </tl-msg-box>
 
       <tl-msg-box variant="text" title="Geographic Bounds">
+        <tl-msg-warning v-if="debugMenu" class="mt-4" style="width:400px" title="Debug menu">
+          <o-field label="Preset bounding box">
+            <o-select v-model="cannedBbox">
+              <option v-for="cannedBboxName of cannedBboxes.keys()" :key="cannedBboxName" :value="cannedBboxName">
+                {{ cannedBboxName }}
+              </option>
+            </o-select>
+          </o-field>
+          <br>
+          <o-field label="Data options">
+            <o-checkbox
+              v-model="scheduleEnabled"
+              :true-value="true"
+              :false-value="false"
+            >
+              Load schedule data
+            </o-checkbox>
+          </o-field>
+        </tl-msg-warning>
+
         <div class="columns">
           <div class="column is-half">
             <o-field>
@@ -43,52 +63,49 @@
                   <o-icon icon="information" />
                 </o-tooltip>
               </template>
-              <o-select v-model="geomSource">
-                <option value="mapExtent" selected>
-                  Covering extent of map
-                </option>
-                <option value="bbox">
-                  Dragging bounding box
-                </option>
-              </o-select>
+              <o-select
+                v-model="geomSource"
+                :options="geomSources"
+                @input="changeGeomSource"
+              />
+            </o-field>
+          </div>
 
-              <tl-msg-warning v-if="debugMenu" class="mt-4" style="width:400px" title="Debug menu">
-                <o-field label="Preset bounding box">
-                  <o-select v-model="cannedBbox">
-                    <option v-for="cannedBboxName of cannedBboxes.keys()" :key="cannedBboxName" :value="cannedBboxName">
-                      {{ cannedBboxName }}
-                    </option>
-                  </o-select>
-                </o-field>
-                <br>
-                <o-field label="Data options">
-                  <o-checkbox
-                    v-model="scheduleEnabled"
-                    :true-value="true"
-                    :false-value="false"
-                  >
-                    Load schedule data
-                  </o-checkbox>
-                </o-field>
-              </tl-msg-warning>
-
-              <!-- <div class="cal-bbox-info">
-                <div style="text-align:center">
-                  <o-button icon-left="pin">
-                    Select on map
-                  </o-button>
-                </div>
-                <o-field label="SW Corner">
-                  <o-input type="text" :value="ptString(props.bbox.sw)" />
-                </o-field>
-                <o-field label="NE Corner">
-                  <o-input type="text" :value="ptString(props.bbox.ne)" />
-                </o-field>
-              </div> -->
+          <div class="column is-half" :class="{ 'is-hidden': geomSource !== 'adminBoundary' }">
+            <o-field>
+              <template #label>
+                Boundary Type
+              </template>
+              <o-select
+                v-model="boundaryType"
+                :options="boundaryTypes"
+                @input="changeBoundaryType"
+              />
             </o-field>
           </div>
         </div>
+
+        <div class="container is-max-tablet" :class="{ 'is-hidden': geomSource !== 'adminBoundary' }">
+          <o-field>
+            <template #label>
+              Include Boundaries
+            </template>
+            <o-taginput
+              v-model="boundaries"
+              :options="sampleBoundaryData"
+              open-on-focus
+              closable
+              close-icon=""
+              keep-open
+              icon="magnify"
+              placeholder="Search..."
+              :filter="filterBoundaries"
+              expanded
+            />
+          </o-field>
+        </div>
       </tl-msg-box>
+
       <o-button variant="primary" :disabled="!validQueryParams" class="is-fullwidth is-large" @click="emit('explore')">
         Run Query
       </o-button>
@@ -98,7 +115,7 @@
 
 <script setup lang="ts">
 import { type Bbox, parseBbox } from '../geom'
-import { cannedBboxes } from '../constants'
+import { cannedBboxes, geomSources, boundaryTypes } from '../constants'
 import { useToggle } from '@vueuse/core'
 
 const props = defineProps<{
@@ -113,11 +130,36 @@ const emit = defineEmits([
 const startDate = defineModel<Date>('startDate')
 const endDate = defineModel<Date>('endDate')
 const geomSource = defineModel<string>('geomSource')
+const boundaryType = defineModel<string>('boundaryType')
 const scheduleEnabled = defineModel<boolean>('scheduleEnabled')
 const cannedBbox = ref('')
 const selectSingleDay = ref(true)
 const toggleSelectSingleDay = useToggle(selectSingleDay)
 const debugMenu = useDebugMenu()
+
+const boundaries = ref([])
+const sampleBoundaryData = {
+  Q581346: 'Aloha',
+  Q2587933: 'Barberton',
+  Q588923: 'Bethany',
+  Q1815228: 'Bull Mountain',
+  Q2896285: 'Cedar Hills',
+  Q2896288: 'Cedar Mill',
+  Q3473327: 'Dunthorpe',
+  Q3046557: 'Fairview',
+  Q1815675: 'Felida',
+  Q1983444: 'Garden Home-Whitford',
+  Q2605832: 'Hazel Dell',
+  Q1815789: 'Hockinson',
+  Q3473329: 'Marlene Village',
+  Q1815894: 'Minnehaha',
+  Q1815903: 'Mount Vista',
+  Q2889407: 'Oak Hills',
+  Q2581728: 'Orchards',
+  Q1815994: 'Salmon Creek',
+  Q3473334: 'West Haven-Sylvan',
+  Q1816149: 'West Slope',
+}
 
 watch(() => cannedBbox.value, (cannedBboxName) => {
   if (cannedBboxName) {
@@ -129,22 +171,42 @@ const validQueryParams = computed(() => {
   return startDate.value && props.bbox?.valid
 })
 
+function changeGeomSource () {
+  boundaryType.value = ''
+  boundaries.value = []
+}
+
+function changeBoundaryType () {
+  boundaries.value = []
+}
+
+// Which boundaries to show in the select field
+// @param  option - the option to test (keys from the list of boundaries)
+// @param  value  - the value to test (what the user typed)
+function filterBoundaries (option: string, value: string): boolean {
+  const exists = Array.from(boundaries.value).includes(option)
+  if (exists) {
+    return true // value was already picked, exclude it
+  }
+  const label = sampleBoundaryData[option]?.toLowerCase()
+  const val = value.toLowerCase()
+  return !label?.includes(val)
+}
+
 </script>
 
 <style scoped lang="scss">
-.cal-query {
-  display:flex;
-  flex-direction:column;
-  background: var(--bulma-scheme-main);
-  height:100%;
-  padding-left:20px;
-  padding-right:20px;
-  > .cal-body {
-      > div, > article
-       {
-      margin-bottom:10px;
-    }
-
+  .cal-query {
+    display:flex;
+    flex-direction:column;
+    background: var(--bulma-scheme-main);
+    height:100%;
+    padding-left:20px;
+    padding-right:20px;
+    > .cal-body {
+      > div, > article {
+        margin-bottom:10px;
+      }
     }
   }
 
@@ -153,4 +215,4 @@ const validQueryParams = computed(() => {
     margin-top:10px;
     padding:10px;
   }
-  </style>
+</style>

--- a/components/cal/query.vue
+++ b/components/cal/query.vue
@@ -112,7 +112,7 @@
 </template>
 
 <script setup lang="ts">
-import { type Bbox, parseBbox } from '../geom'
+import { type Bbox, type Feature, type Geometry, parseBbox } from '../geom'
 import { cannedBboxes, geomSources, geomLayers } from '../constants'
 import { gql } from 'graphql-tag'
 import { useToggle } from '@vueuse/core'
@@ -160,7 +160,7 @@ interface CensusGeography {
   geoid: string
   layer_name: string
   name: string
-  geometry: GeoJSON.FeatureCollection
+  geometry: Geometry
 }
 
 interface CensusDataset {
@@ -254,6 +254,7 @@ watch(geomSelected, () => {
     features.push({
       type: 'Feature',
       geometry: geo.geometry,
+      id: geo.geoid,
       properties: {
         id: geo.geoid,
         name: geo.name,
@@ -263,11 +264,7 @@ watch(geomSelected, () => {
     })
   }
 
-  const geojson = {
-    type: 'FeatureCollection',
-    features: features
-  }
-  emit('setFeatures', geojson)
+  emit('setFeatures', features)
 })
 
 const validQueryParams = computed(() => {

--- a/components/cal/query.vue
+++ b/components/cal/query.vue
@@ -164,6 +164,35 @@ const sampleBoundaryData = {
 /////////////////////////////////////////
 /////////////////////////////////////////
 
+// query mockup
+// {
+//   census_datasets(where:{dataset_name:"tiger2024"}) {
+//     dataset_name
+//     geographies(limit: 10, where:{layer:"county", search:"ala"}) {
+//       id
+//       geoid
+//       name
+//     }
+//   }
+// }
+// result mockup
+// {
+//   "data": {
+//     "census_datasets": [
+//       {
+//         "dataset_name": "tiger2024",
+//         "geographies": [
+//           {
+//             "id": 2099,
+//             "geoid": "0500000US06001",
+//             "name": "Alameda"
+//           }
+//         ]
+//       }
+//     ]
+//   }
+// }
+
 // import { gql } from 'graphql-tag'
 // import { useQuery } from '@vue/apollo-composable'
 

--- a/components/cal/query.vue
+++ b/components/cal/query.vue
@@ -161,6 +161,56 @@ const sampleBoundaryData = {
   Q1816149: 'West Slope',
 }
 
+/////////////////////////////////////////
+/////////////////////////////////////////
+
+// import { gql } from 'graphql-tag'
+// import { useQuery } from '@vue/apollo-composable'
+
+// const geographyQuery = gql`
+// query($dataset_name: String, $search: String, $layer: String, $limit: Int=10){
+//   census_datasets(where:{dataset_name:$dataset_name}) {
+//     dataset_name
+//     # layers # COMING SOON
+//     geographies(limit: $limit, where:{layer:$layer, search:$search}) {
+//       id
+//       geoid
+//       name
+//       # geometry
+//     }
+//   }
+// }
+// `
+
+// const { geomResult, loading, error } = useQuery(
+//   geographyQuery,
+//   () => ({
+//     dataset_name: 'tiger2024',
+//     search: geomSearch.value,
+//     layer: geomLayer.value,
+//     limit: 10,
+//   }))
+
+// const geomSearchLayers = computed(() => {
+//   // aggregate uniq off geomResult.value.census_datasets.layers results
+//   return ['tract', 'census']
+// })
+// const geomSearchEntities = computed(() => {
+//   // aggregate off geomResult.value.census_datasets.geographies results
+//   return []
+// })
+// const geomSearchEntitiesSelected = computed(() => {
+//   // filter geomSearchEntities based on user selection
+//   return []
+// })
+
+// end goal: have an array of geojson features selected by the user
+//    to pass into the scenario
+//    and have each stop returned by the query to include the matching geography ids
+
+/////////////////////////////////////////
+/////////////////////////////////////////
+
 watch(() => cannedBbox.value, (cannedBboxName) => {
   if (cannedBboxName) {
     emit('setBbox', parseBbox(cannedBboxes.get(cannedBboxName)))

--- a/components/cal/scenario.vue
+++ b/components/cal/scenario.vue
@@ -4,7 +4,7 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
-import { type Bbox } from '../geom'
+import { type Bbox, type Feature } from '../geom'
 import { useLazyQuery } from '@vue/apollo-composable'
 import { useTask } from 'vue-concurrency'
 import { type dow, routeTypes } from '../constants'
@@ -67,6 +67,7 @@ const frequencyUnder = defineModel<number>('frequencyUnder')
 const frequencyOver = defineModel<number>('frequencyOver')
 const frequencyUnderEnabled = defineModel<boolean>('frequencyUnderEnabled')
 const frequencyOverEnabled = defineModel<boolean>('frequencyOverEnabled')
+const selectedFeatures = defineModel<Feature[]>('selectedFeatures')
 
 const stopLimit = 1000
 const stopDepartureCache = new StopDepartureCache()
@@ -320,6 +321,7 @@ watch(() => [
   selectedRouteTypes.value,
   startTime.value,
   stopDepartureLoadingComplete.value,
+  selectedFeatures.value,
 ], () => {
   // Check defaults
   const selectedDayOfWeekModeValue = selectedDayOfWeekMode.value || ''
@@ -332,6 +334,8 @@ watch(() => [
   const endTimeValue = endTime.value ? format(endTime.value, 'HH:mm:ss') : '24:00:00'
   const frequencyUnderValue = (frequencyUnderEnabled.value ? frequencyUnder.value : -1) || -1
   const frequencyOverValue = (frequencyOverEnabled.value ? frequencyOver.value : -1) || -1
+
+  console.log('selectedFeatures', selectedFeatures.value)
 
   /////////////////////////
   // Apply route filters

--- a/components/constants.ts
+++ b/components/constants.ts
@@ -43,7 +43,7 @@ export const geomSources = {
   'adminBoundary': 'Administrative Boundary',
 }
 
-export const boundaryTypes = {
+export const geomLayers = {
   'county': 'County',
   'state': 'State',
   'censusTract': 'Census Tract',

--- a/components/constants.ts
+++ b/components/constants.ts
@@ -37,6 +37,23 @@ export const dowValues: dow[] = [
   'sunday'
 ]
 
+export const geomSources = {
+  'mapExtent': 'Covering extent of map',
+  'bbox': 'Dragging bounding box',
+  'adminBoundary': 'Administrative Boundary',
+}
+
+export const boundaryTypes = {
+  'county': 'County',
+  'state': 'State',
+  'censusTract': 'Census Tract',
+  'censusBlockGroup': 'Census Block Group',
+  'censusBlock': 'Census Block',
+  'city': 'City',
+  'censusUrbanizedArea': 'Census Urbanized Area',
+  'ftaUrbanizedArea': 'FTA Urbanized Area',
+}
+
 export const routeColorModes = [
   'Mode',
   'Frequency',

--- a/components/stop.ts
+++ b/components/stop.ts
@@ -12,6 +12,7 @@ export const stopQuery = gql`
 query ($limit: Int, $after: Int, $where: StopFilter) {
   stops(limit: $limit, after: $after, where: $where) {
     id
+    within_features
     location_type
     stop_id
     stop_name
@@ -81,6 +82,7 @@ export interface StopVisitSummary {
 export type StopGql = {
   id: number
   geometry: GeoJSON.Point
+  within_features: string[]
   route_stops: {
     route: {
       id: number

--- a/pages/tne.vue
+++ b/pages/tne.vue
@@ -147,6 +147,7 @@
         :end-time="endTime"
         :geom-source="geomSource"
         :schedule-enabled="scheduleEnabled"
+        :selected-features="selectedFeatures"
         @set-stop-departure-progress="stopDepartureProgress = $event"
         @set-stop-departure-loading-complete="stopDepartureLoadingComplete = $event"
         @set-stop-features="stopFeatures = $event"
@@ -159,6 +160,7 @@
       <!-- This is a component for displaying the map and legend -->
       <cal-map
         :bbox="bbox"
+        :selected-features="selectedFeatures"
         :stop-features="stopFeatures"
         :route-features="routeFeatures"
         :agency-features="agencyFeatures"
@@ -196,7 +198,7 @@ const route = useRoute()
 const scheduleEnabled = ref(true)
 const defaultBbox = '-122.69075,45.51358,-122.66809,45.53306'
 const runCount = ref(0)
-const selectedFeatures = ref(null) // for now
+const selectedFeatures = ref<Feature[]>([]) // for now
 
 // Loading and error handling
 const loading = ref(false)
@@ -483,7 +485,7 @@ const filterSummary = computed((): string[] => {
   const results: string[] = []
 
   // route types
-  const rtypes = selectedRouteTypes.value.map(val => toTitleCase(routeTypes.get(val))).filter(Boolean)
+  const rtypes = selectedRouteTypes.value.map(val => toTitleCase(routeTypes.get(val) || '')).filter(Boolean)
   if (rtypes.length !== routeTypes.size) {
     results.push('with route types ' + rtypes.join(', '))
   }

--- a/pages/tne.vue
+++ b/pages/tne.vue
@@ -72,10 +72,11 @@
             v-model:start-date="startDate"
             v-model:end-date="endDate"
             v-model:geom-source="geomSource"
-            v-model:boundary-type="boundaryType"
+            v-model:geom-layer="geomLayer"
             v-model:schedule-enabled="scheduleEnabled"
             :bbox="bbox"
             @set-bbox="bbox = $event"
+            @set-features="selectedFeatures = $event"
             @explore="runQuery()"
           />
         </div>
@@ -195,6 +196,7 @@ const route = useRoute()
 const scheduleEnabled = ref(true)
 const defaultBbox = '-122.69075,45.51358,-122.66809,45.53306'
 const runCount = ref(0)
+const selectedFeatures = ref(null) // for now
 
 // Loading and error handling
 const loading = ref(false)
@@ -231,12 +233,12 @@ const geomSource = computed({
   }
 })
 
-const boundaryType = computed({
+const geomLayer = computed({
   get () {
-    return route.query.boundaryType?.toString() || ''
+    return route.query.geomLayer?.toString() || ''
   },
   set (v: string) {
-    setQuery({ ...route.query, boundaryType: v })
+    setQuery({ ...route.query, geomLayer: v })
   }
 })
 

--- a/pages/tne.vue
+++ b/pages/tne.vue
@@ -72,6 +72,7 @@
             v-model:start-date="startDate"
             v-model:end-date="endDate"
             v-model:geom-source="geomSource"
+            v-model:boundary-type="boundaryType"
             v-model:schedule-enabled="scheduleEnabled"
             :bbox="bbox"
             @set-bbox="bbox = $event"
@@ -227,6 +228,15 @@ const geomSource = computed({
   },
   set (v: string) {
     setQuery({ ...route.query, geomSource: v })
+  }
+})
+
+const boundaryType = computed({
+  get () {
+    return route.query.boundaryType?.toString() || ''
+  },
+  set (v: string) {
+    setQuery({ ...route.query, boundaryType: v })
   }
 })
 


### PR DESCRIPTION
Initial front-end work for #112 (subtask of #103)
We can refine it as needed..

- `geomSource` select field now supports "Administrative Boundary" option
- Added `boundaryType` select field and code to persist to url querystring
- Added "Include Boundaries" Oruga `tagInput` field for the boundary picker
- Added some sample census boundaries to make the tagInput field work
- These fields are only visible when `geomSource === adminBoundary`
- These are on the existing `query.vue` component for now

It looks like this! 

![admin boundaries](https://github.com/user-attachments/assets/1e43a106-7f2a-4dbd-aca8-0747bcf2097d)
