### PR TITLE
Improve reports view

### DIFF
--- a/app/components/analysis/visioneval-viewer.vue
+++ b/app/components/analysis/visioneval-viewer.vue
@@ -51,7 +51,6 @@
             </h4>
             <cal-datagrid
               :table-report="mareaDatagrid"
-              :show-results-count="false"
               filename="marea_transit_service"
             >
               <template #column-DRRevMi="{ value }">
@@ -94,7 +93,6 @@
 
             <cal-datagrid
               :table-report="costDatagrid"
-              :show-results-count="false"
               filename="cost_per_revenue_mile"
             >
               <template #column-Mode="{ value }">
@@ -119,7 +117,6 @@
 
             <cal-datagrid
               :table-report="rawDatagrid"
-              :show-results-count="false"
               filename="ntd_raw_records"
             >
               <template #column-vehicleRevenueMiles="{ value }">

--- a/app/components/analysis/wsdot-stops-routes-viewer.vue
+++ b/app/components/analysis/wsdot-stops-routes-viewer.vue
@@ -18,7 +18,6 @@
 
             <cal-datagrid
               :table-report="agencyDatagrid"
-              :show-results-count="false"
             >
               <template #column-agencyId="{ value }">
                 <cat-safelink
@@ -48,7 +47,6 @@
 
             <cal-datagrid
               :table-report="stopDatagrid"
-              :show-results-count="false"
             >
               <template #column-stopId="{ value }">
                 <cat-safelink
@@ -158,7 +156,6 @@
 
             <cal-datagrid
               :table-report="routeDatagrid"
-              :show-results-count="false"
             >
               <template #column-routeId="{ value }">
                 <cat-safelink

--- a/app/components/analysis/wsdot-viewer.vue
+++ b/app/components/analysis/wsdot-viewer.vue
@@ -143,7 +143,6 @@
 
     <cal-datagrid
       :table-report="stopDatagrid"
-      :show-results-count="false"
     >
       <template #additional-downloads>
         <cat-field>

--- a/app/components/cal/datagrid.vue
+++ b/app/components/cal/datagrid.vue
@@ -15,13 +15,6 @@
 
       <!-- Slot for additional download buttons, such as GeoJSON -->
       <slot name="additional-downloads" :data="tableReport.data" :loading="loading" />
-
-      <cat-pagination
-        v-model:current="current"
-        :total="total"
-        :per-page="perPage"
-        style="margin-left: auto;"
-      />
     </div>
 
     <div class="table-container">
@@ -52,6 +45,16 @@
           </tr>
         </tbody>
       </table>
+    </div>
+
+    <div class="is-flex is-align-items-center mt-4" style="gap: 0.5rem;">
+      <span class="has-text-grey">Showing {{ rangeStart }}-{{ rangeEnd }} of {{ total }} results</span>
+      <cat-pagination
+        v-model:current="current"
+        :total="total"
+        :per-page="perPage"
+        style="margin-left: auto;"
+      />
     </div>
   </div>
 </template>
@@ -88,6 +91,12 @@ const currentRows = computed(() => {
 })
 const total = computed(() => {
   return (tableReport?.value?.data || []).length
+})
+const rangeStart = computed(() => {
+  return total.value === 0 ? 0 : (current.value - 1) * perPage + 1
+})
+const rangeEnd = computed(() => {
+  return Math.min(current.value * perPage, total.value)
 })
 </script>
 

--- a/app/components/cal/datagrid.vue
+++ b/app/components/cal/datagrid.vue
@@ -1,20 +1,23 @@
 <template>
   <div class="mb-6">
-    <div v-if="showResultsCount" class="cal-report-total block">
-      {{ total }} results found
-    </div>
-
     <div class="is-flex is-align-items-center mb-4" style="gap: 0.5rem;">
-      <cat-field>
+      <cat-input
+        v-model="searchQuery"
+        type="search"
+        placeholder="Search..."
+        icon="magnify"
+      />
+
+      <!-- Slot for additional download buttons, such as GeoJSON -->
+      <slot name="additional-downloads" :data="tableReport.data" :loading="loading" />
+
+      <cat-field style="margin-left: auto;">
         <cal-csv-download
           :data="tableReport.data"
           :disabled="loading"
           :filename="props.filename"
         />
       </cat-field>
-
-      <!-- Slot for additional download buttons, such as GeoJSON -->
-      <slot name="additional-downloads" :data="tableReport.data" :loading="loading" />
     </div>
 
     <div class="table-container">
@@ -78,19 +81,41 @@ const perPage = 20
 const loading = defineModel<boolean>('loading', { default: false })
 const tableReport = defineModel<TableReport>('tableReport', { required: true })
 const current = defineModel<number>('current', { default: 1 })
-const showResultsCount = defineModel<boolean>('showResultsCount', { default: true })
 
 const props = defineProps<{
   filename?: string
 }>()
 
