### PR TITLE
Add focus management, table captions, and improve contrast

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -1,4 +1,4 @@
-$primary: #8c67ef;
+$primary: #8058ee;
 $link: $primary;
 $duration: 1000ms;
 

--- a/app/components/cal/datagrid.vue
+++ b/app/components/cal/datagrid.vue
@@ -22,6 +22,9 @@
 
     <div class="table-container" :class="{ 'is-freeze-first': props.freezeFirstColumn }">
       <table class="cal-report-table table is-bordered is-striped is-hoverable is-fullwidth">
+        <caption v-if="props.caption" class="is-sr-only">
+          {{ props.caption }}
+        </caption>
         <thead>
           <tr>
             <th
@@ -149,6 +152,10 @@ const props = defineProps<{
   filename?: string
   // Horizontally scrollable, with the first column pinned.
   freezeFirstColumn?: boolean
+  // Accessible table caption. Rendered as a visually-hidden <caption> so screen
+  // readers announce the table's purpose; sighted users still see surrounding
+  // heading/tab UI for context.
+  caption?: string
 }>()
 
 const searchQuery = ref('')

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -41,6 +41,7 @@
           </template>
           <cat-datepicker
             v-if="!selectSingleDay"
+            ref="endDateRef"
             v-model="endDate"
             :min-date="minAllowedDate"
             :max-date="maxAllowedDate"
@@ -389,14 +390,19 @@ const {
   }
 )
 
+const endDateRef = ref<{ focus: () => void } | null>(null)
+
 // When toggling single-day mode, sync endDate to the URL query params.
 // In single-day mode, endDate matches startDate. When switching to range mode,
 // we create a copy so Vue detects a change and persists the value to the URL.
-watch(selectSingleDay, (newVal) => {
+// When the end-date picker appears, move focus into it for keyboard users (#361).
+watch(selectSingleDay, async (newVal) => {
   if (newVal) {
     endDate.value = startDate.value
   } else {
     endDate.value = new Date(endDate.value)
+    await nextTick()
+    endDateRef.value?.focus()
   }
 })
 

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -69,6 +69,7 @@
 
     <cal-datagrid
       :table-report="activeTableReport"
+      :caption="`${activeReportTabLabel} — ${reportHeading}`"
     >
       <!-- Custom rendering for URLs column (flex areas) -->
       <template #column-urls="{ row }">
@@ -330,6 +331,16 @@ const reportHeading = computed(() => {
 type ReportTab = 'routes' | 'stops' | 'stops-aggregated' | 'agencies' | 'flex'
 
 const activeReportTab = ref<ReportTab>('routes')
+
+const reportTabLabels: Record<ReportTab, string> = {
+  'routes': 'Routes',
+  'stops': 'Stops (Individual)',
+  'stops-aggregated': 'Stops (Aggregated)',
+  'agencies': 'Agencies',
+  'flex': 'Flex Areas',
+}
+
+const activeReportTabLabel = computed(() => reportTabLabels[activeReportTab.value])
 
 const hasAggregateLayer = computed(() => {
   return aggregateLayer.value !== '' && aggregateLayer.value !== 'none'


### PR DESCRIPTION
## Summary
Third of three follow-up PRs to the catenary 0.2.0 bump (#375) addressing the a11y umbrella (#329). Adds focus management when the End-Date picker is revealed, gives each reports table an accessible caption, and darkens the primary lavender to improve text/background contrast.

Closes #365
Partially closes #361 (End-Date half; Time-of-Day half ships in PR #379)

## User-facing changes
- Clicking "Set an end date" in the query builder now moves keyboard focus to the newly revealed end-date picker.
- Each reports table is announced by its active tab (Routes / Stops / Agencies / Flex Areas) along with the report's date range when navigated by screen reader.
- The primary lavender (`#8c67ef` → `#8058ee`) is slightly darker, raising contrast against white text on `is-primary` buttons, tags, and link colors.

## Implementation details
- `app/components/cal/query.vue`: end-date `cat-datepicker` gets a `ref`; the `watch(selectSingleDay)` calls `endDateRef.value?.focus()` after `nextTick` when the picker appears.
- `app/components/cal/datagrid.vue`: new optional `caption` prop, rendered as `<caption class="is-sr-only">` so screen readers announce the table without affecting the visible layout.
- `app/components/cal/report.vue`: maps each `ReportTab` to a label and passes `"<tab label> — <date range>"` to `cal-datagrid`.
- `app/assets/main.scss`: `$primary` changes from `#8c67ef` to `#8058ee`. Cascades to every `is-primary` / `is-link` / `--bulma-primary` consumer (Bulma + catenary).

## User test plan
- In the query builder, click "Set an end date" — focus should land in the end-date picker.
- On the Reports tab, switch between Routes / Stops / Agencies / Flex Areas with a screen reader open; each table should be announced with its tab label and date range.
- Spot-check buttons, links, and the active filter-tab background across the app — color should be marginally darker but visually consistent.