### PR TITLE
Open Help in new tab

### DIFF
--- a/app/components/main-header.vue
+++ b/app/components/main-header.vue
@@ -34,6 +34,7 @@
                 :class="itemHelper('/help')"
                 title="Help"
                 role="button"
+                target="_blank"
               >
                 <t-icon icon="help" size="large" class="is-fullwidth" variant="white" />
               </nuxt-link>


### PR DESCRIPTION
(fixes #217)

Simple fix suggested on #217 to have the Help page open in a new tab.