### PR TITLE
Adjust panel width and expand 'run browse query' buttons

### DIFF
--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -181,7 +181,7 @@
         </t-field>
       </t-msg>
 
-      <div class="field has-addons">
+      <div class="field has-addons cal-query-actions">
         <t-button variant="primary" :disabled="!validQueryParams" class="is-fullwidth is-large" @click="emit('explore')">
           Run Browse Query
         </t-button>
@@ -394,6 +394,13 @@ const validQueryParams = computed(() => {
     opacity: 0.45;
     pointer-events: none;
     user-select: none;
+  }
+
+  .cal-query-actions {
+    width: 100%;
+    :deep(.control) {
+      flex-grow: 1;
+    }
   }
 
   .cal-bbox-info {

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -877,7 +877,7 @@ const activeTab = ref({ tab: 'query', sub: '' })
 // Panel layout constants — single source of truth for widths.
 // Used both for CSS (via v-bind) and for map padding computation.
 const PANEL_PADDING = 20
-const QUERY_PANEL_WIDTH = 600
+const QUERY_PANEL_WIDTH = 620
 const FILTER_MAIN_WIDTH = 300
 const FILTER_SUB_WIDTH = 400
 const FILTER_COLLAPSED_WIDTH = FILTER_MAIN_WIDTH + PANEL_PADDING // 320


### PR DESCRIPTION
## Summary

Widens the query panel slightly and makes the "Run Browse Query" / "Run Advanced Analysis" buttons expand to fill the full available width, improving the layout of the query form.

### Query panel width
- Increased `QUERY_PANEL_WIDTH` from 600px to 620px to give the form content more breathing room

### Full-width action buttons
- Added `cal-query-actions` class to the button group container with `width: 100%` and `flex-grow: 1` on child `.control` elements so both buttons expand to fill the panel width

## Test plan
- Open the query panel and verify "Run Browse Query" and "Run Advanced Analysis" buttons span the full width of the panel
- Verify the query panel is slightly wider than before without overlapping the map excessively
