### PR TITLE
Fix filter tab summary for geographic extent

### DIFF
--- a/app/components/cal/filter.vue
+++ b/app/components/cal/filter.vue
@@ -50,7 +50,7 @@
           {{ geographicBoundaryLabel }}
         </p>
         <p>
-          <a>Change date or region</a>
+          <a @click="emit('showQuery')">Change date or region</a>
         </p>
       </div>
     </div>
@@ -607,9 +607,9 @@ const geographicBoundaryLabel = computed(() => {
       .join('; ')
   }
   if (props.geomSource === 'mapExtent') {
-    return 'map extent'
+    return 'Selected map extent'
   }
-  return 'bounding box'
+  return 'Selected bounding box'
 })
 
 // CSS bindings from layout props (single source of truth defined in tne.vue)
@@ -620,6 +620,7 @@ const panelPaddingPx = computed(() => `${props.panelPadding ?? 20}px`)
 const emit = defineEmits([
   'resetFilters',
   'setTimeRange',
+  'showQuery',
 ])
 const activeTab = defineModel<string>('activeTab')
 

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -140,6 +140,7 @@
             :panel-padding="PANEL_PADDING"
             @reset-filters="resetFilters"
             @set-time-range="setTimeRange"
+            @show-query="activeTab = { tab: 'query', sub: '' }"
           />
         </div>
 


### PR DESCRIPTION
## Summary

The filters tab summary previously displayed a hardcoded "bounding box" label regardless of which geographic boundary type was actually selected. This updates the filter summary to show the correct geography — displaying admin boundary names (e.g. "Thurston County, Washington") when an administrative boundary is selected, "Selected map extent" for map extent mode, and "Selected bounding box" for bounding box mode. The non-functional "Change date or region" link is now wired up to navigate back to the query panel.

Resolves #244 

### Filter summary geographic label

- Replaced hardcoded `<t-button>bounding box</t-button>` with a computed `geographicBoundaryLabel` that reflects the actual `geomSource` and selected census geographies
- When `geomSource` is `adminBoundary`, displays geography names with state (e.g. "Thurston County, Washington"); multiple geographies are joined with semicolons
- When `geomSource` is `mapExtent`, displays "Selected map extent"
- Defaults to "Selected bounding box" for bbox mode
- Added `geomSource` and `censusGeographiesSelected` props to `cal-filter`, passed from `tne.vue`

### Layout and navigation

- Changed from `<t-button>` to plain text in a `<p>` so long geography names wrap naturally within the panel width
- Added right padding and bottom padding to the summary section for spacing
- Wired up "Change date or region" link to emit `showQuery`, which switches back to the query panel

## Test plan

- Select an administrative boundary (e.g. Thurston County, Washington), run a query, switch to the Filters tab, and verify the summary shows "Thurston County, Washington" instead of "bounding box"
- Select multiple admin boundaries and verify they display joined with semicolons
- Use bounding box mode and verify the summary shows "Selected bounding box"
- Use map extent mode and verify the summary shows "Selected map extent"
- Click "Change date or region" in the filter summary and verify it navigates back to the query panel
- Verify long geography names wrap within the panel without overflowing
