### PR TITLE
Pass NUXT_AUTH0_CLIENT_ID to production build

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -36,6 +36,9 @@ jobs:
         env:
           NITRO_PRESET: cloudflare_pages
           NUXT_PUBLIC_TLV2_PROTOMAPS_APIKEY: ${{ secrets.NUXT_PUBLIC_TLV2_PROTOMAPS_APIKEY }}
+          # Required: tlv2-auth's build-time guard bakes a "disabled.invalid" placeholder into
+          # runtimeConfig.auth0 unless NUXT_AUTH0_CLIENT_ID is set during the build.
+          NUXT_AUTH0_CLIENT_ID: ${{ secrets.NUXT_AUTH0_CLIENT_ID }}
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
Fixes production `/auth/login` 500s. tlv2-auth's module setup bakes a `disabled.invalid` placeholder into `runtimeConfig.auth0` unless `NUXT_AUTH0_CLIENT_ID` is set at build time (see `@interline-io/tlv2-auth/dist/module.mjs:37`). Staging works because Cloudflare's built-in Pages builder injects env vars at build time; GH Actions wasn't passing this one.

related to https://github.com/interline-io/calact-network-analysis-tool/issues/332