### PR TITLE
Add production deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,44 @@
+name: Deploy Production
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: pnpm build
+        env:
+          NITRO_PRESET: cloudflare_pages
+          NUXT_PUBLIC_TLV2_PROTOMAPS_APIKEY: ${{ secrets.NUXT_PUBLIC_TLV2_PROTOMAPS_APIKEY }}
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .output/public --project-name=calact-network-analysis-tool-prod


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to deploy to the new `calact-network-analysis-tool-prod` Cloudflare Pages project when a GitHub release is published. The existing Cloudflare GitHub App continues to handle staging deploys (push to `main`) and PR preview deployments.

### Setup required before first deploy
- Create `calact-network-analysis-tool-prod` Pages project in Cloudflare dashboard (Direct Upload, no Git connection)
- Add GitHub Actions repo secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `NUXT_PUBLIC_TLV2_PROTOMAPS_APIKEY`
- Add runtime env vars in the Cloudflare Pages project settings: `NUXT_AUTH0_DOMAIN`, `NUXT_AUTH0_CLIENT_ID`, `NUXT_AUTH0_CLIENT_SECRET`, `NUXT_AUTH0_SESSION_SECRET`, `NUXT_AUTH0_APP_BASE_URL`, `NUXT_AUTH0_AUDIENCE`, `NUXT_TLV2_PROXY_BASE_DEFAULT`, `NUXT_TLV2_GRAPHQL_APIKEY`
- Add production CNAME pointing at `calact-network-analysis-tool-prod.pages.dev`

## Test plan
- Merge and cut a test release to verify the workflow triggers and deploys successfully
- Confirm the deployed site loads and authenticates correctly at the production URL

closes https://github.com/interline-io/calact-network-analysis-tool/issues/332