+const searchQuery = ref('')
+
+const filteredData = computed(() => {
+  const data = tableReport?.value?.data || []
+  const query = searchQuery.value.trim().toLowerCase()
+  if (!query) {
+    return data
+  }
+  return data.filter(row =>
+    Object.values(row).some(val =>
+      String(val ?? '').toLowerCase().includes(query),
+    ),
+  )
+})
+
+watch(searchQuery, () => {
+  current.value = 1
+})
+
+watch(() => tableReport.value?.columns, () => {
+  searchQuery.value = ''
+})
+
 const currentRows = computed(() => {
   const start = (current.value - 1) * perPage
   const end = start + perPage
-  return tableReport?.value?.data.slice(start, end) || []
+  return filteredData.value.slice(start, end)
 })
 const total = computed(() => {
-  return (tableReport?.value?.data || []).length
+  return filteredData.value.length
 })
 const rangeStart = computed(() => {
   return total.value === 0 ? 0 : (current.value - 1) * perPage + 1

--- a/app/components/cal/datagrid.vue
+++ b/app/components/cal/datagrid.vue
@@ -50,7 +50,7 @@
       </table>
     </div>
 
-    <div class="is-flex is-align-items-center mt-4" style="gap: 0.5rem;">
+    <div v-if="total > 0" class="is-flex is-align-items-center mt-4" style="gap: 0.5rem;">
       <span class="has-text-grey">Showing {{ rangeStart }}-{{ rangeEnd }} of {{ total }} results</span>
       <cat-pagination
         v-model:current="current"
@@ -58,6 +58,9 @@
         :per-page="perPage"
         style="margin-left: auto;"
       />
+    </div>
+    <div v-else class="has-text-grey mt-4">
+      No results found
     </div>
   </div>
 </template>

--- a/app/components/cal/datagrid.vue
+++ b/app/components/cal/datagrid.vue
@@ -34,7 +34,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="row in currentRows" :key="row.id">
+          <tr v-for="(row, idx) in currentRows" :key="row.id ?? row.geoid ?? row.location_id ?? idx">
             <td v-for="column in tableReport.columns" :key="column.key">
               <slot
                 :name="`column-${column.key}`"
@@ -107,6 +107,11 @@ watch(searchQuery, () => {
 
 watch(() => tableReport.value?.columns, () => {
   searchQuery.value = ''
+})
+
+// Reset pagination when data changes (e.g. tab switch, filter update)
+watch(() => tableReport.value?.data, () => {
+  current.value = 1
 })
 
 const currentRows = computed(() => {

--- a/app/components/cal/datagrid.vue
+++ b/app/components/cal/datagrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="mb-6">
     <div v-if="showResultsCount" class="cal-report-total block">
       {{ total }} results found
     </div>
@@ -26,7 +26,7 @@
 
     <div class="table-container">
       <table class="cal-report-table table is-bordered is-striped is-hoverable is-fullwidth">
-        <thead class="is-sticky">
+        <thead>
           <tr>
             <th v-for="column in tableReport.columns" :key="column.key">
               <cat-tooltip v-if="column.tooltip" :text="column.tooltip" position="bottom" class="col-header-tooltip">
@@ -93,8 +93,6 @@ const total = computed(() => {
 
 <style scoped lang="scss">
 .table-container {
-  max-height: 70vh;
-  overflow: auto;
   border: 1px solid var(--bulma-border);
   border-radius: var(--bulma-radius);
   position: relative;
@@ -111,15 +109,7 @@ const total = computed(() => {
     background: var(--bulma-scheme-main-ter);
     color: var(--bulma-text-strong);
     font-weight: 600;
-    position: sticky;
-    top: 0;
-    z-index: 10;
     border-bottom: 2px solid var(--bulma-border);
-
-    // Promote the hovered th so its ::after tooltip paints above table rows
-    &:hover {
-      z-index: 20;
-    }
 
     .col-header-tooltip {
       display: inline-flex;
@@ -137,27 +127,8 @@ const total = computed(() => {
     background: var(--bulma-scheme-main-bis);
   }
 
-  // Freeze first column
-  th:first-child,
   td:first-child {
-    position: sticky;
-    left: 0;
-  }
-
-  th:first-child {
-    z-index: 15; // above both sticky header row and sticky column
-  }
-
-  td:first-child {
-    z-index: 5;
     background: var(--bulma-scheme-main);
-  }
-
-  // Ensure sticky header works properly
-  thead.is-sticky {
-    position: sticky;
-    top: 0;
-    z-index: 10;
   }
 }
 

--- a/app/components/cal/geojson-download.vue
+++ b/app/components/cal/geojson-download.vue
@@ -1,5 +1,5 @@
 <template>
-  <cat-button icon-left="download" :disabled="disabled" @click="saveFile">
+  <cat-button icon-left="download" :disabled="disabled" :variant="variant" @click="saveFile">
     {{ buttonText }}
   </cat-button>
 </template>
@@ -23,6 +23,7 @@ export default {
     disabled: { type: Boolean, default: false },
     filename: { type: String, default: 'export' },
     data: { type: Array, default () { return [] } },
+    variant: { type: String, default: undefined },
   },
   methods: {
     async saveFile () {

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -1,20 +1,25 @@
 <template>
   <div class="cal-report">
-    <cal-title :title="reportHeading">
-      {{ reportHeading }}
-    </cal-title>
+    <div class="cal-report-title-row">
+      <cal-title :title="reportHeading">
+        {{ reportHeading }}
+      </cal-title>
+      <cal-geojson-download
+        :data="downloadFeatures"
+        variant="primary"
+      />
+    </div>
 
     <div class="cal-report-header block">
-      <div class="cal-report-header-top mb-4">
-        <ul style="list-style: disc inside">
-          <li v-for="item of filterSummary" :key="item">
-            {{ item }}
-          </li>
-        </ul>
-        <cal-geojson-download
-          :data="downloadFeatures"
-          variant="primary"
-        />
+      <div class="cal-report-filter-tags mb-4">
+        <span
+          v-for="tag of filterTags"
+          :key="tag.label + tag.value"
+          class="tag is-medium"
+          :class="tag.active ? 'is-primary' : 'is-light'"
+        >
+          {{ tag.label }}: {{ tag.value }}
+        </span>
       </div>
 
       <div class="tabs is-boxed mb-0">
@@ -83,10 +88,10 @@
 import type { TableReport, TableColumn } from './datagrid.vue'
 import { stopToStopCsv, stopGeoAggregateCsv, routeToRouteCsv, agencyToAgencyCsv } from '~~/src/tl'
 import type { ScenarioFilterResult } from '~~/src/scenario'
-import { fmtDate, type DataDisplayMode, type Feature } from '~~/src/core'
+import { fmtDate, type DataDisplayMode, type Feature, type FilterTag } from '~~/src/core'
 
 const props = defineProps<{
-  filterSummary: string[]
+  filterTags: FilterTag[]
   censusGeographyLayerOptions: { label: string, value: string }[]
   scenarioFilterResult?: ScenarioFilterResult
   exportFeatures?: Feature[]
@@ -369,10 +374,15 @@ const activeTableReport = computed((): TableReport => {
     padding-right:20px;
   }
 
-  .cal-report-header-top {
+  .cal-report-title-row {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
+    align-items: center;
+  }
+
+  .cal-report-filter-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
 </style>

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -106,12 +106,14 @@ const downloadFeatures = computed((): Feature[] => {
 })
 
 const reportHeading = computed(() => {
-  const start = fmtDate(props.startDate, 'dd MMM, yyyy')
-  const end = fmtDate(props.endDate, 'dd MMM, yyyy')
-  if (start && end) {
-    return `Reports: ${start} - ${end}`
+  if (!props.startDate || !props.endDate) {
+    return 'Reports'
   }
-  return 'Reports'
+  const sameMonthYear = fmtDate(props.startDate, 'MMM yyyy') === fmtDate(props.endDate, 'MMM yyyy')
+  if (sameMonthYear) {
+    return `Reports: ${fmtDate(props.startDate, 'dd')} - ${fmtDate(props.endDate, 'dd MMM, yyyy')}`
+  }
+  return `Reports: ${fmtDate(props.startDate, 'dd MMM, yyyy')} - ${fmtDate(props.endDate, 'dd MMM, yyyy')}`
 })
 
 const dataDisplayMode = defineModel<DataDisplayMode>('dataDisplayMode', { default: 'Stop visits' })

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -22,25 +22,13 @@
         </span>
       </div>
 
-      <div class="tabs is-boxed mb-0">
-        <ul>
-          <li v-if="props.fixedRouteEnabled" :class="{ 'is-active': activeReportTab === 'routes' }">
-            <a @click="setReportTab('routes')">Routes</a>
-          </li>
-          <li v-if="props.fixedRouteEnabled" :class="{ 'is-active': activeReportTab === 'stops' }">
-            <a @click="setReportTab('stops')">Stops (Individual)</a>
-          </li>
-          <li v-if="props.fixedRouteEnabled && hasAggregateLayer" :class="{ 'is-active': activeReportTab === 'stops-aggregated' }">
-            <a @click="setReportTab('stops-aggregated')">Stops (Aggregated)</a>
-          </li>
-          <li v-if="props.fixedRouteEnabled" :class="{ 'is-active': activeReportTab === 'agencies' }">
-            <a @click="setReportTab('agencies')">Agencies</a>
-          </li>
-          <li v-if="props.flexDisplayFeatures && props.flexDisplayFeatures.length > 0" :class="{ 'is-active': activeReportTab === 'flex' }">
-            <a @click="setReportTab('flex')">Flex Areas</a>
-          </li>
-        </ul>
-      </div>
+      <cat-tabs v-model="activeReportTab" type="boxed">
+        <cat-tab-item v-if="props.fixedRouteEnabled" value="routes" label="Routes" />
+        <cat-tab-item v-if="props.fixedRouteEnabled" value="stops" label="Stops (Individual)" />
+        <cat-tab-item v-if="props.fixedRouteEnabled && hasAggregateLayer" value="stops-aggregated" label="Stops (Aggregated)" />
+        <cat-tab-item v-if="props.fixedRouteEnabled" value="agencies" label="Agencies" />
+        <cat-tab-item v-if="props.flexDisplayFeatures && props.flexDisplayFeatures.length > 0" value="flex" label="Flex Areas" />
+      </cat-tabs>
     </div>
 
     <!-- Aggregation layer selector for aggregated tab -->
@@ -133,26 +121,26 @@ const hasAggregateLayer = computed(() => {
   return aggregateLayer.value !== '' && aggregateLayer.value !== 'none'
 })
 
-function setReportTab (tab: ReportTab) {
-  activeReportTab.value = tab
-  // Sync dataDisplayMode with parent so map/filters stay in sync
-  const modeMap: Record<ReportTab, DataDisplayMode> = {
-    'routes': 'Transit mode',
-    'stops': 'Stop visits',
-    'stops-aggregated': 'Stop visits',
-    'agencies': 'Agency',
-    'flex': 'Service area',
-  }
-  dataDisplayMode.value = modeMap[tab]
+// Sync dataDisplayMode when user switches tabs
+const modeMap: Record<ReportTab, DataDisplayMode> = {
+  'routes': 'Transit mode',
+  'stops': 'Stop visits',
+  'stops-aggregated': 'Stop visits',
+  'agencies': 'Agency',
+  'flex': 'Service area',
 }
+
+watch(activeReportTab, (tab) => {
+  dataDisplayMode.value = modeMap[tab]
+})
 
 watch(hasAggregateLayer, (has) => {
   if (!has && activeReportTab.value === 'stops-aggregated') {
-    setReportTab('stops')
+    activeReportTab.value = 'stops'
   }
 })
 
-// Keep tab in sync if dataDisplayMode changes externally
+// Keep tab in sync if dataDisplayMode changes externally; immediate to set correct initial tab
 watch(dataDisplayMode, (mode) => {
   if (mode === 'Transit mode' || mode === 'Route frequency') {
     activeReportTab.value = 'routes'
@@ -163,7 +151,7 @@ watch(dataDisplayMode, (mode) => {
   } else if (mode === 'Service area') {
     activeReportTab.value = 'flex'
   }
-})
+}, { immediate: true })
 
 const routeColumns: TableColumn[] = [
   { key: 'route_id', label: 'Route ID', sortable: true },

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -1,121 +1,64 @@
 <template>
   <div class="cal-report">
-    <cal-title title="Reports">
-      Reports
+    <cal-title :title="reportHeading">
+      {{ reportHeading }}
     </cal-title>
 
-    <div class="cal-report-options block">
-      <div class="filter-detail">
-        <div class="has-text-weight-semibold mb-3">
-          Report showing {{ reportTitle }}:
-        </div>
-
+    <div class="cal-report-header block">
+      <div class="cal-report-header-top mb-4">
         <ul style="list-style: disc inside">
           <li v-for="item of filterSummary" :key="item">
             {{ item }}
           </li>
         </ul>
-      </div>
-
-      <div class="cal-report-option-section">
-        <!-- Fixed-route service options -->
-        <section v-if="props.fixedRouteEnabled" class="mb-2">
-          <div class="has-text-weight-semibold mb-1 is-flex is-justify-content-space-between is-align-items-center">
-            <span>Showing fixed-route service by:</span>
-            <cat-tooltip text="The selected view determines what rows and associated columns appear in the report. Currently only stops can be aggregated by geographies, such as Census geographies.">
-              <cat-icon icon="information" />
-            </cat-tooltip>
-          </div>
-          <cat-field class="mb-0">
-            <cat-radio
-              v-model="dataDisplayMode"
-              name="dataDisplayMode"
-              native-value="Transit mode"
-              label="Routes"
-            />
-          </cat-field>
-          <cat-field class="mb-0">
-            <cat-radio
-              v-model="dataDisplayMode"
-              name="dataDisplayMode"
-              native-value="Stop visits"
-              label="Stops"
-            />
-          </cat-field>
-          <cat-field class="mb-0">
-            <cat-radio
-              v-model="dataDisplayMode"
-              name="dataDisplayMode"
-              native-value="Agency"
-              label="Agency"
-            />
-          </cat-field>
-        </section>
-
-        <!-- Flex service options -->
-        <section v-if="props.flexDisplayFeatures && props.flexDisplayFeatures.length > 0" class="mb-0">
-          <div class="has-text-weight-semibold mb-1 is-flex is-justify-content-space-between is-align-items-center">
-            <span>Showing flex service by:</span>
-            <cat-tooltip text="The selected view determines what rows and associated columns appear in the report.">
-              <cat-icon icon="information" />
-            </cat-tooltip>
-          </div>
-          <cat-field class="mb-0">
-            <cat-radio
-              v-model="dataDisplayMode"
-              name="dataDisplayMode"
-              native-value="Service area"
-              label="Service areas"
-            />
-          </cat-field>
-        </section>
-      </div>
-
-      <div class="cal-report-option-section">
-        <div class="has-text-weight-semibold mb-1 is-flex is-justify-content-space-between is-align-items-center">
-          <span>Aggregate by:</span>
-          <cat-tooltip text="The selected geography level determines how stop data is grouped in the aggregated table below. Enable 'Show Agg. Areas' in Map Display to visualize these areas on the map.">
-            <cat-icon icon="information" />
-          </cat-tooltip>
-        </div>
-        <cat-field class="mb-3">
-          <cat-select v-model="aggregateLayer">
-            <option
-              v-for="option of censusGeographyLayerOptions"
-              :key="option.value"
-              :value="option.value"
-            >
-              {{ option.label }}
-            </option>
-          </cat-select>
-        </cat-field>
-
-        <div class="has-text-weight-semibold mb-1">
-          Download
-        </div>
         <cal-geojson-download
           :data="downloadFeatures"
+          variant="primary"
         />
+      </div>
+
+      <div class="tabs is-boxed mb-0">
+        <ul>
+          <li v-if="props.fixedRouteEnabled" :class="{ 'is-active': activeReportTab === 'routes' }">
+            <a @click="setReportTab('routes')">Routes</a>
+          </li>
+          <li v-if="props.fixedRouteEnabled" :class="{ 'is-active': activeReportTab === 'stops' }">
+            <a @click="setReportTab('stops')">Stops (Individual)</a>
+          </li>
+          <li v-if="props.fixedRouteEnabled && hasAggregateLayer" :class="{ 'is-active': activeReportTab === 'stops-aggregated' }">
+            <a @click="setReportTab('stops-aggregated')">Stops (Aggregated)</a>
+          </li>
+          <li v-if="props.fixedRouteEnabled" :class="{ 'is-active': activeReportTab === 'agencies' }">
+            <a @click="setReportTab('agencies')">Agencies</a>
+          </li>
+          <li v-if="props.flexDisplayFeatures && props.flexDisplayFeatures.length > 0" :class="{ 'is-active': activeReportTab === 'flex' }">
+            <a @click="setReportTab('flex')">Flex Areas</a>
+          </li>
+        </ul>
       </div>
     </div>
 
-    <div v-if="geoReportData.columns.length > 0">
-      <h4 class="title is-5 mb-4">
-        Aggregated by {{ censusLayerLabels[aggregateLayer]?.singular || 'Geographic Area' }}
-      </h4>
-      <cal-datagrid
-        :table-report="geoReportData"
-      />
-      <hr class="my-5">
+    <!-- Aggregation layer selector for aggregated tab -->
+    <div v-if="activeReportTab === 'stops-aggregated'" class="mb-4 is-flex is-align-items-center" style="gap: 0.5rem">
+      <span class="has-text-weight-semibold">Aggregate by:</span>
+      <cat-select v-model="aggregateLayer" style="width: auto">
+        <option
+          v-for="option of censusGeographyLayerOptions"
+          :key="option.value"
+          :value="option.value"
+        >
+          {{ option.label }}
+        </option>
+      </cat-select>
+      <cat-tooltip text="The selected geography level determines how stop data is grouped. Enable 'Show Agg. Areas' in Map Display to visualize these areas on the map.">
+        <cat-icon icon="information" />
+      </cat-tooltip>
     </div>
 
-    <h4 class="title is-5 mb-4">
-      Individual results
-    </h4>
     <cal-datagrid
-      :table-report="reportData"
+      :table-report="activeTableReport"
     >
-      <!-- Custom rendering for URLs column -->
+      <!-- Custom rendering for URLs column (flex areas) -->
       <template #column-urls="{ row }">
         <span class="flex-url-links">
           <span v-if="row.info_url" title="Service Information" class="mr-2">
@@ -139,13 +82,15 @@
 import type { TableReport, TableColumn } from './datagrid.vue'
 import { stopToStopCsv, stopGeoAggregateCsv, routeToRouteCsv, agencyToAgencyCsv } from '~~/src/tl'
 import type { ScenarioFilterResult } from '~~/src/scenario'
-import { censusLayerLabels, type DataDisplayMode, type Feature } from '~~/src/core'
+import { fmtDate, type DataDisplayMode, type Feature } from '~~/src/core'
 
 const props = defineProps<{
   filterSummary: string[]
   censusGeographyLayerOptions: { label: string, value: string }[]
   scenarioFilterResult?: ScenarioFilterResult
   exportFeatures?: Feature[]
+  startDate?: Date
+  endDate?: Date
   // Service type toggles
   fixedRouteEnabled?: boolean
   flexServicesEnabled?: boolean
@@ -160,8 +105,51 @@ const downloadFeatures = computed((): Feature[] => {
   return props.exportFeatures || []
 })
 
+const reportHeading = computed(() => {
+  const start = fmtDate(props.startDate, 'dd MMM, yyyy')
+  const end = fmtDate(props.endDate, 'dd MMM, yyyy')
+  if (start && end) {
+    return `Reports: ${start} - ${end}`
+  }
+  return 'Reports'
+})
+
 const dataDisplayMode = defineModel<DataDisplayMode>('dataDisplayMode', { default: 'Stop visits' })
 const aggregateLayer = defineModel<string>('aggregateLayer', { default: '' })
+
+type ReportTab = 'routes' | 'stops' | 'stops-aggregated' | 'agencies' | 'flex'
+
+const activeReportTab = ref<ReportTab>('routes')
+
+const hasAggregateLayer = computed(() => {
+  return aggregateLayer.value !== '' && aggregateLayer.value !== 'none'
+})
+
+function setReportTab (tab: ReportTab) {
+  activeReportTab.value = tab
+  // Sync dataDisplayMode with parent so map/filters stay in sync
+  const modeMap: Record<ReportTab, DataDisplayMode> = {
+    'routes': 'Transit mode',
+    'stops': 'Stop visits',
+    'stops-aggregated': 'Stop visits',
+    'agencies': 'Agency',
+    'flex': 'Service area',
+  }
+  dataDisplayMode.value = modeMap[tab]
+}
+
+// Keep tab in sync if dataDisplayMode changes externally
+watch(dataDisplayMode, (mode) => {
+  if (mode === 'Transit mode' || mode === 'Route frequency') {
+    activeReportTab.value = 'routes'
+  } else if (mode === 'Stop visits' && activeReportTab.value !== 'stops-aggregated') {
+    activeReportTab.value = 'stops'
+  } else if (mode === 'Agency') {
+    activeReportTab.value = 'agencies'
+  } else if (mode === 'Service area') {
+    activeReportTab.value = 'flex'
+  }
+})
 
 const routeColumns: TableColumn[] = [
   { key: 'route_id', label: 'Route ID', sortable: true },
@@ -315,52 +303,55 @@ const geoReportData = computed((): TableReport => {
   if (aggregateLayer.value === '' || aggregateLayer.value === 'none') {
     return { data: [], columns: [] }
   }
-  // Handle aggregation
-  if (dataDisplayMode.value === 'Stop visits') {
-    return {
-      data: stopGeoAggregateCsv((props.scenarioFilterResult?.stops || []).filter(s => (s.marked)), aggregateLayer.value),
-      columns: stopGeoAggregateColumns.value
-    }
+  return {
+    data: stopGeoAggregateCsv((props.scenarioFilterResult?.stops || []).filter(s => (s.marked)), aggregateLayer.value),
+    columns: stopGeoAggregateColumns.value
   }
-  return { data: [], columns: [] }
 })
 
-const reportData = computed((): TableReport => {
-  if (dataDisplayMode.value === 'Transit mode' || dataDisplayMode.value === 'Route frequency') {
-    return {
-      data: (props.scenarioFilterResult?.routes || []).filter(s => (s.marked)).map(routeToRouteCsv),
-      columns: routeColumns
-    }
-  } else if (dataDisplayMode.value === 'Stop visits') {
-    return {
-      data: (props.scenarioFilterResult?.stops || []).filter(s => s.marked).map(stopToStopCsv),
-      columns: stopColumns
-    }
-  } else if (dataDisplayMode.value === 'Agency') {
-    return {
-      data: (props.scenarioFilterResult?.agencies || []).filter(s => s.marked).map(agencyToAgencyCsv),
-      columns: agencyColumns
-    }
-  } else if (dataDisplayMode.value === 'Service area') {
-    return {
-      data: (props.flexDisplayFeatures || []).map(flexFeatureToCsv),
-      columns: flexAreaColumns
-    }
+const routesReportData = computed((): TableReport => {
+  return {
+    data: (props.scenarioFilterResult?.routes || []).filter(s => (s.marked)).map(routeToRouteCsv),
+    columns: routeColumns
   }
-  return { data: [], columns: [] }
 })
 
-const reportTitle = computed(() => {
-  if (dataDisplayMode.value === 'Transit mode' || dataDisplayMode.value === 'Route frequency') {
-    return 'routes'
-  } else if (dataDisplayMode.value === 'Stop visits') {
-    return 'stops'
-  } else if (dataDisplayMode.value === 'Agency') {
-    return 'agencies'
-  } else if (dataDisplayMode.value === 'Service area') {
-    return 'flex service areas'
+const stopsReportData = computed((): TableReport => {
+  return {
+    data: (props.scenarioFilterResult?.stops || []).filter(s => s.marked).map(stopToStopCsv),
+    columns: stopColumns
   }
-  return ''
+})
+
+const agenciesReportData = computed((): TableReport => {
+  return {
+    data: (props.scenarioFilterResult?.agencies || []).filter(s => s.marked).map(agencyToAgencyCsv),
+    columns: agencyColumns
+  }
+})
+
+const flexReportData = computed((): TableReport => {
+  return {
+    data: (props.flexDisplayFeatures || []).map(flexFeatureToCsv),
+    columns: flexAreaColumns
+  }
+})
+
+const activeTableReport = computed((): TableReport => {
+  switch (activeReportTab.value) {
+    case 'routes':
+      return routesReportData.value
+    case 'stops':
+      return stopsReportData.value
+    case 'stops-aggregated':
+      return geoReportData.value
+    case 'agencies':
+      return agenciesReportData.value
+    case 'flex':
+      return flexReportData.value
+    default:
+      return { data: [], columns: [] }
+  }
 })
 </script>
 
@@ -373,51 +364,12 @@ const reportTitle = computed(() => {
     width: calc(100vw - 100px);
     padding-left:20px;
     padding-right:20px;
-    > .cal-body {
-      > div, > article {
-        margin-bottom:10px;
-      }
-    }
   }
 
-  .cal-report-options {
+  .cal-report-header-top {
     display: flex;
-    flex: 0;
-    flex-flow: row nowrap;
     justify-content: space-between;
-
-    > .filter-detail {
-      flex: 1 1 25%;
-      align-self: stretch;
-      background-color: #f8f9fa;
-      border: 1px solid #333;
-      padding: 1rem;
-      border-radius: 6px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    }
-
-    > .cal-report-option-section {
-      flex: 1;
-      align-self: stretch;
-      border: 1px solid #333;
-      padding: 1rem;
-      margin-left: 15px;
-      background-color: #fff;
-      border-radius: 6px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-
-      > .which-report {
-        font-size: larger;
-        font-weight: bold;
-      }
-    }
-
-    > .cal-report-download {
-      flex: 1;
-      display: flex;
-      align-self: center;
-      flex-flow: column nowrap;
-      margin-left: 15px;
-    }
+    align-items: flex-start;
+    gap: 1rem;
   }
 </style>

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -80,7 +80,7 @@
         </span>
       </template>
     </cal-datagrid>
-    <div style="min-height: 3rem" />
+    <div class="cal-report-spacer" />
   </div>
 </template>
 
@@ -145,6 +145,12 @@ function setReportTab (tab: ReportTab) {
   }
   dataDisplayMode.value = modeMap[tab]
 }
+
+watch(hasAggregateLayer, (has) => {
+  if (!has && activeReportTab.value === 'stops-aggregated') {
+    setReportTab('stops')
+  }
+})
 
 // Keep tab in sync if dataDisplayMode changes externally
 watch(dataDisplayMode, (mode) => {
@@ -384,5 +390,9 @@ const activeTableReport = computed((): TableReport => {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+  }
+
+  .cal-report-spacer {
+    min-height: 3rem;
   }
 </style>

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -75,6 +75,7 @@
         </span>
       </template>
     </cal-datagrid>
+    <div style="min-height: 3rem" />
   </div>
 </template>
 

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -161,7 +161,7 @@
             :census-geography-layer-options="censusGeographyLayerOptions"
             :scenario-filter-result="scenarioFilterResult"
             :export-features="exportFeatures"
-            :filter-summary="filterSummary"
+            :filter-tags="filterTags"
             :start-date="startDate"
             :end-date="endDate"
             :fixed-route-enabled="fixedRouteEnabled"
@@ -251,14 +251,12 @@ import {
   bboxString,
   routeTypeNames,
   cannedBboxes,
-  fmtDate,
   fmtTime,
   asDateString,
   asTimeString,
   parseDate,
   normalizeDate,
   parseTime,
-  getLocalDateNoTime,
   dateToSeconds,
   convertBbox,
   SCENARIO_DEFAULTS,
@@ -266,7 +264,8 @@ import {
   choroplethPalette,
   flexAdvanceNoticeTypes,
   flexAreaTypes,
-  type DataDisplayMode
+  type DataDisplayMode,
+  type FilterTag,
 } from '~~/src/core'
 import { navigateTo, useToastNotification, useRouter } from '#imports'
 import type { FlexAdvanceNotice, FlexAreaType, FlexAreaFeature, CensusDataset, CensusGeography } from '~~/src/tl'
@@ -1419,107 +1418,72 @@ watch(() => [
 })
 
 /////////////////
-// Filter summary
+// Filter tags
 /////////////////
 
-// Each result in the filter summary will be a string to be used as a bullet point.
-// We will only include results if the filter is set to something interesting (not default)
-const filterSummary = computed((): string[] => {
-  // const mode = dataDisplayMode.value
-  const results: string[] = []
+const filterTags = computed((): FilterTag[] => {
+  const tags: FilterTag[] = []
 
   // route types
   const selectedRtypes = scenarioFilter.value.selectedRouteTypes
-  if (selectedRtypes == null || selectedRtypes.length === 0) {
-    results.push('with any route type')
-  } else if (selectedRtypes.length !== routeTypeNames.size) {
-    const rtypes = selectedRtypes.map(val => toTitleCase(routeTypeNames.get(val) || '')).filter(Boolean)
-    results.push('with route types ' + rtypes.join(', '))
-  }
-
-  // agencies
-  const agencies = scenarioFilter.value.selectedAgencies
-  if (agencies == null || agencies.length === 0) {
-    results.push('operated by any agency')
+  if (selectedRtypes == null || selectedRtypes.length === 0 || selectedRtypes.length === routeTypeNames.size) {
+    tags.push({ label: 'Route Type', value: 'All', active: false })
   } else {
-    results.push('operated by ' + agencies.join(', '))
-  }
-
-  // date range
-  const rawStartDate = scenarioConfig.value.startDate
-  const rawEndDate = scenarioConfig.value.endDate
-  if (rawStartDate == null && rawEndDate == null) {
-    results.push('operating on any date')
-  } else {
-    const today = fmtDate(getLocalDateNoTime(), 'P')
-    const sdate = fmtDate(rawStartDate, 'P') || today
-    const edate = fmtDate(rawEndDate, 'P') || today
-    if (sdate !== today && edate !== today && sdate !== edate) {
-      results.push('operating between ' + sdate + ' and ' + edate)
-    } else if (sdate !== today && edate !== today && sdate === edate) {
-      results.push('operating on ' + sdate)
-    } else if (sdate !== today && edate === today) {
-      results.push('operating after ' + sdate)
+    for (const rt of selectedRtypes) {
+      const name = toTitleCase(routeTypeNames.get(rt) || '')
+      if (name) {
+        tags.push({ label: 'Route Type', value: name, active: true })
+      }
     }
   }
 
-  // days of week  (always show something here)
+  // days of week
   const days = scenarioFilter.value.selectedWeekdays
-  const dowMode = scenarioFilter.value.selectedWeekdayMode
   if (days == null || days.length === 0) {
-    // Any day of the week
-  } else if (dowMode === 'All') {
-    results.push('operating all of ' + days.map(val => toTitleCase(val)).join(', '))
-  } else if (dowMode === 'Any') {
-    results.push('operating any of ' + days.map(val => toTitleCase(val)).join(', '))
+    tags.push({ label: 'Days of Week', value: 'All', active: false })
+  } else {
+    tags.push({ label: 'Days of Week', value: days.map(val => toTitleCase(val)).join(', '), active: true })
   }
 
-  // time range
-  if (scenarioFilter.value.startTime != null || scenarioFilter.value.endTime != null) {
-    const stime = fmtTime(scenarioFilter.value.startTime, 'p')
-    const etime = fmtTime(scenarioFilter.value.endTime, 'p')
-    if (stime && etime && stime !== etime) {
-      // Any time
-    } else if (stime && etime && stime === etime) {
-      results.push('operating at ' + stime)
-    } else if (stime && !etime) {
-      results.push('operating after ' + stime)
-    } else if (etime && !stime) {
-      results.push('operating before ' + etime)
-    }
+  // time of day
+  const stime = fmtTime(scenarioFilter.value.startTime, 'p')
+  const etime = fmtTime(scenarioFilter.value.endTime, 'p')
+  if (stime && etime && stime !== etime) {
+    tags.push({ label: 'Time of Day', value: `${stime} – ${etime}`, active: true })
+  } else if (stime && !etime) {
+    tags.push({ label: 'Time of Day', value: `After ${stime}`, active: true })
+  } else if (etime && !stime) {
+    tags.push({ label: 'Time of Day', value: `Before ${etime}`, active: true })
+  } else {
+    tags.push({ label: 'Time of Day', value: 'All', active: false })
   }
 
   // frequencies
   const minFreq = scenarioFilter.value.frequencyOver
   const maxFreq = scenarioFilter.value.frequencyUnder
-  const hasMinFreq = minFreq != null
-  const hasMaxFreq = maxFreq != null
-  if (hasMinFreq && hasMaxFreq && minFreq !== maxFreq) {
-    results.push('with frequency between ' + minFreq + ' and ' + maxFreq + ' minutes')
-  } else if (hasMinFreq && hasMaxFreq && minFreq === maxFreq) {
-    results.push('with frequency exactly ' + minFreq + ' minutes')
-  } else if (hasMinFreq && !hasMaxFreq) {
-    results.push('with frequency at least ' + minFreq + ' minutes')
-  } else if (hasMaxFreq && !hasMinFreq) {
-    results.push('with frequency less than ' + maxFreq + ' minutes')
+  if (minFreq != null && maxFreq != null && minFreq !== maxFreq) {
+    tags.push({ label: 'Frequencies', value: `${minFreq}–${maxFreq} min`, active: true })
+  } else if (minFreq != null && maxFreq != null && minFreq === maxFreq) {
+    tags.push({ label: 'Frequencies', value: `${minFreq} min`, active: true })
+  } else if (minFreq != null) {
+    tags.push({ label: 'Frequencies', value: `≥${minFreq} min`, active: true })
+  } else if (maxFreq != null) {
+    tags.push({ label: 'Frequencies', value: `<${maxFreq} min`, active: true })
+  } else {
+    tags.push({ label: 'Frequencies', value: 'All', active: false })
   }
 
-  // fares
-  const hasMinFare = minFareEnabled.value
-  const minDollar = minFare.value
-  const hasMaxFare = maxFareEnabled.value
-  const maxDollar = maxFare.value
-  if (hasMinFare && hasMaxFare && minDollar !== maxDollar) {
-    results.push('with fare between $' + minDollar + ' and $' + maxDollar)
-  } else if (hasMinFare && hasMaxFare && minDollar === maxDollar) {
-    results.push('with fare exactly $' + minDollar)
-  } else if (hasMinFare && !hasMaxFare) {
-    results.push('with fare at least $' + minDollar)
-  } else if (hasMaxFare && !hasMinFare) {
-    results.push('with fare less than $' + maxDollar)
+  // agencies
+  const agencies = scenarioFilter.value.selectedAgencies
+  if (agencies == null || agencies.length === 0) {
+    tags.push({ label: 'Agencies', value: 'All', active: false })
+  } else {
+    for (const agency of agencies) {
+      tags.push({ label: 'Agency', value: agency, active: true })
+    }
   }
 
-  return results
+  return tags
 })
 
 //////////////////////

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -162,6 +162,8 @@
             :scenario-filter-result="scenarioFilterResult"
             :export-features="exportFeatures"
             :filter-summary="filterSummary"
+            :start-date="startDate"
+            :end-date="endDate"
             :fixed-route-enabled="fixedRouteEnabled"
             :flex-services-enabled="flexServicesEnabled"
             :flex-display-features="flexFeaturesForReport"

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -1439,10 +1439,12 @@ const filterTags = computed((): FilterTag[] => {
 
   // days of week
   const days = scenarioFilter.value.selectedWeekdays
+  const dowMode = scenarioFilter.value.selectedWeekdayMode
   if (days == null || days.length === 0) {
     tags.push({ label: 'Days of Week', value: 'All', active: false })
   } else {
-    tags.push({ label: 'Days of Week', value: days.map(val => toTitleCase(val)).join(', '), active: true })
+    const modePrefix = dowMode === 'All' ? 'All of ' : 'Any of '
+    tags.push({ label: 'Days of Week', value: modePrefix + days.map(val => toTitleCase(val)).join(', '), active: true })
   }
 
   // time of day

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -251,6 +251,7 @@ import {
   bboxString,
   routeTypeNames,
   cannedBboxes,
+  fmtDate,
   fmtTime,
   asDateString,
   asTimeString,
@@ -1435,6 +1436,16 @@ const filterTags = computed((): FilterTag[] => {
         tags.push({ label: 'Route Type', value: name, active: true })
       }
     }
+  }
+
+  // date range
+  const sd = startDate.value
+  const ed = endDate.value
+  const sameMonthYear = fmtDate(sd, 'MMM yyyy') === fmtDate(ed, 'MMM yyyy')
+  if (sameMonthYear) {
+    tags.push({ label: 'Dates', value: `${fmtDate(sd, 'dd')} – ${fmtDate(ed, 'dd MMM, yyyy')}`, active: true })
+  } else {
+    tags.push({ label: 'Dates', value: `${fmtDate(sd, 'dd MMM, yyyy')} – ${fmtDate(ed, 'dd MMM, yyyy')}`, active: true })
   }
 
   // days of week

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -205,6 +205,12 @@ export const flexColorByModes = [
 
 export type FlexColorByMode = typeof flexColorByModes[number]
 
+export interface FilterTag {
+  label: string
+  value: string
+  active: boolean
+}
+
 /**
  * 5-class sequential blue palette for choropleth map shading.
  * Used in both feature generation (tne.vue) and legend CSS (legend.vue).


### PR DESCRIPTION
## Summary

Redesigns the Reports view to match the updated wireframe from #301. The radio-button report switcher is replaced with a tab bar, tables are simplified to pagination-only (no scroll), filters are displayed as compact tags, and the overall layout is streamlined with a search bar, repositioned controls, and better whitespace.

### Report view layout

- Replace radio buttons with `cat-tabs`/`cat-tab-item` components for a proper 5-tab bar: Routes, Stops (Individual), Stops (Aggregated), Agencies, Flex Areas
- Only one table is shown at a time; the aggregated stops view is now its own tab instead of a secondary table
- Title row shows date range ("Reports: 01 - 07 Jan, 2026") with condensed format when same month/year
- "Download as GeoJSON" button moved to title row with primary styling
- Tab/dataDisplayMode sync uses an immediate watcher so the correct tab is selected on first render

### Filter tags

- Replace prose bullet-point filter summary with Bulma `.tag` pill elements
- Active (non-default) filters render as purple (`is-primary`) tags; defaults as gray (`is-light`)
- Individual tags per route type and per agency for better wrapping behavior
- New `FilterTag` interface in `src/core/constants.ts`

### Datagrid improvements

- Remove scroll container (`max-height`/`overflow`) and sticky header/column — tables render at natural height with pagination only
- Add search input above table (filters all columns, clears on tab switch) with CSV download right-aligned
- Move pagination below table with "Showing X-Y of Z results" summary
- Reset pagination to page 1 when the underlying data changes (tab switch, filter update)
- Use stable row keys with fallback chain (`id ?? geoid ?? location_id ?? index`) to handle all report types
- Remove unused `showResultsCount` prop and clean up references in analysis viewers
- Add bottom whitespace via margin and spacer element

## Test plan

- Open the Reports view after running a scenario query
- Verify tab switching between Routes, Stops, Stops (Aggregated), Agencies, and Flex Areas — each should show exactly one table
- Confirm Stops (Aggregated) tab only appears when an aggregation layer is selected in the filter panel
- Check that filter tags display correctly: purple for active filters, gray for defaults
- Test the search input filters table rows and clears when switching tabs
- Verify pagination appears below the table with correct "Showing X-Y of Z" counts and resets to page 1 on tab switch
- Confirm Download CSV and Download GeoJSON buttons still work
- Check analysis views (WSDOT, VisionEval) still render their datagrids correctly