### PR TITLE
fix tooltips placed in .menu-label

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -48,3 +48,9 @@ $duration: 1000ms;
 .message .media-content{
     overflow: visible !important; /* so datetime picker isn't hidden */
 }
+
+// Tooltip fixes
+.t-tooltip::after {
+    text-transform: none; // Prevent inheriting text-transform from parent elements (e.g., menu-label)
+    font-weight: normal; // Reset font weight that might be inherited
+}


### PR DESCRIPTION
before:

<img width="400" alt="CleanShot 2026-01-19 at 16 18 58@2x" src="https://github.com/user-attachments/assets/6807c102-5825-42aa-a426-80ef989e0ebd" />

after:

<img width="400" alt="CleanShot 2026-01-19 at 16 23 19@2x" src="https://github.com/user-attachments/assets/dcc8e204-ec15-4135-8570-cc459cedc122" />
