### PR TITLE
Default Time of Day window to 06:00 - 10:00

### DIFF
--- a/app/components/cal/filter.vue
+++ b/app/components/cal/filter.vue
@@ -571,7 +571,8 @@ import {
   flexAreaTypes,
   flexColorByModes,
   fmtDate,
-  parseTime
+  parseTime,
+  DEFAULT_TIME_WINDOW
 } from '~~/src/core'
 import type { ScenarioFilterResult } from '~~/src/scenario'
 import type { CensusGeography } from '~~/src/tl/census'
@@ -691,7 +692,7 @@ const isAllDayMode = computed({
       emit('setTimeRange', { startTime: undefined, endTime: undefined })
     } else {
       // Emit event to parent to update both params in single navigation
-      emit('setTimeRange', { startTime: parseTime('06:00:00'), endTime: parseTime('10:00:00') })
+      emit('setTimeRange', { startTime: parseTime(DEFAULT_TIME_WINDOW.start), endTime: parseTime(DEFAULT_TIME_WINDOW.end) })
     }
   }
 })

--- a/app/components/cal/filter.vue
+++ b/app/components/cal/filter.vue
@@ -691,7 +691,7 @@ const isAllDayMode = computed({
       emit('setTimeRange', { startTime: undefined, endTime: undefined })
     } else {
       // Emit event to parent to update both params in single navigation
-      emit('setTimeRange', { startTime: parseTime('00:00:00'), endTime: parseTime('23:59:00') })
+      emit('setTimeRange', { startTime: parseTime('06:00:00'), endTime: parseTime('10:00:00') })
     }
   }
 })

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -133,6 +133,14 @@ export const timeOfDayModes = [
 
 export type TimeOfDayMode = typeof timeOfDayModes[number]
 
+// Default start/end times populated when the user toggles "All Day" off
+// under Filter > Time of Day. Chosen to cover a typical AM-peak window so
+// the unchecked state produces an immediately visible filter.
+export const DEFAULT_TIME_WINDOW = {
+  start: '06:00:00',
+  end: '10:00:00',
+} as const
+
 export const baseMapStyles = [
   { name: 'Streets', icon: 'map-search', available: true },
   { name: 'Satellite', icon: 'satellite', available: false },


### PR DESCRIPTION
## Summary

Toggling "All Day" off in Filter > Time of Day previously populated the start/end pickers with `00:00`–`23:59`. That window covers essentially the whole day, so the resulting "specific-hours" filter behaved indistinguishably from all-day mode by default — the user had to adjust both pickers before any filtering kicked in.

This change sets the default unchecked state to `06:00`–`10:00` (a typical AM-peak window) so the toggle has an immediately visible effect. Users can still adjust either picker afterwards.

## What changed

- `src/core/constants.ts` — new `DEFAULT_TIME_WINDOW = { start: '06:00:00', end: '10:00:00' }` constant exported from the existing core module (sits next to `timeOfDayModes`).
- `app/components/cal/filter.vue` — imports and uses the constant instead of inline literals.

## Why a separate PR

Surfaced while working on #239 (frequency/visits report revisions, PR #328) but unrelated to the report-column work there. Pulling it out keeps that PR focused on its actual scope.

## Test plan

- In Filter > Time of Day, with "All Day" checked, untoggle it. Both pickers should populate to `06:00:00` and `10:00:00`.
- Re-toggle "All Day" on; pickers should clear back to undefined.
- The browse-query result count should change immediately when toggling off (route/stop counts now reflect a narrow window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)