### PR TITLE
More robust bbox/geography overlay and geomSource switching

### DIFF
--- a/app/components/cal/filter.vue
+++ b/app/components/cal/filter.vue
@@ -505,7 +505,7 @@
           <ul>
             <li>
               <t-checkbox v-model="showBbox">
-                Show selected bounding box
+                Show geographic filters
               </t-checkbox>
             </li>
           </ul>
@@ -656,7 +656,7 @@ const minFareEnabled = defineModel<boolean>('minFareEnabled')
 const minFare = defineModel<number>('minFare')
 
 // Bbox display toggle
-const showBbox = defineModel<boolean>('showBbox', { default: false })
+const showBbox = defineModel<boolean>('showBbox', { default: true })
 
 // Fixed-Route Transit toggle
 const fixedRouteEnabled = defineModel<boolean | undefined>('fixedRouteEnabled') // On by default

--- a/app/components/cal/map-viewer-ts.vue
+++ b/app/components/cal/map-viewer-ts.vue
@@ -427,12 +427,13 @@ function updateOverlayFeatures (features: Feature[]) {
   // Only fit if the set of features actually changed (not just object references).
   // This prevents re-fitting when filters change but geographies stay the same.
   // Avoid fitting the bbox, as that makes it difficult for the user to resize it (see #206).
+  // Skip tracking when features are empty (e.g. toggle off) so toggling back on doesn't re-fit.
   const featuresWithoutBbox = features.filter(f => f.id !== 'bbox')
   const currentIds = featuresWithoutBbox
     .map(f => f.id)
     .sort().join(',')
 
-  if (currentIds !== lastOverlayFeatureIds) {
+  if (currentIds && currentIds !== lastOverlayFeatureIds) {
     lastOverlayFeatureIds = currentIds
     fitFeatures(featuresWithoutBbox)
   }

--- a/app/components/cal/map.vue
+++ b/app/components/cal/map.vue
@@ -609,20 +609,24 @@ const styleData = computed((): Matcher[] => {
 // Match all features to styling rules and apply as GeoJSON simplestyle
 const overlayFeatures = computed((): Feature[] => {
   const forDisplay: Feature[] = []
+  const hasGeographies = props.censusGeographiesSelected.length > 0
 
-  // Include bbox in display features
-  for (const feature of bboxArea.value) {
-    forDisplay.push(toRaw(feature))
-  }
-
-  // Include selected features in display features
-  for (const feature of props.censusGeographiesSelected) {
-    forDisplay.push({
-      type: 'Feature',
-      id: feature.id.toString(),
-      geometry: feature.geometry,
-      properties: {}
-    })
+  // Show admin geographies OR bbox, never both (mirrors server-side priority)
+  if (hasGeographies) {
+    if (props.showBbox) {
+      for (const feature of props.censusGeographiesSelected) {
+        forDisplay.push({
+          type: 'Feature',
+          id: feature.id.toString(),
+          geometry: feature.geometry,
+          properties: {}
+        })
+      }
+    }
+  } else {
+    for (const feature of bboxArea.value) {
+      forDisplay.push(toRaw(feature))
+    }
   }
   return forDisplay
 })

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -263,6 +263,7 @@ function clearScenario () {
   scenarioData.value = undefined
   scenarioFilterResult.value = undefined
   exportFeatures.value = []
+  querySubmitted.value = false
   clearAllResults()
 }
 
@@ -905,7 +906,7 @@ const advancedReport = computed({
   }
 })
 
-const showBbox = ref(false)
+const showBbox = ref(true)
 
 // showBboxOnMap controls the bbox outline — visible when the filter toggle is on or on the query tab
 const showBboxOnMap = computed(() => showBbox.value || activeTab.value.tab === 'query')


### PR DESCRIPTION
## Summary

Fixes incomplete state reset when clicking "Reset and start a new query" and unifies the geographic overlay toggle to handle both bounding boxes and administrative boundaries.

Resolves #212 

### Query reset fix

- `clearScenario()` now resets `querySubmitted` to `false`, which re-enables bbox drag handles and map-extent tracking after resetting a loaded query

### Unified geographic overlay toggle

- Renamed the "Show selected bounding box" checkbox to "Show geographic filters" and changed its default to on
- The map overlay now displays admin geographies OR the bounding box, never both, mirroring the server-side priority where geography IDs take precedence over bbox
- Prevented spurious map autofit when toggling the overlay off and back on by skipping feature-ID tracking when the feature set is empty

## Test plan

- Run a browse query using a dragged bounding box, then click "Reset and start a new query" on the Query tab; verify that bbox drag handles reappear and the bbox outline is visible
- Switch "Select geography" to "Covering extent of map" after a reset; verify the bbox updates as the map is panned
- Run a query using an administrative boundary; verify the map shows the geography polygons and not the bbox rectangle
- Toggle "Show geographic filters" off and back on; verify the map does not re-zoom/fit on re-enable
- Confirm the toggle defaults to on for a fresh page load

