### PR TITLE
Honor requireLogin in scenario/wsdot/visioneval endpoints

### DIFF
--- a/server/api/scenario.post.ts
+++ b/server/api/scenario.post.ts
@@ -28,9 +28,8 @@ export default defineEventHandler(async (event) => {
   setHeader(event, 'cache-control', 'no-cache')
   setHeader(event, 'connection', 'keep-alive')
 
+  const token = await resolveAccessToken(event)
   const runtimeConfig = useRuntimeConfig(event)
-  const requireLogin = runtimeConfig.public?.tlv2?.requireLogin ?? true
-  const token = await resolveAccessToken(event, requireLogin)
   const client = new BasicGraphQLClient(
     runtimeConfig.tlv2.proxyBase.default + '/query',
     apiFetch(runtimeConfig.tlv2?.graphqlApikey || '', token),

--- a/server/api/scenario.post.ts
+++ b/server/api/scenario.post.ts
@@ -7,6 +7,7 @@ import { createError } from 'h3'
 import type { ScenarioConfig } from '~~/src/scenario'
 import { streamScenario } from '~~/src/scenario'
 import { BasicGraphQLClient, apiFetch, logMemory } from '~~/src/core'
+import { resolveAccessToken } from '~~/server/utils/auth'
 
 export default defineEventHandler(async (event) => {
   logMemory('request-start')
@@ -27,16 +28,9 @@ export default defineEventHandler(async (event) => {
   setHeader(event, 'cache-control', 'no-cache')
   setHeader(event, 'connection', 'keep-alive')
 
-  if (!event.context.auth0Session) {
-    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
-  }
   const runtimeConfig = useRuntimeConfig(event)
-  let token
-  try {
-    token = await event.context.auth0Session.getAccessToken()
-  } catch {
-    throw createError({ statusCode: 401, statusMessage: 'Session expired, please log in again' })
-  }
+  const requireLogin = runtimeConfig.public?.tlv2?.requireLogin ?? true
+  const token = await resolveAccessToken(event, requireLogin)
   const client = new BasicGraphQLClient(
     runtimeConfig.tlv2.proxyBase.default + '/query',
     apiFetch(runtimeConfig.tlv2?.graphqlApikey || '', token),

--- a/server/api/visioneval.post.ts
+++ b/server/api/visioneval.post.ts
@@ -27,9 +27,8 @@ export default defineEventHandler(async (event) => {
   setHeader(event, 'cache-control', 'no-cache')
   setHeader(event, 'connection', 'keep-alive')
 
+  const token = await resolveAccessToken(event)
   const runtimeConfig = useRuntimeConfig(event)
-  const requireLogin = runtimeConfig.public?.tlv2?.requireLogin ?? true
-  const token = await resolveAccessToken(event, requireLogin)
   const client = new BasicGraphQLClient(
     runtimeConfig.tlv2.proxyBase.default + '/query',
     apiFetch(runtimeConfig.tlv2?.graphqlApikey || '', token),

--- a/server/api/visioneval.post.ts
+++ b/server/api/visioneval.post.ts
@@ -1,5 +1,6 @@
 import { runVisionEvalAnalysisStreaming, type VisionEvalConfig } from '~~/src/analysis/visioneval'
 import { BasicGraphQLClient, apiFetch } from '~~/src/core'
+import { resolveAccessToken } from '~~/server/utils/auth'
 
 export default defineEventHandler(async (event) => {
   // Parse the request body
@@ -26,16 +27,9 @@ export default defineEventHandler(async (event) => {
   setHeader(event, 'cache-control', 'no-cache')
   setHeader(event, 'connection', 'keep-alive')
 
-  if (!event.context.auth0Session) {
-    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
-  }
   const runtimeConfig = useRuntimeConfig(event)
-  let token
-  try {
-    token = await event.context.auth0Session.getAccessToken()
-  } catch {
-    throw createError({ statusCode: 401, statusMessage: 'Session expired, please log in again' })
-  }
+  const requireLogin = runtimeConfig.public?.tlv2?.requireLogin ?? true
+  const token = await resolveAccessToken(event, requireLogin)
   const client = new BasicGraphQLClient(
     runtimeConfig.tlv2.proxyBase.default + '/query',
     apiFetch(runtimeConfig.tlv2?.graphqlApikey || '', token),

--- a/server/api/wsdot.post.ts
+++ b/server/api/wsdot.post.ts
@@ -20,9 +20,8 @@ export default defineEventHandler(async (event) => {
   setHeader(event, 'cache-control', 'no-cache')
   setHeader(event, 'connection', 'keep-alive')
 
+  const token = await resolveAccessToken(event)
   const runtimeConfig = useRuntimeConfig(event)
-  const requireLogin = runtimeConfig.public?.tlv2?.requireLogin ?? true
-  const token = await resolveAccessToken(event, requireLogin)
   const client = new BasicGraphQLClient(
     runtimeConfig.tlv2.proxyBase.default + '/query',
     apiFetch(runtimeConfig.tlv2?.graphqlApikey || '', token),

--- a/server/api/wsdot.post.ts
+++ b/server/api/wsdot.post.ts
@@ -1,5 +1,6 @@
 import { runAnalysis, type WSDOTReportConfig } from '~~/src/analysis/wsdot'
 import { BasicGraphQLClient, apiFetch } from '~~/src/core'
+import { resolveAccessToken } from '~~/server/utils/auth'
 
 export default defineEventHandler(async (event) => {
   // Parse the request body
@@ -19,16 +20,9 @@ export default defineEventHandler(async (event) => {
   setHeader(event, 'cache-control', 'no-cache')
   setHeader(event, 'connection', 'keep-alive')
 
-  if (!event.context.auth0Session) {
-    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
-  }
   const runtimeConfig = useRuntimeConfig(event)
-  let token
-  try {
-    token = await event.context.auth0Session.getAccessToken()
-  } catch {
-    throw createError({ statusCode: 401, statusMessage: 'Session expired, please log in again' })
-  }
+  const requireLogin = runtimeConfig.public?.tlv2?.requireLogin ?? true
+  const token = await resolveAccessToken(event, requireLogin)
   const client = new BasicGraphQLClient(
     runtimeConfig.tlv2.proxyBase.default + '/query',
     apiFetch(runtimeConfig.tlv2?.graphqlApikey || '', token),

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,0 +1,36 @@
+import type { H3Event } from 'h3'
+import { createError } from 'h3'
+
+/**
+ * Resolve the Auth0 access token for an incoming request, honoring the
+ * public `requireLogin` runtime flag.
+ *
+ * Behavior:
+ * - If a session is present, returns its access token. If token retrieval
+ *   throws and `requireLogin` is true, raises 401; otherwise returns undefined.
+ * - If no session is present and `requireLogin` is true, raises 401.
+ * - If no session is present and `requireLogin` is false, returns undefined —
+ *   downstream code falls back to the server's default API key (the same
+ *   posture as the /api/proxy route in tlv2-auth).
+ *
+ * The matching client-side flag (`NUXT_PUBLIC_TLV2_REQUIRE_LOGIN=false`)
+ * disables the in-app login gate; this keeps the server-side endpoints
+ * symmetric so that dev and Playwright runs can drive scenarios end-to-end
+ * against a local tlserver without an Auth0 session.
+ */
+export async function resolveAccessToken (event: H3Event, requireLogin: boolean): Promise<string | undefined> {
+  if (event.context.auth0Session) {
+    try {
+      return await event.context.auth0Session.getAccessToken()
+    } catch {
+      if (requireLogin) {
+        throw createError({ statusCode: 401, statusMessage: 'Session expired, please log in again' })
+      }
+      return undefined
+    }
+  }
+  if (requireLogin) {
+    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
+  }
+  return undefined
+}

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -18,7 +18,8 @@ import { createError } from 'h3'
  * symmetric so that dev and Playwright runs can drive scenarios end-to-end
  * against a local tlserver without an Auth0 session.
  */
-export async function resolveAccessToken (event: H3Event, requireLogin: boolean): Promise<string | undefined> {
+export async function resolveAccessToken (event: H3Event): Promise<string | undefined> {
+  const requireLogin = useRuntimeConfig(event).public.tlv2.requireLogin
   if (event.context.auth0Session) {
     try {
       return await event.context.auth0Session.getAccessToken()

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -14,14 +14,18 @@ import { createError } from 'h3'
  *   posture as the /api/proxy route in tlv2-auth).
  */
 export async function resolveAccessToken (event: H3Event): Promise<string | undefined> {
-  const requireLogin = useRuntimeConfig(event).public.tlv2.requireLogin
+  // Default to the secure posture if the flag is missing or falsy-but-not-false
+  // (e.g. an empty NUXT_PUBLIC_TLV2_REQUIRE_LOGIN env var). Only an explicit
+  // `false` should relax the 401.
+  const requireLogin = useRuntimeConfig(event).public.tlv2.requireLogin ?? true
   if (event.context.auth0Session) {
     try {
       return await event.context.auth0Session.getAccessToken()
-    } catch {
+    } catch (err) {
       if (requireLogin) {
         throw createError({ statusCode: 401, statusMessage: 'Session expired, please log in again' })
       }
+      console.warn('[auth] getAccessToken failed; falling back to apikey-only auth (requireLogin=false):', err)
       return undefined
     }
   }

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -12,11 +12,6 @@ import { createError } from 'h3'
  * - If no session is present and `requireLogin` is false, returns undefined —
  *   downstream code falls back to the server's default API key (the same
  *   posture as the /api/proxy route in tlv2-auth).
- *
- * The matching client-side flag (`NUXT_PUBLIC_TLV2_REQUIRE_LOGIN=false`)
- * disables the in-app login gate; this keeps the server-side endpoints
- * symmetric so that dev and Playwright runs can drive scenarios end-to-end
- * against a local tlserver without an Auth0 session.
  */
 export async function resolveAccessToken (event: H3Event): Promise<string | undefined> {
   const requireLogin = useRuntimeConfig(event).public.tlv2.requireLogin


### PR DESCRIPTION
## Summary

Allow authentication to be disabled during local automated browser based tests that are accessing local backend resources.

### What changed

- New helper `server/utils/auth.ts` exposes `resolveAccessToken(event)`:
  - session present → return its access token (throws 401 on retrieval failure when `requireLogin=true`, returns `undefined` otherwise)
  - no session, `requireLogin=true` → throws 401 (unchanged production behavior)
  - no session, `requireLogin=false` → returns `undefined`; downstream code falls through with apikey-only auth
- The helper reads `runtimeConfig.public.tlv2.requireLogin` itself (same flag the client honors), so each endpoint collapses to a single `resolveAccessToken(event)` call. Production deployments (`requireLogin=true` by default) see no behavior change.
- Applied to all three streaming endpoints (`scenario`, `wsdot`, `visioneval`).

### Why this is a small standalone PR

Surfaced while writing browser tests for #239 (PR #328). Wanted to land it on its own so the #239 PR doesn't carry unrelated request-auth changes; once this merges I'll rebase #328 on top.

## Test plan

- With `NUXT_PUBLIC_TLV2_REQUIRE_LOGIN=false` and `NUXT_TLV2_PROXY_BASE_DEFAULT=http://localhost:8080` set, `pnpm dev` followed by visiting `/tne` and clicking "Run Browse Query" completes the scenario stream against a local tlserver — no 401, the toast "Browsing query data loaded successfully" appears.
- Default deployment (`requireLogin=true`, no env override) still rejects unauthenticated POSTs to `/api/scenario`, `/api/wsdot`, `/api/visioneval` with 401.
- `pnpm test:browser test/browser/query.test.ts` — the data-loading hook now succeeds (the original 3 query.test.ts assertions that fail are unrelated stale UI checks; pruning them is a separate cleanup).