### PR TITLE
Simplify the headway pipeline

### DIFF
--- a/src/scenario/route-headway.test.ts
+++ b/src/scenario/route-headway.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { routeHeadways, newRouteHeadwaySummary, calculateHeadwayStats } from './route-headway'
+import { routeHeadways, calculateHeadwayStats, hasServiceOnWeekday } from './route-headway'
 import { StopDepartureCache, RouteDepartureIndex } from '../tl/departure-cache'
 import type { Route } from '../tl/route'
 import type { StopTime } from '../tl/departure'
@@ -74,7 +74,6 @@ function makeRoute (id: number): Route {
     route_name: `Route ${id}`,
     agency_name: 'Test Agency',
     route_mode: 'Bus',
-    headways: newRouteHeadwaySummary(),
   }
 }
 
@@ -96,7 +95,7 @@ function hms (time: string): number {
 }
 
 describe('routeHeadways', () => {
-  it('selects representative stop with most departures', () => {
+  it('selects the representative stop (most departures) for each date', () => {
     const routeId = 100
     const route = makeRoute(routeId)
     const dateStr = '2024-01-15'
@@ -104,7 +103,7 @@ describe('routeHeadways', () => {
 
     const sdCache = new StopDepartureCache()
 
-    // 3 trips, with varying stop patterns
+    // Stop 2 visited by all 3 trips; stops 1/3/4 visited once each.
     addTripToCache(sdCache, dateStr, makeTrip(routeId, '1001', 0, [
       { stopId: 1, departure: '09:20:00' },
       { stopId: 2, departure: '09:22:00' },
@@ -123,20 +122,13 @@ describe('routeHeadways', () => {
     const routeIndex = RouteDepartureIndex.fromCache(sdCache)
     const result = routeHeadways(route, [date], '00:00:00', '24:00:00', routeIndex)
 
-    // Stop 2 should be selected as the representative stop (3 departures)
-    expect(result.total.dir0.stop_id).toBe(2)
-
-    // One date in range → one inner array with 3 departures
-    expect(result.total.dir0.departures).toHaveLength(1)
-    expect(result.total.dir0.departures[0]).toHaveLength(3)
-
-    // Monday should also have the departures (since Jan 15, 2024 is a Monday)
-    expect(result.monday.dir0.departures).toHaveLength(1)
-    expect(result.monday.dir0.departures[0]).toHaveLength(3)
-
-    // Other days should be empty (no inner arrays at all)
-    expect(result.tuesday.dir0.departures).toHaveLength(0)
-    expect(result.sunday.dir0.departures).toHaveLength(0)
+    // One date in range → one inner array.
+    // Stop 2 is the rep stop (3 departures), so dir0[0] holds its 3 times.
+    expect(result.dir0).toHaveLength(1)
+    expect(result.dir0[0]).toEqual([hms('09:22'), hms('09:33'), hms('09:43')])
+    // No dir1 activity in this fixture.
+    expect(result.dir1).toHaveLength(1)
+    expect(result.dir1[0]).toEqual([])
   })
 
   it('filters departures by time window', () => {
@@ -146,8 +138,6 @@ describe('routeHeadways', () => {
     const dateStr = '2024-01-15'
 
     const sdCache = new StopDepartureCache()
-
-    // 5 trips at various times, each visiting stop 1
     addTripToCache(sdCache, dateStr, makeTrip(routeId, '1001', 0, [{ stopId: 1, departure: '08:00:00' }]))
     addTripToCache(sdCache, dateStr, makeTrip(routeId, '1002', 0, [{ stopId: 1, departure: '09:00:00' }]))
     addTripToCache(sdCache, dateStr, makeTrip(routeId, '1003', 0, [{ stopId: 1, departure: '10:00:00' }]))
@@ -156,47 +146,33 @@ describe('routeHeadways', () => {
 
     const routeIndex = RouteDepartureIndex.fromCache(sdCache)
 
-    // When startTime/endTime are undefined, no filtering occurs
     const resultNoFilter = routeHeadways(route, [date], undefined, undefined, routeIndex)
-    expect(resultNoFilter.total.dir0.departures.flat()).toHaveLength(5)
-    expect(resultNoFilter.total.dir0.departures.flat()).toEqual([
+    expect(resultNoFilter.dir0[0]).toEqual([
       hms('08:00'), hms('09:00'), hms('10:00'), hms('11:00'), hms('12:00'),
     ])
 
-    // When only startTime is set, filters "trips after X"
     const resultStartOnly = routeHeadways(route, [date], '09:30:00', undefined, routeIndex)
-    expect(resultStartOnly.total.dir0.departures.flat()).toEqual([
-      hms('10:00'), hms('11:00'), hms('12:00'),
-    ])
+    expect(resultStartOnly.dir0[0]).toEqual([hms('10:00'), hms('11:00'), hms('12:00')])
 
-    // When only endTime is set, filters "trips before Y"
     const resultEndOnly = routeHeadways(route, [date], undefined, '10:30:00', routeIndex)
-    expect(resultEndOnly.total.dir0.departures.flat()).toEqual([
-      hms('08:00'), hms('09:00'), hms('10:00'),
-    ])
+    expect(resultEndOnly.dir0[0]).toEqual([hms('08:00'), hms('09:00'), hms('10:00')])
 
-    // When time window doesn't match any departures, the inner array is empty
     const resultEmpty = routeHeadways(route, [date], '13:00:00', '14:00:00', routeIndex)
-    expect(resultEmpty.total.dir0.departures.flat()).toHaveLength(0)
+    expect(resultEmpty.dir0[0]).toEqual([])
 
-    // Filter to 09:00-10:30 window
     const result = routeHeadways(route, [date], '09:00:00', '10:30:00', routeIndex)
-    expect(result.total.dir0.departures.flat()).toEqual([hms('09:00'), hms('10:00')])
+    expect(result.dir0[0]).toEqual([hms('09:00'), hms('10:00')])
   })
 
-  it('keeps each date in its own inner array (per-day structure)', () => {
+  it('keeps each date in its own inner array, positionally aligned with selectedDateRange', () => {
     const routeId = 100
     const route = makeRoute(routeId)
     const monday = makeLocalDate('2024-01-15')
     const tuesday = makeLocalDate('2024-01-16')
 
     const sdCache = new StopDepartureCache()
-
-    // Monday: 2 trips
     addTripToCache(sdCache, '2024-01-15', makeTrip(routeId, '1001', 0, [{ stopId: 1, departure: '09:00:00' }]))
     addTripToCache(sdCache, '2024-01-15', makeTrip(routeId, '1002', 0, [{ stopId: 1, departure: '09:30:00' }]))
-
-    // Tuesday: 3 trips
     addTripToCache(sdCache, '2024-01-16', makeTrip(routeId, '1003', 0, [{ stopId: 1, departure: '09:00:00' }]))
     addTripToCache(sdCache, '2024-01-16', makeTrip(routeId, '1004', 0, [{ stopId: 1, departure: '09:30:00' }]))
     addTripToCache(sdCache, '2024-01-16', makeTrip(routeId, '1005', 0, [{ stopId: 1, departure: '10:00:00' }]))
@@ -204,31 +180,45 @@ describe('routeHeadways', () => {
     const routeIndex = RouteDepartureIndex.fromCache(sdCache)
     const result = routeHeadways(route, [monday, tuesday], undefined, undefined, routeIndex)
 
-    // Total has one inner array per date
-    expect(result.total.dir0.departures).toHaveLength(2)
-    expect(result.total.dir0.departures[0]).toEqual([hms('09:00'), hms('09:30')])
-    expect(result.total.dir0.departures[1]).toEqual([hms('09:00'), hms('09:30'), hms('10:00')])
-
-    // Monday bucket has only Monday's array
-    expect(result.monday.dir0.departures).toHaveLength(1)
-    expect(result.monday.dir0.departures[0]).toEqual([hms('09:00'), hms('09:30')])
-
-    // Tuesday bucket has only Tuesday's array
-    expect(result.tuesday.dir0.departures).toHaveLength(1)
-    expect(result.tuesday.dir0.departures[0]).toEqual([hms('09:00'), hms('09:30'), hms('10:00')])
+    expect(result.dir0).toHaveLength(2)
+    expect(result.dir0[0]).toEqual([hms('09:00'), hms('09:30')]) // Monday
+    expect(result.dir0[1]).toEqual([hms('09:00'), hms('09:30'), hms('10:00')]) // Tuesday
   })
 
-  it('returns empty result when no cache provided', () => {
+  it('keeps empty inner arrays for service-less days to preserve positional mapping', () => {
+    const routeId = 100
+    const route = makeRoute(routeId)
+    const dates = [
+      makeLocalDate('2024-01-15'),
+      makeLocalDate('2024-01-16'),
+      makeLocalDate('2024-01-17'),
+    ]
+
+    const sdCache = new StopDepartureCache()
+    // Only the middle date has service.
+    addTripToCache(sdCache, '2024-01-16', makeTrip(routeId, '1001', 0, [{ stopId: 1, departure: '09:00:00' }]))
+    addTripToCache(sdCache, '2024-01-16', makeTrip(routeId, '1002', 0, [{ stopId: 1, departure: '09:30:00' }]))
+
+    const routeIndex = RouteDepartureIndex.fromCache(sdCache)
+    const result = routeHeadways(route, dates, undefined, undefined, routeIndex)
+
+    expect(result.dir0).toHaveLength(3)
+    expect(result.dir0[0]).toEqual([])
+    expect(result.dir0[1]).toEqual([hms('09:00'), hms('09:30')])
+    expect(result.dir0[2]).toEqual([])
+  })
+
+  it('returns empty arrays when no routeIndex is provided', () => {
     const route = makeRoute(100)
     const date = makeLocalDate('2024-01-15')
 
     const result = routeHeadways(route, [date], '00:00:00', '24:00:00', undefined)
 
-    expect(result.total.dir0.departures).toHaveLength(0)
-    expect(result.total.dir1.departures).toHaveLength(0)
+    expect(result.dir0).toEqual([])
+    expect(result.dir1).toEqual([])
   })
 
-  it('handles route with no departures', () => {
+  it('handles a route with no departures', () => {
     const routeId = 100
     const route = makeRoute(routeId)
     const date = makeLocalDate('2024-01-15')
@@ -238,30 +228,60 @@ describe('routeHeadways', () => {
 
     const result = routeHeadways(route, [date], '00:00:00', '24:00:00', routeIndex)
 
-    expect(result.total.dir0.departures.flat()).toHaveLength(0)
-    expect(result.total.dir1.departures.flat()).toHaveLength(0)
+    expect(result.dir0).toEqual([[]])
+    expect(result.dir1).toEqual([[]])
+  })
+})
+
+describe('hasServiceOnWeekday', () => {
+  const monday = makeLocalDate('2024-01-15') // Monday
+  const tuesday = makeLocalDate('2024-01-16')
+  const monday2 = makeLocalDate('2024-01-22') // the next Monday
+
+  it('returns true when the matching weekday has at least one dir0 departure', () => {
+    const deps = { dir0: [[hms('09:00')], []], dir1: [[], []] }
+    expect(hasServiceOnWeekday(deps, [monday, tuesday], 'monday')).toBe(true)
+    expect(hasServiceOnWeekday(deps, [monday, tuesday], 'tuesday')).toBe(false)
+  })
+
+  it('returns true when only dir1 has service', () => {
+    const deps = { dir0: [[]], dir1: [[hms('09:00')]] }
+    expect(hasServiceOnWeekday(deps, [monday], 'monday')).toBe(true)
+  })
+
+  it('returns true if any matching-weekday date has service, even if others do not', () => {
+    // Two Mondays in range; only the second has service.
+    const deps = { dir0: [[], [], []], dir1: [[], [], [hms('09:00')]] }
+    expect(hasServiceOnWeekday(deps, [monday, tuesday, monday2], 'monday')).toBe(true)
+  })
+
+  it('returns false for a weekday that does not appear in the range', () => {
+    const deps = { dir0: [[hms('09:00')]], dir1: [[]] }
+    expect(hasServiceOnWeekday(deps, [monday], 'friday')).toBe(false)
+  })
+
+  it('returns false when the matching dates are all empty', () => {
+    const deps = { dir0: [[], []], dir1: [[], []] }
+    expect(hasServiceOnWeekday(deps, [monday, monday2], 'monday')).toBe(false)
   })
 })
 
 describe('calculateHeadwayStats', () => {
   it('calculates average, fastest, and slowest headways from a single day', () => {
-    // 6 departures with varying headways
-    // 09:00, 09:15, 09:40, 10:05, 10:20, 10:55
-    // Headways: 15, 25, 25, 15, 35 minutes
-    const departures = [[
+    // 09:00, 09:15, 09:40, 10:05, 10:20, 10:55 → headways 15, 25, 25, 15, 35
+    const stats = calculateHeadwayStats([[
       hms('09:00'),
       hms('09:15'),
       hms('09:40'),
       hms('10:05'),
       hms('10:20'),
       hms('10:55'),
-    ]]
-    const stats = calculateHeadwayStats(departures)
+    ]])
 
     expect(stats).toBeDefined()
     expect(stats!.fastest).toBe(15 * 60)
     expect(stats!.slowest).toBe(35 * 60)
-    expect(stats!.average).toBe(23 * 60) // (15+25+25+15+35)/5 = 23
+    expect(stats!.average).toBe(23 * 60)
   })
 
   it('returns undefined for empty input', () => {
@@ -274,7 +294,6 @@ describe('calculateHeadwayStats', () => {
   })
 
   it('calculates correct stats for two departures', () => {
-    // 09:00, 09:22 → single 22-minute headway
     const stats = calculateHeadwayStats([[hms('09:00'), hms('09:22')]])
 
     expect(stats).toBeDefined()
@@ -300,9 +319,6 @@ describe('calculateHeadwayStats', () => {
   })
 
   it('sorts unsorted departures within each day before calculating', () => {
-    // 6 departures out of order with varying headways (20-30 min)
-    // Sorted: 09:00, 09:20, 09:50, 10:15, 10:40, 11:00
-    // Headways: 20, 30, 25, 25, 20 minutes
     const stats = calculateHeadwayStats([[
       hms('10:15'),
       hms('09:00'),
@@ -315,13 +331,10 @@ describe('calculateHeadwayStats', () => {
     expect(stats).toBeDefined()
     expect(stats!.fastest).toBe(20 * 60)
     expect(stats!.slowest).toBe(30 * 60)
-    expect(stats!.average).toBe(24 * 60) // (20+30+25+25+20)/5 = 24
+    expect(stats!.average).toBe(24 * 60)
   })
 
   it('filters out headways under 2 minutes as noise', () => {
-    // 09:00, 09:01, 09:20, 09:21, 09:45, 10:10
-    // Raw headways: 1, 19, 1, 24, 25 minutes
-    // After filtering (>= 2 min): 19, 24, 25 minutes
     const stats = calculateHeadwayStats([[
       hms('09:00'),
       hms('09:01'),
@@ -332,8 +345,8 @@ describe('calculateHeadwayStats', () => {
     ]])
 
     expect(stats).toBeDefined()
-    expect(stats!.fastest).toBe(19 * 60) // 09:01 to 09:20
-    expect(stats!.slowest).toBe(25 * 60) // 09:45 to 10:10
+    expect(stats!.fastest).toBe(19 * 60)
+    expect(stats!.slowest).toBe(25 * 60)
     expect(stats!.average).toBeCloseTo((19 + 24 + 25) / 3 * 60)
   })
 
@@ -349,9 +362,8 @@ describe('calculateHeadwayStats', () => {
   })
 
   it('aggregates intervals across multiple days, never spanning service days', () => {
-    // Day 1 (Monday): trips at 06:00 and 22:00 → one 16-hour intra-day gap
-    // Day 2 (Tuesday): trips at 06:00 and 22:00 → one 16-hour intra-day gap
-    // Cross-day "gap" between Mon 22:00 and Tue 06:00 must NOT appear.
+    // Two days, each 06:00 and 22:00. The cross-day "gap" 22:00 Day1 → 06:00 Day2
+    // must NOT appear in the stats.
     const stats = calculateHeadwayStats([
       [hms('06:00'), hms('22:00')],
       [hms('06:00'), hms('22:00')],
@@ -364,9 +376,7 @@ describe('calculateHeadwayStats', () => {
   })
 
   it('combines per-day intervals into a single average', () => {
-    // Day 1: 09:00, 09:15, 09:45 → headways 15, 30
-    // Day 2: 10:00, 10:20 → headway 20
-    // Aggregate: [15, 30, 20] → avg = 65/3 ≈ 21.67 min
+    // Day 1 headways: 15, 30. Day 2 headway: 20. Avg = 65/3 min.
     const stats = calculateHeadwayStats([
       [hms('09:00'), hms('09:15'), hms('09:45')],
       [hms('10:00'), hms('10:20')],
@@ -379,7 +389,6 @@ describe('calculateHeadwayStats', () => {
   })
 
   it('skips days with fewer than 2 departures', () => {
-    // Day 1 has 1 trip (no headway). Day 2 has 3 trips with consistent 20-min headways.
     const stats = calculateHeadwayStats([
       [hms('09:00')],
       [hms('10:00'), hms('10:20'), hms('10:40')],

--- a/src/scenario/route-headway.test.ts
+++ b/src/scenario/route-headway.test.ts
@@ -96,17 +96,12 @@ function hms (time: string): number {
 }
 
 describe('routeHeadways', () => {
-  /**
-   * Test scenario with synthetic data:
-   */
-
   it('selects representative stop with most departures', () => {
     const routeId = 100
     const route = makeRoute(routeId)
     const dateStr = '2024-01-15'
     const date = makeLocalDate(dateStr) // A Monday
 
-    // Create departure cache with synthetic data
     const sdCache = new StopDepartureCache()
 
     // 3 trips, with varying stop patterns
@@ -125,22 +120,23 @@ describe('routeHeadways', () => {
       { stopId: 4, departure: '09:46:00' },
     ]))
 
-    // Calculate headways
     const routeIndex = RouteDepartureIndex.fromCache(sdCache)
     const result = routeHeadways(route, [date], '00:00:00', '24:00:00', routeIndex)
 
-    // Stop 2 should be selected as the representative stop (it has 3 departures, others have fewer)
+    // Stop 2 should be selected as the representative stop (3 departures)
     expect(result.total.dir0.stop_id).toBe(2)
 
-    // Direction 0 should have 3 departures at that stop
-    expect(result.total.dir0.departures.length).toBe(3)
+    // One date in range → one inner array with 3 departures
+    expect(result.total.dir0.departures).toHaveLength(1)
+    expect(result.total.dir0.departures[0]).toHaveLength(3)
 
     // Monday should also have the departures (since Jan 15, 2024 is a Monday)
-    expect(result.monday.dir0.departures.length).toBe(3)
+    expect(result.monday.dir0.departures).toHaveLength(1)
+    expect(result.monday.dir0.departures[0]).toHaveLength(3)
 
-    // Other days should be empty
-    expect(result.tuesday.dir0.departures.length).toBe(0)
-    expect(result.sunday.dir0.departures.length).toBe(0)
+    // Other days should be empty (no inner arrays at all)
+    expect(result.tuesday.dir0.departures).toHaveLength(0)
+    expect(result.sunday.dir0.departures).toHaveLength(0)
   })
 
   it('filters departures by time window', () => {
@@ -158,44 +154,37 @@ describe('routeHeadways', () => {
     addTripToCache(sdCache, dateStr, makeTrip(routeId, '1004', 0, [{ stopId: 1, departure: '11:00:00' }]))
     addTripToCache(sdCache, dateStr, makeTrip(routeId, '1005', 0, [{ stopId: 1, departure: '12:00:00' }]))
 
-    // When startTime/endTime are undefined, no filtering occurs
     const routeIndex = RouteDepartureIndex.fromCache(sdCache)
+
+    // When startTime/endTime are undefined, no filtering occurs
     const resultNoFilter = routeHeadways(route, [date], undefined, undefined, routeIndex)
-    expect(resultNoFilter.total.dir0.departures.length).toBe(5)
-    expect(resultNoFilter.total.dir0.departures).toContain(hms('08:00'))
-    expect(resultNoFilter.total.dir0.departures).toContain(hms('09:00'))
-    expect(resultNoFilter.total.dir0.departures).toContain(hms('10:00'))
-    expect(resultNoFilter.total.dir0.departures).toContain(hms('11:00'))
-    expect(resultNoFilter.total.dir0.departures).toContain(hms('12:00'))
+    expect(resultNoFilter.total.dir0.departures.flat()).toHaveLength(5)
+    expect(resultNoFilter.total.dir0.departures.flat()).toEqual([
+      hms('08:00'), hms('09:00'), hms('10:00'), hms('11:00'), hms('12:00'),
+    ])
 
     // When only startTime is set, filters "trips after X"
     const resultStartOnly = routeHeadways(route, [date], '09:30:00', undefined, routeIndex)
-    expect(resultStartOnly.total.dir0.departures.length).toBe(3)
-    expect(resultStartOnly.total.dir0.departures).toContain(hms('10:00'))
-    expect(resultStartOnly.total.dir0.departures).toContain(hms('11:00'))
-    expect(resultStartOnly.total.dir0.departures).toContain(hms('12:00'))
+    expect(resultStartOnly.total.dir0.departures.flat()).toEqual([
+      hms('10:00'), hms('11:00'), hms('12:00'),
+    ])
 
     // When only endTime is set, filters "trips before Y"
     const resultEndOnly = routeHeadways(route, [date], undefined, '10:30:00', routeIndex)
-    expect(resultEndOnly.total.dir0.departures.length).toBe(3)
-    expect(resultEndOnly.total.dir0.departures).toContain(hms('08:00'))
-    expect(resultEndOnly.total.dir0.departures).toContain(hms('09:00'))
-    expect(resultEndOnly.total.dir0.departures).toContain(hms('10:00'))
+    expect(resultEndOnly.total.dir0.departures.flat()).toEqual([
+      hms('08:00'), hms('09:00'), hms('10:00'),
+    ])
 
-    // When time window doesn't match any departures, result is empty
+    // When time window doesn't match any departures, the inner array is empty
     const resultEmpty = routeHeadways(route, [date], '13:00:00', '14:00:00', routeIndex)
-    expect(resultEmpty.total.dir0.departures.length).toBe(0)
+    expect(resultEmpty.total.dir0.departures.flat()).toHaveLength(0)
 
     // Filter to 09:00-10:30 window
     const result = routeHeadways(route, [date], '09:00:00', '10:30:00', routeIndex)
-
-    // Should only include 09:00 and 10:00 departures
-    expect(result.total.dir0.departures.length).toBe(2)
-    expect(result.total.dir0.departures).toContain(hms('09:00'))
-    expect(result.total.dir0.departures).toContain(hms('10:00'))
+    expect(result.total.dir0.departures.flat()).toEqual([hms('09:00'), hms('10:00')])
   })
 
-  it('aggregates departures across multiple dates', () => {
+  it('keeps each date in its own inner array (per-day structure)', () => {
     const routeId = 100
     const route = makeRoute(routeId)
     const monday = makeLocalDate('2024-01-15')
@@ -215,22 +204,18 @@ describe('routeHeadways', () => {
     const routeIndex = RouteDepartureIndex.fromCache(sdCache)
     const result = routeHeadways(route, [monday, tuesday], undefined, undefined, routeIndex)
 
-    // Total should aggregate both days
-    expect(result.total.dir0.departures.length).toBe(5)
-    expect(result.total.dir0.departures).toContain(hms('09:00'))
-    expect(result.total.dir0.departures).toContain(hms('09:30'))
-    expect(result.total.dir0.departures).toContain(hms('10:00'))
+    // Total has one inner array per date
+    expect(result.total.dir0.departures).toHaveLength(2)
+    expect(result.total.dir0.departures[0]).toEqual([hms('09:00'), hms('09:30')])
+    expect(result.total.dir0.departures[1]).toEqual([hms('09:00'), hms('09:30'), hms('10:00')])
 
-    // Monday bucket should have 09:00 and 09:30
-    expect(result.monday.dir0.departures.length).toBe(2)
-    expect(result.monday.dir0.departures).toContain(hms('09:00'))
-    expect(result.monday.dir0.departures).toContain(hms('09:30'))
+    // Monday bucket has only Monday's array
+    expect(result.monday.dir0.departures).toHaveLength(1)
+    expect(result.monday.dir0.departures[0]).toEqual([hms('09:00'), hms('09:30')])
 
-    // Tuesday bucket should have 09:00, 09:30, 10:00
-    expect(result.tuesday.dir0.departures.length).toBe(3)
-    expect(result.tuesday.dir0.departures).toContain(hms('09:00'))
-    expect(result.tuesday.dir0.departures).toContain(hms('09:30'))
-    expect(result.tuesday.dir0.departures).toContain(hms('10:00'))
+    // Tuesday bucket has only Tuesday's array
+    expect(result.tuesday.dir0.departures).toHaveLength(1)
+    expect(result.tuesday.dir0.departures[0]).toEqual([hms('09:00'), hms('09:30'), hms('10:00')])
   })
 
   it('returns empty result when no cache provided', () => {
@@ -239,8 +224,8 @@ describe('routeHeadways', () => {
 
     const result = routeHeadways(route, [date], '00:00:00', '24:00:00', undefined)
 
-    expect(result.total.dir0.departures.length).toBe(0)
-    expect(result.total.dir1.departures.length).toBe(0)
+    expect(result.total.dir0.departures).toHaveLength(0)
+    expect(result.total.dir1.departures).toHaveLength(0)
   })
 
   it('handles route with no departures', () => {
@@ -248,52 +233,49 @@ describe('routeHeadways', () => {
     const route = makeRoute(routeId)
     const date = makeLocalDate('2024-01-15')
 
-    // Empty cache
     const sdCache = new StopDepartureCache()
     const routeIndex = RouteDepartureIndex.fromCache(sdCache)
 
     const result = routeHeadways(route, [date], '00:00:00', '24:00:00', routeIndex)
 
-    expect(result.total.dir0.departures.length).toBe(0)
-    expect(result.total.dir1.departures.length).toBe(0)
+    expect(result.total.dir0.departures.flat()).toHaveLength(0)
+    expect(result.total.dir1.departures.flat()).toHaveLength(0)
   })
 })
 
 describe('calculateHeadwayStats', () => {
-  it('calculates average, fastest, and slowest headways', () => {
+  it('calculates average, fastest, and slowest headways from a single day', () => {
     // 6 departures with varying headways
     // 09:00, 09:15, 09:40, 10:05, 10:20, 10:55
     // Headways: 15, 25, 25, 15, 35 minutes
-    const departures = [
+    const departures = [[
       hms('09:00'),
       hms('09:15'),
       hms('09:40'),
       hms('10:05'),
       hms('10:20'),
       hms('10:55'),
-    ]
+    ]]
     const stats = calculateHeadwayStats(departures)
 
     expect(stats).toBeDefined()
-    expect(stats!.fastest).toBe(15 * 60) // 15 minutes
-    expect(stats!.slowest).toBe(35 * 60) // 35 minutes
-    expect(stats!.average).toBe(23 * 60) // (15+25+25+15+35)/5 = 23 minutes
+    expect(stats!.fastest).toBe(15 * 60)
+    expect(stats!.slowest).toBe(35 * 60)
+    expect(stats!.average).toBe(23 * 60) // (15+25+25+15+35)/5 = 23
   })
 
-  it('returns undefined for empty departures', () => {
-    const stats = calculateHeadwayStats([])
-    expect(stats).toBeUndefined()
+  it('returns undefined for empty input', () => {
+    expect(calculateHeadwayStats([])).toBeUndefined()
+    expect(calculateHeadwayStats([[]])).toBeUndefined()
   })
 
-  it('returns undefined for single departure', () => {
-    const stats = calculateHeadwayStats([hms('09:00')])
-    expect(stats).toBeUndefined()
+  it('returns undefined for a single departure', () => {
+    expect(calculateHeadwayStats([[hms('09:00')]])).toBeUndefined()
   })
 
   it('calculates correct stats for two departures', () => {
-    // Departures at 09:00 and 09:22 (single headway: 22min)
-    const departures = [hms('09:00'), hms('09:22')]
-    const stats = calculateHeadwayStats(departures)
+    // 09:00, 09:22 → single 22-minute headway
+    const stats = calculateHeadwayStats([[hms('09:00'), hms('09:22')]])
 
     expect(stats).toBeDefined()
     expect(stats!.fastest).toBe(22 * 60)
@@ -302,16 +284,14 @@ describe('calculateHeadwayStats', () => {
   })
 
   it('handles uniform headways', () => {
-    // Departures every 30 minutes: 09:00, 09:30, 10:00, 10:30, 11:00, 11:30
-    const departures = [
+    const stats = calculateHeadwayStats([[
       hms('09:00'),
       hms('09:30'),
       hms('10:00'),
       hms('10:30'),
       hms('11:00'),
       hms('11:30'),
-    ]
-    const stats = calculateHeadwayStats(departures)
+    ]])
 
     expect(stats).toBeDefined()
     expect(stats!.fastest).toBe(30 * 60)
@@ -319,57 +299,95 @@ describe('calculateHeadwayStats', () => {
     expect(stats!.average).toBe(30 * 60)
   })
 
-  it('sorts unsorted departures before calculating', () => {
+  it('sorts unsorted departures within each day before calculating', () => {
     // 6 departures out of order with varying headways (20-30 min)
-    // Sorted order: 09:00, 09:20, 09:50, 10:15, 10:40, 11:00
+    // Sorted: 09:00, 09:20, 09:50, 10:15, 10:40, 11:00
     // Headways: 20, 30, 25, 25, 20 minutes
-    const departures = [
+    const stats = calculateHeadwayStats([[
       hms('10:15'),
       hms('09:00'),
       hms('11:00'),
       hms('09:50'),
       hms('09:20'),
       hms('10:40'),
-    ]
-    const stats = calculateHeadwayStats(departures)
+    ]])
 
     expect(stats).toBeDefined()
-    expect(stats!.fastest).toBe(20 * 60) // 20 minutes
-    expect(stats!.slowest).toBe(30 * 60) // 30 minutes
-    expect(stats!.average).toBe(24 * 60) // (20+30+25+25+20)/5 = 24 minutes
+    expect(stats!.fastest).toBe(20 * 60)
+    expect(stats!.slowest).toBe(30 * 60)
+    expect(stats!.average).toBe(24 * 60) // (20+30+25+25+20)/5 = 24
   })
 
   it('filters out headways under 2 minutes as noise', () => {
-    // 6 departures with some bunched (under 2 min apart)
     // 09:00, 09:01, 09:20, 09:21, 09:45, 10:10
     // Raw headways: 1, 19, 1, 24, 25 minutes
     // After filtering (>= 2 min): 19, 24, 25 minutes
-    const departures = [
+    const stats = calculateHeadwayStats([[
       hms('09:00'),
-      hms('09:01'), // bunched with 09:00 (1 min gap)
+      hms('09:01'),
       hms('09:20'),
-      hms('09:21'), // bunched with 09:20 (1 min gap)
+      hms('09:21'),
       hms('09:45'),
       hms('10:10'),
-    ]
-    const stats = calculateHeadwayStats(departures)
+    ]])
 
     expect(stats).toBeDefined()
-    expect(stats!.fastest).toBe(19 * 60) // 19 minutes (09:01 to 09:20)
-    expect(stats!.slowest).toBe(25 * 60) // 25 minutes (09:45 to 10:10)
-    expect(stats!.average).toBeCloseTo((19 + 24 + 25) / 3 * 60) // ~22.67 minutes
+    expect(stats!.fastest).toBe(19 * 60) // 09:01 to 09:20
+    expect(stats!.slowest).toBe(25 * 60) // 09:45 to 10:10
+    expect(stats!.average).toBeCloseTo((19 + 24 + 25) / 3 * 60)
   })
 
   it('returns undefined when all headways are under 2 minutes', () => {
-    // All departures bunched together (under 2 min apart)
-    const departures = [
+    const stats = calculateHeadwayStats([[
       hms('09:00'),
       hms('09:01'),
       hms('09:01:30'),
       hms('09:02'),
-    ]
-    const stats = calculateHeadwayStats(departures)
+    ]])
 
     expect(stats).toBeUndefined()
+  })
+
+  it('aggregates intervals across multiple days, never spanning service days', () => {
+    // Day 1 (Monday): trips at 06:00 and 22:00 → one 16-hour intra-day gap
+    // Day 2 (Tuesday): trips at 06:00 and 22:00 → one 16-hour intra-day gap
+    // Cross-day "gap" between Mon 22:00 and Tue 06:00 must NOT appear.
+    const stats = calculateHeadwayStats([
+      [hms('06:00'), hms('22:00')],
+      [hms('06:00'), hms('22:00')],
+    ])
+
+    expect(stats).toBeDefined()
+    expect(stats!.fastest).toBe(16 * 3600)
+    expect(stats!.slowest).toBe(16 * 3600)
+    expect(stats!.average).toBe(16 * 3600)
+  })
+
+  it('combines per-day intervals into a single average', () => {
+    // Day 1: 09:00, 09:15, 09:45 → headways 15, 30
+    // Day 2: 10:00, 10:20 → headway 20
+    // Aggregate: [15, 30, 20] → avg = 65/3 ≈ 21.67 min
+    const stats = calculateHeadwayStats([
+      [hms('09:00'), hms('09:15'), hms('09:45')],
+      [hms('10:00'), hms('10:20')],
+    ])
+
+    expect(stats).toBeDefined()
+    expect(stats!.fastest).toBe(15 * 60)
+    expect(stats!.slowest).toBe(30 * 60)
+    expect(stats!.average).toBeCloseTo(65 * 60 / 3)
+  })
+
+  it('skips days with fewer than 2 departures', () => {
+    // Day 1 has 1 trip (no headway). Day 2 has 3 trips with consistent 20-min headways.
+    const stats = calculateHeadwayStats([
+      [hms('09:00')],
+      [hms('10:00'), hms('10:20'), hms('10:40')],
+    ])
+
+    expect(stats).toBeDefined()
+    expect(stats!.fastest).toBe(20 * 60)
+    expect(stats!.slowest).toBe(20 * 60)
+    expect(stats!.average).toBe(20 * 60)
   })
 })

--- a/src/scenario/route-headway.test.ts
+++ b/src/scenario/route-headway.test.ts
@@ -208,14 +208,25 @@ describe('routeHeadways', () => {
     expect(result.dir0[2]).toEqual([])
   })
 
-  it('returns empty arrays when no routeIndex is provided', () => {
+  it('returns one empty inner array per date when no routeIndex is provided (preserves positional contract)', () => {
     const route = makeRoute(100)
-    const date = makeLocalDate('2024-01-15')
+    const dates = [
+      makeLocalDate('2024-01-15'),
+      makeLocalDate('2024-01-16'),
+      makeLocalDate('2024-01-17'),
+    ]
 
-    const result = routeHeadways(route, [date], '00:00:00', '24:00:00', undefined)
+    const result = routeHeadways(route, dates, '00:00:00', '24:00:00', undefined)
 
-    expect(result.dir0).toEqual([])
-    expect(result.dir1).toEqual([])
+    expect(result.dir0).toEqual([[], [], []])
+    expect(result.dir1).toEqual([[], [], []])
+  })
+
+  it('returns empty arrays for an empty date range regardless of routeIndex presence', () => {
+    const route = makeRoute(100)
+    const resultNoIndex = routeHeadways(route, [], undefined, undefined, undefined)
+    expect(resultNoIndex.dir0).toEqual([])
+    expect(resultNoIndex.dir1).toEqual([])
   })
 
   it('handles a route with no departures', () => {

--- a/src/scenario/route-headway.ts
+++ b/src/scenario/route-headway.ts
@@ -72,10 +72,11 @@ export function routeHeadways (
         .filter(depTime => depTime >= 0 && depTime >= startTime && depTime <= endTime)
       stSecs.sort((a, b) => a - b)
 
-      // Add to result
+      // Add to result. Each date contributes its own inner array so headways
+      // are calculated per-day and never span service days.
       const resultDir = dir ? result.total.dir1 : result.total.dir0
       resultDir.stop_id = stopId
-      resultDir.departures.push(...stSecs)
+      resultDir.departures.push(stSecs)
 
       let resultDay: RouteHeadwayDirections | undefined
       switch (d.getDay()) {
@@ -104,7 +105,7 @@ export function routeHeadways (
       if (resultDay != undefined) {
         const dayDir = dir ? resultDay.dir1 : resultDay.dir0
         dayDir.stop_id = stopId
-        dayDir.departures.push(...stSecs)
+        dayDir.departures.push(stSecs)
       }
     }
   }
@@ -142,34 +143,34 @@ export function newRouteHeadwayDirections () {
 const MIN_HEADWAY_SECONDS = 2 * 60
 
 /**
- * Calculate headway statistics from an array of departure times.
- * Headways are the time intervals between consecutive departures.
+ * Calculate headway statistics from per-day departure arrays.
+ * Headways are computed within each day and then aggregated, so an interval
+ * is never measured between trips on different service days.
  * Headways under 2 minutes are filtered out as noise.
  *
- * @param departures - Array of departure times in seconds since midnight
- * @returns Object with average, fastest (min), and slowest (max) headways in seconds, or undefined if < 2 departures
+ * @param departuresByDay - Each inner array is one date's departure times in seconds since midnight
+ * @returns Object with average, fastest (min), and slowest (max) headways in seconds, or undefined if no qualifying intervals
  */
-export function calculateHeadwayStats (departures: number[]): {
+export function calculateHeadwayStats (departuresByDay: number[][]): {
   average: number
   fastest: number
   slowest: number
 } | undefined {
-  if (departures.length < 2) {
-    return undefined
-  }
-
-  // Sort departures ascending before calculating headways
-  const sorted = [...departures].sort((a, b) => a - b)
-
   const headways: number[] = []
-  for (let i = 0; i < sorted.length - 1; i++) {
-    const curr = sorted[i]
-    const next = sorted[i + 1]
-    if (curr !== undefined && next !== undefined) {
-      const headway = next - curr
-      // Filter out headways under 2 minutes as noise
-      if (headway >= MIN_HEADWAY_SECONDS) {
-        headways.push(headway)
+  for (const dayDepartures of departuresByDay) {
+    if (dayDepartures.length < 2) {
+      continue
+    }
+    const sorted = [...dayDepartures].sort((a, b) => a - b)
+    for (let i = 0; i < sorted.length - 1; i++) {
+      const curr = sorted[i]
+      const next = sorted[i + 1]
+      if (curr !== undefined && next !== undefined) {
+        const headway = next - curr
+        // Filter out headways under 2 minutes as noise
+        if (headway >= MIN_HEADWAY_SECONDS) {
+          headways.push(headway)
+        }
       }
     }
   }

--- a/src/scenario/route-headway.ts
+++ b/src/scenario/route-headway.ts
@@ -60,10 +60,14 @@ export function routeHeadways (
   selectedEndTime?: string,
   routeIndex?: RouteDepartureIndex
 ): RouteDepartures {
-  const result: RouteDepartures = { dir0: [], dir1: [] }
   if (!routeIndex) {
-    return result
+    // Preserve the positional-alignment contract even in the no-index case.
+    return {
+      dir0: selectedDateRange.map(() => []),
+      dir1: selectedDateRange.map(() => []),
+    }
   }
+  const result: RouteDepartures = { dir0: [], dir1: [] }
   const startTime = parseHMS(selectedStartTime || '00:00:00')
   const endTime = parseHMS(selectedEndTime || '24:00:00')
   for (const dir of [0, 1]) {

--- a/src/scenario/route-headway.ts
+++ b/src/scenario/route-headway.ts
@@ -7,37 +7,51 @@
  */
 
 import { format } from 'date-fns'
-import { parseHMS } from '../core'
+import { parseHMS, type Weekday } from '../core'
 import type {
   Route,
-  RouteHeadwayDirections,
-  RouteHeadwaySummary,
   StopTimeCacheItem,
   RouteDepartureIndex,
 } from '../tl'
+
+// Maps JS Date.getDay() (0=Sun..6=Sat) to the Weekday string keys. Kept local
+// because `dowValues` in src/core/constants.ts starts at monday, not sunday.
+const WEEKDAY_BY_GETDAY: readonly Weekday[] = [
+  'sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday',
+] as const
+
+/**
+ * Per-direction, per-date in-window departures at each day's representative stop.
+ *
+ * Each inner array corresponds positionally to `selectedDateRange[i]` — i.e.
+ * `dir0[i]` holds direction-0 departures for the i-th date in the range, at
+ * whichever stop was the representative stop for that (route, direction, date).
+ * Empty inner arrays are kept on service-less days to preserve the positional
+ * mapping.
+ */
+export type RouteDepartures = {
+  dir0: number[][]
+  dir1: number[][]
+}
 
 /**
  * Calculate departure times for a route across the selected date range and time window.
  *
  * For each direction (0 and 1) and each date in the range:
- * 1. Find the "representative stop" - the stop with the most departures for this route/direction/date
- * 2. Get all departure times at that stop, filtered to the selected time window
- * 3. Store the departure times (in seconds since midnight) in the result
+ * 1. Find the "representative stop" — the stop with the most departures for this route/direction/date.
+ * 2. Get all departure times at that stop, filtered to the selected time window.
+ * 3. Append the sorted times (in seconds since midnight) as a per-date inner array.
  *
- * Results are aggregated into:
- * - total: all departures across all dates (for overall frequency calculation)
- * - Per day-of-week buckets (sunday, monday, etc.): for day-specific filtering
- *
- * The departure times can later be used to:
- * - Check if a route has any service on selected days (departures.length > 0)
- * - Calculate headways/frequency by computing intervals between consecutive departures
+ * Preserving the per-day boundary (rather than flattening) ensures that downstream
+ * consumers (`calculateHeadwayStats`, weekday-service checks) never treat the gap
+ * between trips on different service days as an interval.
  *
  * @param route - The route to analyze
  * @param selectedDateRange - Array of dates to include
  * @param selectedStartTime - Start of time window (HH:MM:SS), defaults to 00:00:00
  * @param selectedEndTime - End of time window (HH:MM:SS), defaults to 24:00:00
- * @param sdCache - Stop departure cache containing pre-fetched departure data
- * @returns RouteHeadwaySummary with departure times organized by direction and day-of-week
+ * @param routeIndex - Route departure index for lookups
+ * @returns RouteDepartures — dir0/dir1 as parallel arrays to selectedDateRange
  */
 export function routeHeadways (
   route: Route,
@@ -45,97 +59,61 @@ export function routeHeadways (
   selectedStartTime?: string,
   selectedEndTime?: string,
   routeIndex?: RouteDepartureIndex
-): RouteHeadwaySummary {
-  const result = newRouteHeadwaySummary()
+): RouteDepartures {
+  const result: RouteDepartures = { dir0: [], dir1: [] }
   if (!routeIndex) {
     return result
   }
   const startTime = parseHMS(selectedStartTime || '00:00:00')
   const endTime = parseHMS(selectedEndTime || '24:00:00')
   for (const dir of [0, 1]) {
+    const bucket = dir ? result.dir1 : result.dir0
     for (const d of selectedDateRange) {
-      // Get the stop with the most departures
-      let stopId: number = 0
+      // Pick the representative stop (the one with the most departures) for
+      // this (route, direction, date).
       let stopDepartures: StopTimeCacheItem[] = []
       const formattedDate = format(d, 'yyyy-MM-dd')
       const dateStopDeps = routeIndex.getRouteDate(route.id, dir, formattedDate)
-      for (const [depStopId, deps] of dateStopDeps.entries()) {
+      for (const deps of dateStopDeps.values()) {
         if (deps.length > stopDepartures.length) {
-          stopId = depStopId
           stopDepartures = deps
         }
       }
 
-      // Filter by time window (departureTime is already in seconds)
+      // Filter by time window (departureTime is already in seconds) and sort.
       const stSecs = stopDepartures
         .map(st => st.departureTime)
         .filter(depTime => depTime >= 0 && depTime >= startTime && depTime <= endTime)
       stSecs.sort((a, b) => a - b)
 
-      // Add to result. Each date contributes its own inner array so headways
-      // are calculated per-day and never span service days.
-      const resultDir = dir ? result.total.dir1 : result.total.dir0
-      resultDir.stop_id = stopId
-      resultDir.departures.push(stSecs)
-
-      let resultDay: RouteHeadwayDirections | undefined
-      switch (d.getDay()) {
-        case 0:
-          resultDay = result.sunday
-          break
-        case 1:
-          resultDay = result.monday
-          break
-        case 2:
-          resultDay = result.tuesday
-          break
-        case 3:
-          resultDay = result.wednesday
-          break
-        case 4:
-          resultDay = result.thursday
-          break
-        case 5:
-          resultDay = result.friday
-          break
-        case 6:
-          resultDay = result.saturday
-          break
-      }
-      if (resultDay != undefined) {
-        const dayDir = dir ? resultDay.dir1 : resultDay.dir0
-        dayDir.stop_id = stopId
-        dayDir.departures.push(stSecs)
-      }
+      // Always push, even when empty, to keep the positional mapping to
+      // selectedDateRange[i] intact.
+      bucket.push(stSecs)
     }
   }
   return result
 }
 
 /**
- * Create a new empty RouteHeadwaySummary with all days initialized.
+ * Does this route have any in-window service on the given weekday across the
+ * selected date range? True if at least one date in `selectedDateRange` whose
+ * day-of-week matches `target` has a non-empty departures array in either
+ * direction.
  */
-export function newRouteHeadwaySummary (): RouteHeadwaySummary {
-  return {
-    total: newRouteHeadwayDirections(),
-    sunday: newRouteHeadwayDirections(),
-    monday: newRouteHeadwayDirections(),
-    tuesday: newRouteHeadwayDirections(),
-    wednesday: newRouteHeadwayDirections(),
-    thursday: newRouteHeadwayDirections(),
-    friday: newRouteHeadwayDirections(),
-    saturday: newRouteHeadwayDirections(),
+export function hasServiceOnWeekday (
+  deps: RouteDepartures,
+  selectedDateRange: Date[],
+  target: Weekday
+): boolean {
+  for (let i = 0; i < selectedDateRange.length; i++) {
+    if (WEEKDAY_BY_GETDAY[selectedDateRange[i]!.getDay()] !== target) {
+      continue
+    }
+    if ((deps.dir0[i]?.length ?? 0) > 0 || (deps.dir1[i]?.length ?? 0) > 0) {
+      return true
+    }
   }
-}
-
-/**
- * Create a new empty RouteHeadwayDirections with both directions initialized.
- */
-export function newRouteHeadwayDirections () {
-  return {
-    dir0: { stop_id: 0, departures: [] },
-    dir1: { stop_id: 0, departures: [] }
-  }
+  return false
 }
 
 // Minimum headway threshold (2 minutes in seconds)

--- a/src/scenario/scenario-filter.ts
+++ b/src/scenario/scenario-filter.ts
@@ -115,11 +115,13 @@ function routeSetDerived (
     // Assign headways to route so it can be used in filtering
     route.headways = headwayResult
     const hwTotal = headwayResult.total
-    let deps = hwTotal.dir0.departures
-    if (hwTotal.dir1.departures.length > hwTotal.dir0.departures.length) {
-      deps = hwTotal.dir1.departures
-    }
-    // Calculate headways from departures
+    // Pick the direction with more total departures across all service days;
+    // the other direction is intentionally dropped (a route's headway is
+    // reported per dominant direction).
+    const dir0Count = hwTotal.dir0.departures.reduce((sum, d) => sum + d.length, 0)
+    const dir1Count = hwTotal.dir1.departures.reduce((sum, d) => sum + d.length, 0)
+    const deps = dir1Count > dir0Count ? hwTotal.dir1.departures : hwTotal.dir0.departures
+    // Calculate headways per-day from departures
     const stats = calculateHeadwayStats(deps)
     if (stats) {
       route.average_frequency = stats.average
@@ -192,7 +194,10 @@ function routeMarked (
       } else if (sd === 'saturday') {
         dayHeadways = route.headways?.saturday
       }
-      const hasService = dayHeadways && (dayHeadways.dir0.departures.length > 0 || dayHeadways.dir1.departures.length > 0)
+      const hasService = dayHeadways && (
+        dayHeadways.dir0.departures.some(d => d.length > 0)
+        || dayHeadways.dir1.departures.some(d => d.length > 0)
+      )
       if (hasService) {
         hasAny = true
       } else {

--- a/src/scenario/scenario-filter.ts
+++ b/src/scenario/scenario-filter.ts
@@ -47,8 +47,9 @@ import {
 } from './scenario'
 import {
   routeHeadways,
-  newRouteHeadwaySummary,
-  calculateHeadwayStats
+  hasServiceOnWeekday,
+  calculateHeadwayStats,
+  type RouteDepartures,
 } from './route-headway'
 import {
   type Weekday,
@@ -62,7 +63,6 @@ import type {
   Agency,
   FeedVersion,
   Route,
-  RouteHeadwayDirections,
   Stop,
   StopDepartureCache,
   StopGql,
@@ -103,49 +103,41 @@ function routeSetDerived (
   frequencyOver?: number,
   routeIndex?: RouteDepartureIndex,
 ) {
-  // Set derived properties
+  // Build per-direction per-date in-window departures. Empty when no
+  // routeIndex is available (both arrays are empty).
+  const deps = routeHeadways(
+    route,
+    selectedDateRange,
+    selectedStartTime,
+    selectedEndTime,
+    routeIndex,
+  )
+
+  // Set derived frequency scalars
   if (routeIndex) {
-    const headwayResult = routeHeadways(
-      route,
-      selectedDateRange,
-      selectedStartTime,
-      selectedEndTime,
-      routeIndex,
-    )
-    // Assign headways to route so it can be used in filtering
-    route.headways = headwayResult
-    const hwTotal = headwayResult.total
     // Pick the direction with more total departures across all service days;
     // the other direction is intentionally dropped (a route's headway is
     // reported per dominant direction).
-    const dir0Count = hwTotal.dir0.departures.reduce((sum, d) => sum + d.length, 0)
-    const dir1Count = hwTotal.dir1.departures.reduce((sum, d) => sum + d.length, 0)
-    const deps = dir1Count > dir0Count ? hwTotal.dir1.departures : hwTotal.dir0.departures
-    // Calculate headways per-day from departures
-    const stats = calculateHeadwayStats(deps)
+    const dir0Count = deps.dir0.reduce((sum, d) => sum + d.length, 0)
+    const dir1Count = deps.dir1.reduce((sum, d) => sum + d.length, 0)
+    const chosenDir = dir1Count > dir0Count ? deps.dir1 : deps.dir0
+    const stats = calculateHeadwayStats(chosenDir)
     if (stats) {
       route.average_frequency = stats.average
       route.fastest_frequency = stats.fastest
       route.slowest_frequency = stats.slowest
-      // console.debug('routeSetDerived:', route.id,
-      //   'departures:', deps.length,
-      //   'avg:', Math.round(stats.average / 60), 'min',
-      //   'fastest:', Math.round(stats.fastest / 60), 'min',
-      //   'slowest:', Math.round(stats.slowest / 60), 'min'
-      // )
     } else {
       route.average_frequency = undefined
       route.fastest_frequency = undefined
       route.slowest_frequency = undefined
-      // console.debug('routeSetDerived:', route.id,
-      //   'departures:', deps.length,
-      //   'headways: none (need 2+ departures to calculate headways)'
-      // )
     }
   }
+
   // Mark after setting frequency values
   route.marked = routeMarked(
     route,
+    deps,
+    selectedDateRange,
     selectedWeekdays,
     selectedWeekdayMode,
     selectedRouteTypes,
@@ -159,6 +151,8 @@ function routeSetDerived (
 // Filter routes
 function routeMarked (
   route: Route,
+  deps: RouteDepartures,
+  selectedDateRange: Date[],
   selectedWeekdays?: Weekday[],
   selectedWeekdayMode?: WeekdayMode,
   selectedRouteTypes?: RouteType[],
@@ -171,34 +165,12 @@ function routeMarked (
   const effectiveWeekdays = resolveEffectiveWeekdays(selectedWeekdays, selectedWeekdayMode)
   if (effectiveWeekdays != null) {
     if (effectiveWeekdays.length === 0) {
-      // console.debug('routeMarked:', route.id, 'unmarked: selectedWeekdays is empty array')
       return false
     }
-    // Check if route has service on selected days using headway data
     let hasAny = false
     let hasAll = true
     for (const sd of effectiveWeekdays) {
-      let dayHeadways: RouteHeadwayDirections | undefined
-      if (sd === 'sunday') {
-        dayHeadways = route.headways?.sunday
-      } else if (sd === 'monday') {
-        dayHeadways = route.headways?.monday
-      } else if (sd === 'tuesday') {
-        dayHeadways = route.headways?.tuesday
-      } else if (sd === 'wednesday') {
-        dayHeadways = route.headways?.wednesday
-      } else if (sd === 'thursday') {
-        dayHeadways = route.headways?.thursday
-      } else if (sd === 'friday') {
-        dayHeadways = route.headways?.friday
-      } else if (sd === 'saturday') {
-        dayHeadways = route.headways?.saturday
-      }
-      const hasService = dayHeadways && (
-        dayHeadways.dir0.departures.some(d => d.length > 0)
-        || dayHeadways.dir1.departures.some(d => d.length > 0)
-      )
-      if (hasService) {
+      if (hasServiceOnWeekday(deps, selectedDateRange, sd)) {
         hasAny = true
       } else {
         hasAll = false
@@ -550,7 +522,6 @@ export function applyScenarioResultFilter (
       average_frequency: undefined,
       fastest_frequency: undefined,
       slowest_frequency: undefined,
-      headways: newRouteHeadwaySummary(),
       __typename: 'Route', // backwards compat
     }
     routeSetDerived(

--- a/src/tl/route.ts
+++ b/src/tl/route.ts
@@ -86,7 +86,9 @@ export interface RouteDerived {
 
 export type RouteHeadwayCount = {
   stop_id: number
-  departures: number[]
+  // Each inner array is one date's in-window departures, sorted.
+  // Headways are computed per-day and never cross service days.
+  departures: number[][]
 }
 
 export type RouteHeadwayDirections = {

--- a/src/tl/route.ts
+++ b/src/tl/route.ts
@@ -78,33 +78,9 @@ export interface RouteDerived {
   route_name: string
   agency_name: string
   route_mode: string
-  headways: RouteHeadwaySummary
   average_frequency?: number
   fastest_frequency?: number
   slowest_frequency?: number
-}
-
-export type RouteHeadwayCount = {
-  stop_id: number
-  // Each inner array is one date's in-window departures, sorted.
-  // Headways are computed per-day and never cross service days.
-  departures: number[][]
-}
-
-export type RouteHeadwayDirections = {
-  dir0: RouteHeadwayCount
-  dir1: RouteHeadwayCount
-}
-
-export type RouteHeadwaySummary = {
-  total: RouteHeadwayDirections
-  sunday: RouteHeadwayDirections
-  monday: RouteHeadwayDirections
-  tuesday: RouteHeadwayDirections
-  wednesday: RouteHeadwayDirections
-  thursday: RouteHeadwayDirections
-  friday: RouteHeadwayDirections
-  saturday: RouteHeadwayDirections
 }
 
 export type RouteCsv = RouteGtfs & {


### PR DESCRIPTION
## Summary

Restructures the internal headway machinery in `src/scenario/` with two linked changes:

1. **Per-date arrays for cross-day correctness.** `RouteHeadwayCount.departures` moved from a flat `number[]` to a per-date `number[][]`. Makes the service-day boundary explicit in the data so cross-day intervals are structurally impossible to compute. Previously relied on same-time-of-day sort collisions + the 2-min noise filter to paper over cross-day "intervals."

2. **No more persistence.** Drops the `Route.headways: RouteHeadwaySummary` field and the nested type hierarchy (`RouteHeadwaySummary` / `RouteHeadwayDirections` / `RouteHeadwayCount`). The headway data was an internal artifact of `scenario-filter.ts`'s own call tree — nothing outside it consumed `route.headways` — so it didn't need to persist on the `Route` object.

Pure refactor. Same fastest/slowest/average frequency for typical inputs.

## What changed

- `routeHeadways()` now returns `RouteDepartures = { dir0: number[][], dir1: number[][] }` directly. No `total`, no weekday buckets, no nested `Directions` / `Count` types. Deleted `newRouteHeadwaySummary()` / `newRouteHeadwayDirections()` constructors.
- `calculateHeadwayStats()` takes `number[][]`, computes intervals per-day, aggregates. Cross-day intervals are now impossible to compute.
- Direction picking in `routeSetDerived` sums total departures across days via `reduce(...)`.
- New `hasServiceOnWeekday()` helper replaces the 14-way `if/else if` chain that was reading from `route.headways.{weekday}.*`. Takes the ephemeral `RouteDepartures` + `selectedDateRange`, returns a boolean. `routeMarked()` signature changes to accept the ephemeral arrays as parameters.
- Initial Route object construction in `applyScenarioResultFilter` no longer carries a placeholder headway summary.
- Dead `stop_id` field on the old `RouteHeadwayCount` is gone.

## Behavioral note

Identical results for typical inputs. The only observable change is correctness for routes whose late-night service-day rollover used to produce spurious cross-day "intervals" that survived the 2-min noise filter.

## Why a single PR

Surfaced while working on #239 (PR #328) but separable from the report-column work there. Both halves of this PR (per-date shape + drop persistence) touch the same files and tests, so they land together rather than as two sequential reviews.

## Test plan

- 21 tests in `src/scenario/route-headway.test.ts` — per-date arrays, multi-date/multi-week `hasServiceOnWeekday`, single-day and cross-day `calculateHeadwayStats`, empty/single-trip days, 2-min noise filter.
- `pnpm check` clean, 165 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)