### PR TITLE
Bump catenary and tlv2-auth

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,7 +28,7 @@ export default defineNuxtConfig({
       clientId: '',
       clientSecret: '',
       sessionSecret: '',
-      appBaseUrl: process.env.CF_PAGES_URL || '',
+      appBaseUrl: '',
       audience: '',
     },
     tlv2: {
@@ -75,5 +75,6 @@ export default defineNuxtConfig({
     loginGate: true,
     requireLogin: true,
     proxyEnabled: true,
+    autoAppBaseUrl: true,
   },
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -74,5 +74,6 @@ export default defineNuxtConfig({
   tlv2Auth: {
     loginGate: true,
     requireLogin: true,
+    proxyEnabled: true,
   },
 })

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@aitodotai/json-stringify-pretty-compact": "1.3.0",
     "@interline-io/catenary": "0.1.0-sha.280fe3c",
     "@mdi/font": "7.4.47",
-    "@interline-io/tlv2-auth": "0.1.0-sha.45205ff",
+    "@interline-io/tlv2-auth": "0.1.0-sha.a45d5f7",
     "@apollo/client": "3.13.4",
     "@vue/apollo-composable": "4.2.2",
     "@vueuse/core": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "dependencies": {
     "@aitodotai/json-stringify-pretty-compact": "1.3.0",
-    "@interline-io/catenary": "0.1.0-sha.ed961b4",
+    "@interline-io/catenary": "0.1.0-sha.280fe3c",
     "@mdi/font": "7.4.47",
-    "@interline-io/tlv2-auth": "0.0.0-sha.5c65f5e",
+    "@interline-io/tlv2-auth": "0.1.0-sha.45205ff",
     "@apollo/client": "3.13.4",
     "@vue/apollo-composable": "4.2.2",
     "@vueuse/core": "14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: 3.13.4
         version: 3.13.4(graphql@16.10.0)
       '@interline-io/catenary':
-        specifier: 0.1.0-sha.ed961b4
-        version: 0.1.0-sha.ed961b4(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
+        specifier: 0.1.0-sha.280fe3c
+        version: 0.1.0-sha.280fe3c(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       '@interline-io/tlv2-auth':
-        specifier: 0.0.0-sha.5c65f5e
-        version: 0.0.0-sha.5c65f5e(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
+        specifier: 0.1.0-sha.45205ff
+        version: 0.1.0-sha.45205ff(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
       '@mdi/font':
         specifier: 7.4.47
         version: 7.4.47
@@ -735,20 +735,18 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@interline-io/catenary@0.1.0-sha.ed961b4':
-    resolution: {integrity: sha512-UmELxJrejUtyEH5yVPVPOmVI0YGqP+rYVhzEpPZPPKia7FL7NH+y4l3LYjtHQha0BAJHV/7dnfgtzLZU8UdknA==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.1.0-sha.ed961b4/9a7abb7efeda363cc5c3922c2f5c87db42c9ad61}
+  '@interline-io/catenary@0.1.0-sha.280fe3c':
+    resolution: {integrity: sha512-OsByDb2OO9j6UkwUP86UOjnB5/Ob0raXzKPb8XnrRbMNA3v68KTNOGJWlzPonhXkG//07DaV5OA8bfQXszryIQ==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.1.0-sha.280fe3c/893c02f68e1229200425c3bd41289063931baf1e}
     peerDependencies:
       '@mdi/font': ^7.4.0
       bulma: ^1.0.0
       vue: ^3.5.0
       vue-router: ^4.0.0
-    peerDependenciesMeta:
-      vue-router:
-        optional: true
 
-  '@interline-io/tlv2-auth@0.0.0-sha.5c65f5e':
-    resolution: {integrity: sha512-jk7RbXFCDYxuQAQGoq9dwslPk/IU2WdyqXFvlCuXzsOs7H+Da1oo54NdBJ2EjvXzqinWp0f9I0wGTA4dSYxvOA==, tarball: https://npm.pkg.github.com/download/@interline-io/tlv2-auth/0.0.0-sha.5c65f5e/05a5fa683ae29cea6285bae4d19380482449cbbe}
+  '@interline-io/tlv2-auth@0.1.0-sha.45205ff':
+    resolution: {integrity: sha512-kGGFmlKWZu1hdyIIlTDGlaxnKJb4cU79F7J76dFLLAltI6XQzxk3vRkVVAS03YxmaxnrJlCSVsITEo7wgrVBDw==, tarball: https://npm.pkg.github.com/download/@interline-io/tlv2-auth/0.1.0-sha.45205ff/3922f0d5f2546ab6a4e5eeae3aceb7edcb2757fb}
     peerDependencies:
+      h3: ^1.0.0
       nuxt: ^4.0.0
       vue: ^3.0.0
 
@@ -3671,9 +3669,6 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nuxt-csurf@1.6.5:
-    resolution: {integrity: sha512-/DMNTON8LIVhntamKbBmAuM879B0QnuSJa7ZAkmkZe+21m+1QGcjVUxtSkizaM48NUvkuAGYOG0ncn+kqEgrzw==}
-
   nuxt@4.2.0:
     resolution: {integrity: sha512-4qzf2Ymf07dMMj50TZdNZgMqCdzDch8NY3NO2ClucUaIvvsr6wd9+JrDpI1CckSTHwqU37/dIPFpvIQZoeHoYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4735,9 +4730,6 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
-  uncsrf@1.2.0:
-    resolution: {integrity: sha512-EyeG1tIx1zisLuqokSXZ5LhndzaUd2WBMS+18IlBUYobJsKSUQMpLIEm6QUfY/Azmhnnz0v2QbkrT6/u2K/Y1g==}
-
   unctx@2.5.0:
     resolution: {integrity: sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==}
 
@@ -5707,25 +5699,22 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@interline-io/catenary@0.1.0-sha.ed961b4(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/catenary@0.1.0-sha.280fe3c(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@mdi/font': 7.4.47
       bulma: 1.0.4
       csv-stringify: 6.7.0
       date-fns: 4.1.0
       vue: 3.5.22(typescript@5.9.3)
-    optionalDependencies:
       vue-router: 4.6.4(vue@3.5.22(typescript@5.9.3))
 
-  '@interline-io/tlv2-auth@0.0.0-sha.5c65f5e(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/tlv2-auth@0.1.0-sha.45205ff(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@auth0/auth0-nuxt': 1.0.1
       defu: 6.1.4
+      h3: 1.15.8
       nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
-      nuxt-csurf: 1.6.5(magicast@0.5.2)
       vue: 3.5.22(typescript@5.9.3)
-    transitivePeerDependencies:
-      - magicast
 
   '@ioredis/commands@1.5.1': {}
 
@@ -6025,32 +6014,6 @@ snapshots:
   '@nuxt/kit@3.21.2(magicast@0.3.5)':
     dependencies:
       c12: 3.3.3(magicast@0.3.5)
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      errx: 0.1.0
-      exsolve: 1.0.8
-      ignore: 7.0.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      mlly: 1.8.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rc9: 3.0.0
-      scule: 1.3.0
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ufo: 1.6.3
-      unctx: 2.5.0
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
-  '@nuxt/kit@3.21.2(magicast@0.5.2)':
-    dependencies:
-      c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -9003,14 +8966,6 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-csurf@1.6.5(magicast@0.5.2):
-    dependencies:
-      '@nuxt/kit': 3.21.2(magicast@0.5.2)
-      defu: 6.1.4
-      uncsrf: 1.2.0
-    transitivePeerDependencies:
-      - magicast
-
   nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
       '@dxup/nuxt': 0.2.2(magicast@0.5.2)
@@ -10164,8 +10119,6 @@ snapshots:
   ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
-
-  uncsrf@1.2.0: {}
 
   unctx@2.5.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 0.1.0-sha.280fe3c
         version: 0.1.0-sha.280fe3c(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       '@interline-io/tlv2-auth':
-        specifier: 0.1.0-sha.45205ff
-        version: 0.1.0-sha.45205ff(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
+        specifier: 0.1.0-sha.a45d5f7
+        version: 0.1.0-sha.a45d5f7(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
       '@mdi/font':
         specifier: 7.4.47
         version: 7.4.47
@@ -742,9 +742,12 @@ packages:
       bulma: ^1.0.0
       vue: ^3.5.0
       vue-router: ^4.0.0
+    peerDependenciesMeta:
+      vue-router:
+        optional: true
 
-  '@interline-io/tlv2-auth@0.1.0-sha.45205ff':
-    resolution: {integrity: sha512-kGGFmlKWZu1hdyIIlTDGlaxnKJb4cU79F7J76dFLLAltI6XQzxk3vRkVVAS03YxmaxnrJlCSVsITEo7wgrVBDw==, tarball: https://npm.pkg.github.com/download/@interline-io/tlv2-auth/0.1.0-sha.45205ff/3922f0d5f2546ab6a4e5eeae3aceb7edcb2757fb}
+  '@interline-io/tlv2-auth@0.1.0-sha.a45d5f7':
+    resolution: {integrity: sha512-Ncgd84Q9Jcgsl3ZJ2rtS9tf3zvLFfBl/maOkr084cbUoQcELBp9h9FrfbsnbGobidywL7hHOO2Am0DmaTOTwwg==, tarball: https://npm.pkg.github.com/download/@interline-io/tlv2-auth/0.1.0-sha.a45d5f7/c7a30f33f94ea430acd05a688abad3ac1b4c3e22}
     peerDependencies:
       h3: ^1.0.0
       nuxt: ^4.0.0
@@ -5706,9 +5709,10 @@ snapshots:
       csv-stringify: 6.7.0
       date-fns: 4.1.0
       vue: 3.5.22(typescript@5.9.3)
+    optionalDependencies:
       vue-router: 4.6.4(vue@3.5.22(typescript@5.9.3))
 
-  '@interline-io/tlv2-auth@0.1.0-sha.45205ff(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/tlv2-auth@0.1.0-sha.a45d5f7(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@auth0/auth0-nuxt': 1.0.1
       defu: 6.1.4


### PR DESCRIPTION
## Summary

Upgrade `@interline-io/catenary` and `@interline-io/tlv2-auth` to their latest main branch versions. The tlv2-auth upgrade includes breaking changes: the API proxy is now opt-in (`proxyEnabled: true`), and the `audience` runtimeConfig field is now properly typed via the module schema (previously caused a TS2353 build error due to `@auth0/auth0-nuxt`'s `Overrideable` wrapper). The new tlv2-auth also drops `nuxt-csurf` in favor of a direct `h3` peer dependency.

### Dependency upgrades
- `@interline-io/catenary`: `0.1.0-sha.ed961b4` → `0.1.0-sha.280fe3c`
- `@interline-io/tlv2-auth`: `0.0.0-sha.5c65f5e` → `0.1.0-sha.a45d5f7`

### Config changes
- Added `proxyEnabled: true` to `tlv2Auth` config in `nuxt.config.ts` to opt in to the API proxy (now required by tlv2-auth)
- Enabled `autoAppBaseUrl: true` in `tlv2Auth` config — this derives the Auth0 callback URL from the request `Host` header at runtime instead of relying on the `CF_PAGES_URL` build-time env var, so preview branch deployments on Cloudflare Pages get the correct callback URL automatically
- Removed `process.env.CF_PAGES_URL` fallback from `runtimeConfig.auth0.appBaseUrl` (no longer needed with `autoAppBaseUrl`)

## Test plan
- Verify the app starts with `pnpm dev` and loads the login page
- Log in and confirm the API proxy works (scenario queries return data)
- Verify catenary UI components render correctly (buttons, modals, tables, notifications)
- Deploy to a CF Pages preview branch and verify Auth0 login callback redirects correctly