### PR TITLE
Pin github actions

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,16 +15,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@interline-io'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -41,7 +43,7 @@ jobs:
           NUXT_AUTH0_CLIENT_ID: ${{ secrets.NUXT_AUTH0_CLIENT_ID }}
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,16 +16,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@interline-io'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@interline-io'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

Pins every third-party GitHub Action invoked by our workflows to an immutable commit SHA (with the human-readable version tag retained as an inline comment), and aligns the setup pattern with the established workflows. Required by the new repository rule that GitHub Actions dependencies must be pinned.

## User-facing changes

No user-facing changes. CI behavior is unchanged; only the way actions are referenced from workflow files.

## Implementation details

### SHA pinning
- Replaced every floating `@v<major>` reference across `lint.yml`, `test.yml`, and `deploy-production.yml` with the full commit SHA and a `# vX.Y.Z` trailing comment for human readability:
  - `actions/checkout` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
  - `actions/setup-node` → `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0)
  - `pnpm/action-setup` → `0e279bb959325dab635dd2c09392533439d90093` (v6.0.8)
  - `cloudflare/wrangler-action` → `9acf94ace14e7dc412b076f2c5c20b8ce93c79cd` (v3.15.0)

### Align with Interline patterns
- Bumped `pnpm/action-setup` from v4.3.0 to v6.0.8.
- Added `registry-url: 'https://npm.pkg.github.com'` and `scope: '@interline-io'` to each `actions/setup-node` invocation so the action generates `.npmrc` programmatically with the `${NODE_AUTH_TOKEN}` substitution that GitHub Packages auth needs. Removes reliance on the checked-in `.npmrc` env-replacement path in CI.

## User test plan
- Open this PR and confirm the `Lint` and `Test` workflow runs both pass against the new pinned actions and the pnpm v6 action-setup bump.
- After merge, trigger `Deploy Production` via `workflow_dispatch` once and confirm a clean Cloudflare Pages deploy.
