### PR TITLE
Fix production deploy to use Production environment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,4 +41,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist/ --project-name=calact-network-analysis-tool-prod
+          command: pages deploy dist/ --project-name=calact-network-analysis-tool-prod --branch=main


### PR DESCRIPTION
Adds `--branch=main` to `wrangler pages deploy` so Cloudflare labels deployments as Production instead of Preview

related to #332