### PR TITLE
Deferred / opt-in stop buffer demographics

### DIFF
--- a/app/components/cal/buffer-demographics-notice.vue
+++ b/app/components/cal/buffer-demographics-notice.vue
@@ -1,0 +1,51 @@
+<!-- Shared "stop buffer demographics not loaded" notice + load button (#315
+     deferred load). Parents decide visibility; this only renders the prompt. -->
+<template>
+  <div class="cal-buffer-demographics-notice" :class="{ 'is-compact': compact }">
+    <cat-msg variant="info">
+      <p>
+        Stop buffer demographics aren't loaded for this scenario.
+        Loading apportions census data within the statistical radius of each
+        stop and can be slow.
+      </p>
+      <cat-button variant="info" class="mt-2" @click="emit('load')">
+        Load stop buffer demographics
+      </cat-button>
+    </cat-msg>
+  </div>
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{
+  // Slim variant for placement above report tables.
+  compact?: boolean
+}>(), {
+  compact: false,
+})
+
+const emit = defineEmits<{
+  load: []
+}>()
+</script>
+
+<style scoped lang="scss">
+.cal-buffer-demographics-notice {
+  &.is-compact {
+    :deep(.message-body) {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding-top: 8px;
+      padding-bottom: 8px;
+      p {
+        margin: 0;
+      }
+      .button {
+        margin-top: 0 !important;
+        flex-shrink: 0;
+      }
+    }
+  }
+}
+</style>

--- a/app/components/cal/filter.vue
+++ b/app/components/cal/filter.vue
@@ -258,6 +258,11 @@
             </cat-select>
           </cat-field>
 
+          <cal-buffer-demographics-notice
+            v-if="props.scenarioFilterResult && stopBufferRadius > 0 && !bufferDataActive"
+            @load="emit('loadDemographics')"
+          />
+
           <p class="menu-label">
             Fares <cat-tooltip text="Fare filtering is planned for future implementation">
               <i class="mdi mdi-information-outline" />
@@ -545,9 +550,9 @@
                 v-for="option of censusGeographyLayerOptions"
                 :key="option.value"
                 :value="option.value"
-                :disabled="stopBufferRadius > 0 && !HIERARCHICAL_TIGER_LAYERS.has(option.value)"
+                :disabled="bufferDataActive && !HIERARCHICAL_TIGER_LAYERS.has(option.value)"
               >
-                {{ option.label }}{{ stopBufferRadius > 0 && !HIERARCHICAL_TIGER_LAYERS.has(option.value) ? ' (needs radius = 0)' : '' }}
+                {{ option.label }}{{ bufferDataActive && !HIERARCHICAL_TIGER_LAYERS.has(option.value) ? ' (needs radius = 0)' : '' }}
               </option>
             </cat-select>
           </cat-field>
@@ -742,6 +747,12 @@ const markedRouteCount = computed(() => (props.scenarioFilterResult?.routes ?? [
 const totalStopCount = computed(() => props.scenarioFilterResult?.stops.length ?? 0)
 const markedStopCount = computed(() => (props.scenarioFilterResult?.stops ?? []).reduce((n, s) => n + (s.marked ? 1 : 0), 0))
 
+// Buffer demographics are present (#315). With deferred loading, radius > 0
+// no longer implies data — gate buffer UI on this instead.
+const bufferDataActive = computed(() =>
+  stopBufferRadius.value > 0
+  && (props.scenarioFilterResult?.stopBufferGeographies?.size ?? 0) > 0)
+
 const panelMainWidthPx = `${FILTER_MAIN_WIDTH}px`
 const panelSubWidthPx = `${FILTER_SUB_WIDTH}px`
 const panelPaddingPx = `${PANEL_PADDING}px`
@@ -749,6 +760,7 @@ const panelPaddingPx = `${PANEL_PADDING}px`
 const emit = defineEmits([
   'resetFilters',
   'showQuery',
+  'loadDemographics',
 ])
 const activeTab = defineModel<string>('activeTab')
 

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -184,6 +184,16 @@
                 Include Flex Service Areas
               </cat-checkbox>
             </div>
+            <div class="is-flex mt-2">
+              <cat-checkbox
+                v-model="includeStopBufferDemographics"
+              >
+                <cat-tooltip text="Apportions ACS census demographics to the area within the stop statistical radius of each stop, route, and agency. This can be a slow query — leave off to load the scenario faster, then load demographics on demand from the Filters tab or Report tab.">
+                  Include Stop Buffer Demographics
+                  <cat-icon size="small" icon="information" />
+                </cat-tooltip>
+              </cat-checkbox>
+            </div>
           </cat-field>
 
           <!-- Census Geography Dataset -->
@@ -315,6 +325,7 @@ const {
   geoDatasetName,
   includeFixedRoute,
   includeFlexAreas,
+  includeStopBufferDemographics,
   fvids,
 } = useScenarioInputs()
 

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -39,9 +39,9 @@
           v-for="option of censusGeographyLayerOptions"
           :key="option.value"
           :value="option.value"
-          :disabled="stopBufferRadius > 0 && !HIERARCHICAL_TIGER_LAYERS.has(option.value)"
+          :disabled="bufferDataActive && !HIERARCHICAL_TIGER_LAYERS.has(option.value)"
         >
-          {{ option.label }}{{ stopBufferRadius > 0 && !HIERARCHICAL_TIGER_LAYERS.has(option.value) ? ' (needs radius = 0)' : '' }}
+          {{ option.label }}{{ bufferDataActive && !HIERARCHICAL_TIGER_LAYERS.has(option.value) ? ' (needs radius = 0)' : '' }}
         </option>
       </cat-select>
       <cat-tooltip text="The selected geography level determines how stop data is grouped. Enable 'Show Agg. Areas' in Map Display to visualize these areas on the map.">
@@ -54,7 +54,7 @@
          that doesn't exist yet. Surface this honestly rather than silently
          showing un-apportioned values. -->
     <cat-msg
-      v-if="activeReportTab === 'stops-aggregated' && stopBufferRadius > 0 && !HIERARCHICAL_TIGER_LAYERS.has(aggregateLayer)"
+      v-if="activeReportTab === 'stops-aggregated' && bufferDataActive && !HIERARCHICAL_TIGER_LAYERS.has(aggregateLayer)"
       variant="warning"
       title="Buffer apportionment not available for this layer"
       class="mb-4"
@@ -66,6 +66,15 @@
         layer above, or set the stop statistical radius to 0 to acknowledge.
       </p>
     </cat-msg>
+
+    <!-- Deferred-load prompt (#315): demographics weren't loaded with the
+         scenario, so the census columns these tabs would show are absent. -->
+    <cal-buffer-demographics-notice
+      v-if="bufferNoticeVisible"
+      compact
+      class="mb-4"
+      @load="emit('loadDemographics')"
+    />
 
     <cal-datagrid
       :table-report="activeTableReport"
@@ -234,6 +243,7 @@ export interface BufferDetailsPayload {
 const emit = defineEmits<{
   openTimetable: [payload: { route: Route, initialTab: RouteTimetableTab }]
   openBufferDetails: [payload: BufferDetailsPayload]
+  loadDemographics: []
 }>()
 
 function handleOpenTimetable (routeId: number, initialTab: RouteTimetableTab) {
@@ -243,8 +253,22 @@ function handleOpenTimetable (routeId: number, initialTab: RouteTimetableTab) {
   }
 }
 
+// Buffer demographics are present (#315). With deferred loading, radius > 0
+// no longer implies data — gate buffer UI on this instead.
+const bufferDataActive = computed(() =>
+  stopBufferRadius.value > 0
+  && (props.scenarioFilterResult?.stopBufferGeographies?.size ?? 0) > 0)
+
+// Deferred-load prompt: shown on the tabs that would display census columns
+// when demographics are configured (radius > 0) but not loaded.
+const bufferNoticeVisible = computed(() =>
+  props.scenarioFilterResult != null
+  && stopBufferRadius.value > 0
+  && !bufferDataActive.value
+  && ['stops', 'routes', 'agencies', 'stops-aggregated'].includes(activeReportTab.value))
+
 const drillableBufferTab = computed<BufferDetailsKind | null>(() => {
-  if (stopBufferRadius.value <= 0) {
+  if (!bufferDataActive.value) {
     return null
   }
   switch (activeReportTab.value) {
@@ -433,7 +457,7 @@ const routeColumns = computed((): TableColumn[] => {
       tooltip: `The time at which the latest trip on this route ends, ${timeScope} included within the current filters.`,
     },
   ]
-  if (stopBufferRadius.value > 0) {
+  if (bufferDataActive.value) {
     cols.push(...buildCensusColumns(true))
   }
   return cols
@@ -465,7 +489,7 @@ const stopColumns = computed((): TableColumn[] => {
       tooltip: `The sum of all visits at the stop by any route ${acrossDays} included within the current filters. Not currently filtered by the route or agency filters.`,
     },
   ]
-  if (stopBufferRadius.value > 0) {
+  if (bufferDataActive.value) {
     cols.push(...buildCensusColumns(true))
   }
   return cols
@@ -485,7 +509,7 @@ function buildCensusColumns (apportioned: boolean): TableColumn[] {
 }
 
 const bufferAggregationActive = computed(() => {
-  return stopBufferRadius.value > 0
+  return bufferDataActive.value
     && HIERARCHICAL_TIGER_LAYERS.has(aggregateLayer.value)
     && (props.scenarioFilterResult?.aggregationBufferGeographies?.length ?? 0) > 0
 })
@@ -536,7 +560,7 @@ const agencyColumns = computed((): TableColumn[] => {
     { key: 'routes_modes', label: 'Modes', sortable: true },
     { key: 'stops_count', label: 'Number of Stops', sortable: true },
   ]
-  if (stopBufferRadius.value > 0) {
+  if (bufferDataActive.value) {
     cols.push(...buildCensusColumns(true))
   }
   return cols

--- a/app/components/cal/scenario-loading.vue
+++ b/app/components/cal/scenario-loading.vue
@@ -32,7 +32,7 @@
 
     <!-- Results Display -->
     <div class="columns is-multiline">
-      <div class="column is-one-quarter">
+      <div class="column" :class="columnSizeClass">
         <cat-msg variant="info" title="Stops">
           <p><strong>{{ scenarioData?.stops.length || 0 }}</strong> loaded</p>
           <div v-if="scenarioData?.stops.length" class="stop-list">
@@ -45,7 +45,7 @@
           </div>
         </cat-msg>
       </div>
-      <div class="column is-one-quarter">
+      <div class="column" :class="columnSizeClass">
         <cat-msg variant="info" title="Routes">
           <p><strong>{{ scenarioData?.routes.length || 0 }}</strong> loaded</p>
           <div v-if="scenarioData?.routes.length" class="route-list">
@@ -58,7 +58,7 @@
           </div>
         </cat-msg>
       </div>
-      <div class="column is-one-quarter">
+      <div class="column" :class="columnSizeClass">
         <cat-msg variant="info" title="Departures">
           <p><strong>{{ stopsWithDepartures }}</strong> / {{ totalStops }} stops</p>
           <div class="more-label">
@@ -66,7 +66,7 @@
           </div>
         </cat-msg>
       </div>
-      <div class="column is-one-quarter">
+      <div class="column" :class="columnSizeClass">
         <cat-msg variant="info" title="Flex Areas">
           <p><strong>{{ scenarioData?.flexAreas?.length || 0 }}</strong> loaded</p>
           <div v-if="scenarioData?.flexAreas?.length" class="flex-list">
@@ -76,6 +76,17 @@
             <div v-if="scenarioData?.flexAreas.length > 5" class="more-label">
               ... and {{ scenarioData.flexAreas.length - 5 }} more
             </div>
+          </div>
+        </cat-msg>
+      </div>
+      <div v-if="demographicsActive" class="column" :class="columnSizeClass">
+        <cat-msg variant="info" title="Demographics">
+          <div v-for="pass of demographicsPasses" :key="pass.stage" class="demographics-pass">
+            <cat-icon
+              size="small"
+              :icon="pass.status === 'done' ? 'check-circle' : pass.status === 'in-progress' ? 'loading' : 'circle-outline'"
+            />
+            {{ pass.label }}<span v-if="pass.count > 0"> ({{ pass.count.toLocaleString() }})</span>
           </div>
         </cat-msg>
       </div>
@@ -92,12 +103,15 @@ const props = withDefaults(defineProps<{
   error?: Error | string
   scenarioData?: ScenarioData
   stopDepartureCount?: number
+  // Whether buffer demographics load this run (#315) — shows the
+  // Demographics column and folds buffer chunks into the progress bar.
+  demographicsActive?: boolean
 }>(), {})
 
 // Computed values
 const progressPercentage = computed(() => {
   if (!props.progress) { return 0 }
-  // Add feed version progress + stop departure progress
+  // Add feed version progress + stop departure progress + buffer progress
   let total = 0
   let completed = 0
   if (props.progress.feedVersionProgress) {
@@ -108,7 +122,53 @@ const progressPercentage = computed(() => {
     total += props.progress.stopDepartureProgress.total
     completed += props.progress.stopDepartureProgress.completed
   }
+  if (props.progress.bufferProgress) {
+    total += props.progress.bufferProgress.total
+    completed += props.progress.bufferProgress.completed
+  }
   return Math.round((completed / total) * 100)
+})
+
+// Five columns when the Demographics column shows, four otherwise.
+const columnSizeClass = computed(() => {
+  return props.demographicsActive ? 'is-one-fifth' : 'is-one-quarter'
+})
+
+// Buffer-pass order matches runBufferPasses (C/D/E/F).
+const BUFFER_STAGE_ORDER = [
+  'stop-buffer-geographies',
+  'route-buffer-geographies',
+  'agency-buffer-geographies',
+  'aggregation-buffer-geographies',
+] as const
+
+type PassStatus = 'pending' | 'in-progress' | 'done'
+
+// Per-pass status rows for the Demographics column. A pass counts as done
+// once a later pass is active/complete or the whole run finished — counts
+// alone aren't enough because a pass can legitimately return no rows.
+const demographicsPasses = computed((): { label: string, stage: string, count: number, status: PassStatus }[] => {
+  const stage = props.progress?.currentStage
+  const stageIndex = BUFFER_STAGE_ORDER.indexOf(stage as typeof BUFFER_STAGE_ORDER[number])
+  // Not 'ready': the buffer-only refetch initializes progress at 'ready'
+  // before any stream events arrive — passes are pending then, not done.
+  const runDone = stage === 'complete'
+  const counts = [
+    props.scenarioData?.stopBufferGeographies?.size ?? 0,
+    props.scenarioData?.routeBufferGeographies?.size ?? 0,
+    props.scenarioData?.agencyBufferGeographies?.size ?? 0,
+    props.scenarioData?.aggregationBufferGeographies?.length ?? 0,
+  ]
+  const labels = ['Stops', 'Routes', 'Agencies', 'Aggregation']
+  return BUFFER_STAGE_ORDER.map((passStage, i) => {
+    let status: PassStatus = 'pending'
+    if (runDone || (stageIndex >= 0 && i < stageIndex) || ((counts[i] ?? 0) > 0 && stageIndex !== i)) {
+      status = 'done'
+    } else if (stageIndex === i) {
+      status = 'in-progress'
+    }
+    return { label: labels[i] ?? '', stage: passStage, count: counts[i] ?? 0, status }
+  })
 })
 
 // Total number of stops loaded
@@ -178,6 +238,16 @@ function formatStage (stage: ScenarioProgress['currentStage'], stageText: string
 
 .stop-list, .route-list, .flex-list {
   margin-top: 0.5rem;
+}
+
+.demographics-pass {
+  font-size: 0.85rem;
+  color: #6c757d;
+  margin-bottom: 0.2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  white-space: nowrap;
 }
 
 .stop-item, .route-item, .flex-item {

--- a/app/components/cal/scenario-loading.vue
+++ b/app/components/cal/scenario-loading.vue
@@ -32,7 +32,7 @@
 
     <!-- Results Display -->
     <div class="columns is-multiline">
-      <div class="column" :class="columnSizeClass">
+      <div class="column is-one-quarter">
         <cat-msg variant="info" title="Stops">
           <p><strong>{{ scenarioData?.stops.length || 0 }}</strong> loaded</p>
           <div v-if="scenarioData?.stops.length" class="stop-list">
@@ -45,7 +45,7 @@
           </div>
         </cat-msg>
       </div>
-      <div class="column" :class="columnSizeClass">
+      <div class="column is-one-quarter">
         <cat-msg variant="info" title="Routes">
           <p><strong>{{ scenarioData?.routes.length || 0 }}</strong> loaded</p>
           <div v-if="scenarioData?.routes.length" class="route-list">
@@ -58,7 +58,7 @@
           </div>
         </cat-msg>
       </div>
-      <div class="column" :class="columnSizeClass">
+      <div class="column is-one-quarter">
         <cat-msg variant="info" title="Departures">
           <p><strong>{{ stopsWithDepartures }}</strong> / {{ totalStops }} stops</p>
           <div class="more-label">
@@ -66,7 +66,7 @@
           </div>
         </cat-msg>
       </div>
-      <div class="column" :class="columnSizeClass">
+      <div class="column is-one-quarter">
         <cat-msg variant="info" title="Flex Areas">
           <p><strong>{{ scenarioData?.flexAreas?.length || 0 }}</strong> loaded</p>
           <div v-if="scenarioData?.flexAreas?.length" class="flex-list">
@@ -79,14 +79,18 @@
           </div>
         </cat-msg>
       </div>
-      <div v-if="demographicsActive" class="column" :class="columnSizeClass">
+      <!-- Full-width row below the four stage columns: the buffer passes run
+           after the other stages, and a fifth column crowds the layout. -->
+      <div v-if="demographicsActive" class="column is-full">
         <cat-msg variant="info" title="Demographics">
-          <div v-for="pass of demographicsPasses" :key="pass.stage" class="demographics-pass">
-            <cat-icon
-              size="small"
-              :icon="pass.status === 'done' ? 'check-circle' : pass.status === 'in-progress' ? 'loading' : 'circle-outline'"
-            />
-            {{ pass.label }}<span v-if="pass.count > 0"> ({{ pass.count.toLocaleString() }})</span>
+          <div class="demographics-passes">
+            <div v-for="pass of demographicsPasses" :key="pass.stage" class="demographics-pass">
+              <cat-icon
+                size="small"
+                :icon="pass.status === 'done' ? 'check-circle' : pass.status === 'in-progress' ? 'loading' : 'circle-outline'"
+              />
+              {{ pass.label }}<span v-if="pass.count > 0">&nbsp;({{ pass.count.toLocaleString() }})</span>
+            </div>
           </div>
         </cat-msg>
       </div>
@@ -127,11 +131,6 @@ const progressPercentage = computed(() => {
     completed += props.progress.bufferProgress.completed
   }
   return Math.round((completed / total) * 100)
-})
-
-// Five columns when the Demographics column shows, four otherwise.
-const columnSizeClass = computed(() => {
-  return props.demographicsActive ? 'is-one-fifth' : 'is-one-quarter'
 })
 
 // Buffer-pass order matches runBufferPasses (C/D/E/F).
@@ -240,10 +239,15 @@ function formatStage (stage: ScenarioProgress['currentStage'], stageText: string
   margin-top: 0.5rem;
 }
 
+.demographics-passes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 2rem;
+}
+
 .demographics-pass {
   font-size: 0.85rem;
   color: #6c757d;
-  margin-bottom: 0.2rem;
   display: flex;
   align-items: center;
   gap: 0.3rem;

--- a/app/composables/useBufferRefetch.ts
+++ b/app/composables/useBufferRefetch.ts
@@ -27,6 +27,13 @@ export interface UseBufferRefetchReturn {
   // Shared with the main fetch path so refetched buffer state lands in the
   // same accumulator. Parent assigns into this after each main scenario fetch.
   scenarioReceiver: ShallowRef<ScenarioDataReceiver | undefined>
+  // Whether buffer demographics were requested this session — true when the
+  // scenario loaded with `includeStopBufferDemographics`, or after loadNow().
+  // Gates the radius/layer auto-refetch watcher and the loading modal's
+  // Demographics column. Parent resets it after each main scenario fetch.
+  demographicsRequested: ShallowRef<boolean>
+  // Explicit deferred load for the "Load stop buffer demographics" buttons.
+  loadNow: () => Promise<void>
 }
 
 // Without debounce a slider drag fires one request per step.
@@ -36,6 +43,7 @@ export function useBufferRefetch (deps: UseBufferRefetchDeps): UseBufferRefetchR
   // Shared with the main fetch path so refetched buffer state lands in the
   // same accumulator.
   const scenarioReceiver = shallowRef<ScenarioDataReceiver>()
+  const demographicsRequested = shallowRef(false)
 
   // Aborted on the next radius/layer change before issuing the new request.
   let abort: AbortController | undefined
@@ -50,6 +58,15 @@ export function useBufferRefetch (deps: UseBufferRefetchDeps): UseBufferRefetchR
       return
     }
     abort?.abort()
+
+    // Radius 0 means "feature off" — clear loaded demographics rather than
+    // POSTing radius 0 (which /api/buffer-geographies rejects).
+    if (stopBufferRadius.value <= 0) {
+      receiver.clearBufferGeographies()
+      deps.scenarioData.value = receiver.getCurrentData()
+      return
+    }
+
     const localAbort = new AbortController()
     abort = localAbort
 
@@ -109,10 +126,24 @@ export function useBufferRefetch (deps: UseBufferRefetchDeps): UseBufferRefetchR
     }
   }
 
+  // Deferred load for the "Load stop buffer demographics" buttons. Once
+  // called, the radius/layer watcher takes over for subsequent changes.
+  async function loadNow (): Promise<void> {
+    if (stopBufferRadius.value <= 0) {
+      return
+    }
+    demographicsRequested.value = true
+    await refetch()
+  }
+
   // Initial query reads radius/layer via `scenarioConfig` directly; this
-  // watch only kicks in once a scenario is loaded.
+  // watch only kicks in once a scenario is loaded — and only after the user
+  // has requested demographics (with the scenario or via loadNow()).
   watch([stopBufferRadius, stopBufferLayer], () => {
     if (!scenarioReceiver.value || !deps.scenarioData.value) {
+      return
+    }
+    if (!demographicsRequested.value) {
       return
     }
     if (timer) {
@@ -129,5 +160,5 @@ export function useBufferRefetch (deps: UseBufferRefetchDeps): UseBufferRefetchR
     abort?.abort()
   })
 
-  return { scenarioReceiver }
+  return { scenarioReceiver, demographicsRequested, loadNow }
 }

--- a/app/composables/useScenarioInputs.ts
+++ b/app/composables/useScenarioInputs.ts
@@ -31,6 +31,9 @@ interface ScenarioInputs {
   // #315 — 0 disables the feature.
   stopBufferRadius: WritableComputedRef<number>
   stopBufferLayer: WritableComputedRef<string>
+  // Whether the initial scenario load includes the buffer-demographics passes.
+  // Default off — demographics are loaded on demand while browsing.
+  includeStopBufferDemographics: WritableComputedRef<boolean>
 }
 
 // URL-backed inputs that drive scenario fetching.
@@ -127,6 +130,15 @@ export function useScenarioInputs (): ScenarioInputs {
     }
   })
 
+  // Default off (note the inverted polarity vs includeFixedRoute/includeFlexAreas):
+  // the URL param is only present when demographics load with the scenario.
+  const includeStopBufferDemographics = computed<boolean>({
+    get: () => route.query.includeStopBufferDemographics?.toString() === 'true',
+    set: (v) => {
+      setQuery({ includeStopBufferDemographics: v ? 'true' : undefined })
+    }
+  })
+
   return {
     bbox,
     cannedBbox,
@@ -142,5 +154,6 @@ export function useScenarioInputs (): ScenarioInputs {
     fvids,
     stopBufferRadius,
     stopBufferLayer,
+    includeStopBufferDemographics,
   }
 }

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -106,6 +106,7 @@
             :active-tab="activeTab.sub"
             @reset-filters="resetFilters"
             @show-query="activeTab = { tab: 'query', sub: '' }"
+            @load-demographics="loadDemographics"
           />
         </div>
 
@@ -118,6 +119,7 @@
             :flex-display-features="flexFeaturesForReport"
             @open-timetable="openRouteTimetable"
             @open-buffer-details="openBufferDetails"
+            @load-demographics="loadDemographics"
           />
         </div>
 
@@ -178,6 +180,7 @@
           :error="error"
           :stop-departure-count="stopDepartureCount"
           :scenario-data="scenarioData"
+          :demographics-active="demographicsRequested"
         />
       </cat-modal>
 
@@ -310,6 +313,7 @@ const {
   fvids,
   stopBufferRadius,
   stopBufferLayer,
+  includeStopBufferDemographics,
 } = useScenarioInputs()
 const {
   startTime,
@@ -984,6 +988,7 @@ const scenarioConfig = computed((): ScenarioConfig => ({
   excludedFeeds: fvidsForConfig.value.excludedFeeds,
   stopBufferRadius: stopBufferRadius.value,
   stopBufferLayer: stopBufferLayer.value,
+  includeStopBufferDemographics: includeStopBufferDemographics.value,
 }))
 
 const scenarioFilter = computed((): ScenarioFilter => ({
@@ -1082,7 +1087,7 @@ const loadingProgress = ref<ScenarioProgress>()
 const stopDepartureCount = ref<number>(0)
 const showLoadingModal = ref(false)
 
-const { scenarioReceiver } = useBufferRefetch({
+const { scenarioReceiver, demographicsRequested, loadNow: loadDemographics } = useBufferRefetch({
   scenarioData,
   scenarioConfig,
   loadingProgress,
@@ -1139,6 +1144,9 @@ const fetchScenario = async (loadExample: string) => {
     }
   })
   scenarioReceiver.value = receiver
+  // Demographics ride along with this fetch only when opted in; otherwise the
+  // user loads them later via the "Load stop buffer demographics" buttons.
+  demographicsRequested.value = config.includeStopBufferDemographics === true
 
   let response: Response
 

--- a/src/scenario/buffer-fetcher.test.ts
+++ b/src/scenario/buffer-fetcher.test.ts
@@ -80,6 +80,13 @@ describe.skipIf(process.env.TEST_BUFFER !== 'true')('runBufferPasses (integratio
     expect(aggEvent).toBeDefined()
     const aggTracts = aggEvent!.partialData!.aggregationBufferGeographies!
     expect(aggTracts.length).toBeGreaterThan(0)
+
+    // Every event carries chunk progress; the final event completes it.
+    for (const e of events) {
+      expect(e.bufferProgress).toBeDefined()
+    }
+    const last = events[events.length - 1]!
+    expect(last.bufferProgress!.completed).toBe(last.bufferProgress!.total)
   })
 
   it('aggregation total ≤ sum of per-stop tracts (union dedupes overlaps)', async () => {

--- a/src/scenario/buffer-passes.test.ts
+++ b/src/scenario/buffer-passes.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, type Mock } from 'vitest'
+import type { GraphQLClient } from '~~/src/core'
+import { runBufferPasses } from './buffer-passes'
+import type { ScenarioProgress } from './scenario'
+
+// Unit tests for runBufferPasses chunking + bufferProgress math. The entity
+// and intersection fetchers tolerate empty GraphQL responses, so a mock
+// client is enough — each chunk and Pass F issue exactly one query.
+class MockGraphQLClient implements GraphQLClient {
+  public mockQuery: Mock = vi.fn().mockResolvedValue({ data: {} })
+
+  async query<T = any>(query: any, variables?: any): Promise<{ data?: T }> {
+    return this.mockQuery(query, variables)
+  }
+}
+
+function idRange (n: number): number[] {
+  return Array.from({ length: n }, (_, i) => i + 1)
+}
+
+async function run (stopCount: number, routeCount: number, agencyCount: number): Promise<{ events: ScenarioProgress[], client: MockGraphQLClient }> {
+  const client = new MockGraphQLClient()
+  const events: ScenarioProgress[] = []
+  await runBufferPasses({
+    radius: 400,
+    layer: 'tract',
+    geoDatasetName: 'tiger2024',
+    tableDatasetName: 'acsdt5y2021',
+    stopIds: idRange(stopCount),
+    routeIds: idRange(routeCount),
+    agencyIds: idRange(agencyCount),
+  }, client, p => events.push(p))
+  return { events, client }
+}
+
+describe('runBufferPasses progress', () => {
+  it('emits nothing for empty id sets', async () => {
+    const { events, client } = await run(0, 0, 0)
+    expect(events).toHaveLength(0)
+    expect(client.mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('reports bufferProgress across all chunks plus the aggregation pass', async () => {
+    // Default chunk sizes: 100 stops, 50 routes/agencies.
+    // 250 stops → 3 chunks, 60 routes → 2, 50 agencies → 1, +1 aggregation.
+    const { events, client } = await run(250, 60, 50)
+    const expectedTotal = 3 + 2 + 1 + 1
+
+    expect(events).toHaveLength(expectedTotal)
+    expect(client.mockQuery).toHaveBeenCalledTimes(expectedTotal)
+
+    // Stages arrive in pass order.
+    expect(events.map(e => e.currentStage)).toEqual([
+      'stop-buffer-geographies',
+      'stop-buffer-geographies',
+      'stop-buffer-geographies',
+      'route-buffer-geographies',
+      'route-buffer-geographies',
+      'agency-buffer-geographies',
+      'aggregation-buffer-geographies',
+    ])
+
+    // Every event carries the same total; completed counts up monotonically.
+    for (const [i, e] of events.entries()) {
+      expect(e.bufferProgress).toEqual({ total: expectedTotal, completed: i + 1 })
+    }
+    expect(events[events.length - 1]!.bufferProgress!.completed).toBe(expectedTotal)
+  })
+
+  it('skips the aggregation pass when there are no stops', async () => {
+    const { events } = await run(0, 10, 0)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.currentStage).toBe('route-buffer-geographies')
+    expect(events[0]!.bufferProgress).toEqual({ total: 1, completed: 1 })
+  })
+
+  it('respects custom chunk sizes', async () => {
+    const client = new MockGraphQLClient()
+    const events: ScenarioProgress[] = []
+    await runBufferPasses({
+      radius: 400,
+      layer: 'tract',
+      geoDatasetName: 'tiger2024',
+      tableDatasetName: 'acsdt5y2021',
+      stopIds: idRange(10),
+      routeIds: [],
+      agencyIds: [],
+      stopChunkSize: 4,
+    }, client, p => events.push(p))
+
+    // ceil(10/4) = 3 stop chunks + 1 aggregation.
+    expect(events).toHaveLength(4)
+    expect(events[0]!.bufferProgress).toEqual({ total: 4, completed: 1 })
+    expect(events[3]!.currentStage).toBe('aggregation-buffer-geographies')
+    expect(events[3]!.bufferProgress).toEqual({ total: 4, completed: 4 })
+  })
+})

--- a/src/scenario/buffer-passes.ts
+++ b/src/scenario/buffer-passes.ts
@@ -61,11 +61,25 @@ export async function runBufferPasses (
     { kind: 'routes', ids: config.routeIds, batchSize: entityChunkSize },
     { kind: 'agencies', ids: config.agencyIds, batchSize: entityChunkSize },
   ]
+  // Total chunk count is known up front, so the consumer can render a real
+  // progress bar. +1 for the single Pass F aggregation request.
+  const bufferProgressTotal = passes.reduce(
+    (n, p) => n + Math.ceil(p.ids.length / p.batchSize),
+    config.stopIds.length > 0 ? 1 : 0,
+  )
+  let bufferProgressCompleted = 0
+  const bufferProgress = () => ({ total: bufferProgressTotal, completed: bufferProgressCompleted })
   for (const { kind, ids, batchSize } of passes) {
     const { stage, partialKey } = BUFFER_PASS_BY_KIND[kind]
     for (const chunk of chunkArray(ids, batchSize)) {
       const results = await fetchEntityBufferGeographies(kind, { ...baseConfig, ids: chunk })
-      emit({ isLoading: true, currentStage: stage, partialData: { [partialKey]: results } })
+      bufferProgressCompleted += 1
+      emit({
+        isLoading: true,
+        currentStage: stage,
+        bufferProgress: bufferProgress(),
+        partialData: { [partialKey]: results },
+      })
     }
   }
 
@@ -90,9 +104,11 @@ export async function runBufferPasses (
         values: f.properties.values,
       }))
     console.log(`[AggregationBuffer] union over ${config.stopIds.length} stops → ${geographies.length} geographies`)
+    bufferProgressCompleted += 1
     emit({
       isLoading: true,
       currentStage: 'aggregation-buffer-geographies',
+      bufferProgress: bufferProgress(),
       partialData: { aggregationBufferGeographies: geographies },
     })
   }

--- a/src/scenario/scenario.test.ts
+++ b/src/scenario/scenario.test.ts
@@ -189,6 +189,65 @@ describe('ScenarioFetcher', () => {
     })
   })
 
+  describe('deferred buffer demographics (#315)', () => {
+    // One feed → one stop with no routes, so the only buffer ids accumulated
+    // are the stop's. Catch-all empty responses satisfy the departure and
+    // buffer queries (both tolerate empty data).
+    function makeBufferClient (): MockGraphQLClient {
+      const client = new MockGraphQLClient()
+      client.mockQuery
+        .mockResolvedValueOnce({ data: { feeds: [makeFeedGql('1')] } })
+        .mockResolvedValueOnce({ data: { stops: [
+          {
+            id: 1,
+            stop_id: 'stop_1',
+            stop_name: 'Test Stop',
+            location_type: 0,
+            geometry: { type: 'Point', coordinates: [-122.6, 45.5] },
+            census_geographies: [],
+            route_stops: []
+          }
+        ] } })
+        .mockResolvedValue({ data: {} })
+      return client
+    }
+
+    const bufferConfig: ScenarioConfig = {
+      ...config,
+      tableDatasetName: SCENARIO_DEFAULTS.tableDatasetName,
+      includeFlexAreas: false,
+      stopBufferRadius: 400,
+      stopBufferLayer: 'tract',
+    }
+
+    function bufferStages (progressCb: Mock): string[] {
+      return progressCb.mock.calls
+        .map(([p]) => p.currentStage)
+        .filter((s: string) => s.includes('buffer-geographies'))
+    }
+
+    it('runs buffer passes when includeStopBufferDemographics is undefined (CLI parity)', async () => {
+      const progressCb = vi.fn()
+      const fetcher = new ScenarioFetcher(bufferConfig, makeBufferClient(), { onProgress: progressCb })
+      await fetcher.fetch()
+
+      expect(bufferStages(progressCb)).toContain('stop-buffer-geographies')
+      expect(bufferStages(progressCb)).toContain('aggregation-buffer-geographies')
+    })
+
+    it('skips buffer passes when includeStopBufferDemographics is false', async () => {
+      const progressCb = vi.fn()
+      const fetcher = new ScenarioFetcher(
+        { ...bufferConfig, includeStopBufferDemographics: false },
+        makeBufferClient(),
+        { onProgress: progressCb },
+      )
+      await fetcher.fetch()
+
+      expect(bufferStages(progressCb)).toHaveLength(0)
+    })
+  })
+
   it('should call progress callback during fetch', async () => {
     // Mock first call returns one stop, second call returns empty to end recursion
     mockClient.mockQuery

--- a/src/scenario/scenario.ts
+++ b/src/scenario/scenario.ts
@@ -98,6 +98,10 @@ export interface ScenarioConfig {
   stopBufferRadius?: number
   // Aggregation-table rollup only fires when this is in `HIERARCHICAL_TIGER_LAYERS`.
   stopBufferLayer?: string
+  // When false, the initial scenario load skips the buffer passes even if
+  // stopBufferRadius > 0; the SPA fetches them later via /api/buffer-geographies.
+  // Undefined (CLI/WSDOT callers) is treated as enabled.
+  includeStopBufferDemographics?: boolean
 }
 
 export interface ScenarioFilter {
@@ -206,6 +210,10 @@ export interface ScenarioProgress {
   currentStageMessage?: string
   stopDepartureProgress?: { total: number, completed: number }
   feedVersionProgress?: { total: number, completed: number }
+  // Buffer-pass chunk progress (#315). Total is known up front:
+  // ceil(stops/stopChunkSize) + ceil(routes/entityChunkSize) +
+  // ceil(agencies/entityChunkSize) + 1 (aggregation, when any stops).
+  bufferProgress?: { total: number, completed: number }
   error?: any
   // Non-fatal warnings the consumer should toast. Drained per delivery.
   warnings?: string[]
@@ -537,6 +545,15 @@ export class ScenarioFetcher {
     return this.stopDepartureQueue.getProgress()
   }
 
+  // Whether this run executes the #315 buffer passes (C/D/E/F). Radius 0
+  // disables the feature outright; `includeStopBufferDemographics: false`
+  // defers them to a later /api/buffer-geographies fetch. Undefined (CLI)
+  // counts as enabled.
+  private get bufferPassesEnabled (): boolean {
+    return (this.config.stopBufferRadius ?? 0) > 0
+      && this.config.includeStopBufferDemographics !== false
+  }
+
   // Task queues
   private stopFetchQueue: TaskQueue<StopFetchTask>
   private routeFetchQueue: TaskQueue<RouteFetchTask>
@@ -765,6 +782,9 @@ export class ScenarioFetcher {
       return
     }
     this.updateProgress('census-values', true)
+    // Padding stays tied to radius alone (not bufferPassesEnabled): a deferred
+    // buffer load still needs the margin geographies for aggregation rollup,
+    // and the padding is cheap relative to the buffer passes themselves.
     const radius = this.config.stopBufferRadius && this.config.stopBufferRadius > 0
       ? this.config.stopBufferRadius
       : 0
@@ -800,7 +820,7 @@ export class ScenarioFetcher {
   private async fetchBufferData (): Promise<void> {
     const { tableDatasetName, geoDatasetName } = this.config
     const radius = this.config.stopBufferRadius ?? 0
-    if (radius <= 0 || !tableDatasetName) {
+    if (!this.bufferPassesEnabled || !tableDatasetName) {
       return
     }
     await runBufferPasses(
@@ -1009,7 +1029,7 @@ export class ScenarioFetcher {
       }
     }
 
-    if ((this.config.stopBufferRadius ?? 0) > 0) {
+    if (this.bufferPassesEnabled) {
       for (const id of stopIds) {
         this.bufferStopIds.add(id)
       }
@@ -1043,7 +1063,7 @@ export class ScenarioFetcher {
       this.updateProgress('routes', true, { routes: routeBatch })
     }
 
-    if ((this.config.stopBufferRadius ?? 0) > 0) {
+    if (this.bufferPassesEnabled) {
       for (const r of routeData) {
         this.bufferRouteIds.add(r.id)
         const aid = r.agency?.id


### PR DESCRIPTION
## Summary

Makes the expensive stop buffer demographics queries (#315, added in #352) opt-in and deferrable. The base scenario query now skips the four buffer passes by default; users can include them at query time via a new Advanced Settings checkbox, or load them on demand while browsing an already-loaded scenario via "Load stop buffer demographics" buttons that reuse the existing `/api/buffer-geographies` fetch path. The loading modal gains a Demographics row with per-pass status and a progress bar that incorporates buffer chunk progress.

## User-facing changes

### Opt-in at query time
- New "Include Stop Buffer Demographics" checkbox in Query tab → Advanced Settings → Data to Load, default off, with a tooltip linking it to the Stop statistical radius control. URL-backed, so shared links carry it.
- Default queries load noticeably faster since the per-stop / per-route / per-agency / aggregation buffer passes are skipped.

### Deferred load while browsing
- When demographics weren't loaded with the scenario, a notice with a "Load stop buffer demographics" button appears in Filters → Fixed-Route Services (below the radius/layer controls) and above the Report tab's Stops, Routes, Agencies, and Stops (Aggregated) tables.
- Clicking it runs the buffer-only fetch with the current radius/layer; the loading modal shows live progress. After this first load, radius/layer changes auto-refetch exactly as before.
- The radius slider and buffer-layer select stay adjustable before loading — changes simply don't fetch until the user opts in.
- Dragging the radius to 0 after a load now clears demographics cleanly instead of issuing a request the server rejects.

### Loading modal
- New full-width "Demographics" row beneath the four stage columns (shown only when demographics load this run) listing the four passes — Stops, Routes, Agencies, Aggregation — horizontally with pending / in-progress / done icons and result counts.
- The progress bar now includes buffer chunk progress, for both initial and deferred loads.

### Correct gating when demographics are absent
- Census columns, the derivation drill-down, the aggregation-layer "(needs radius = 0)" restrictions, and the apportionment warning banner now key off "buffer data actually loaded" rather than radius > 0 — so a deferred state shows no empty demographic columns and no spurious layer restrictions.
- "Show Agg. Areas" is intentionally unchanged: the choropleth works from main-pipeline census geographies and degrades gracefully without buffer data.

## Implementation details

### Config and pipeline
- `ScenarioConfig.includeStopBufferDemographics?: boolean` — `false` defers the buffer passes even when `stopBufferRadius > 0`; `undefined` (CLI/WSDOT callers) is treated as enabled, preserving their behavior. Applied via a `bufferPassesEnabled` getter in `fetchBufferData()` and both buffer-id accumulation sites.
- Census-values bbox padding stays tied to radius alone (not the new flag) so a later deferred load still has the margin geographies needed for aggregation rollup.
- `ScenarioProgress.bufferProgress { total, completed }` — total is known up front (stop chunks + route chunks + agency chunks + 1 aggregation pass); `runBufferPasses` increments per chunk. Both the inline pipeline and the standalone `/api/buffer-geographies` stream get this for free.

### Client state
- `useScenarioInputs` adds URL-backed `includeStopBufferDemographics` (default off; param present only when on — inverted polarity vs `includeFixedRoute`).
- `useBufferRefetch` exposes `demographicsRequested` (gates the radius/layer auto-refetch watcher and the modal's Demographics row; reset from config on each main fetch) and `loadNow()` (sets the gate and refetches). A radius ≤ 0 guard in `refetch()` clears buffer geographies instead of POSTing.
- The deferred load needs no extra progress wiring: it streams into the same `ScenarioDataReceiver` as the main fetch, whose `onProgress` callback already drives the modal.
- `bufferDataActive` (radius > 0 AND `stopBufferGeographies` populated) is the single gating computed in `filter.vue` and `report.vue`.
- New shared `cal-buffer-demographics-notice` component (with a compact variant for the report tab) keeps the prompt copy and behavior consistent; all instances funnel through the same `loadNow()`.

### Tests
- New `src/scenario/buffer-passes.test.ts` (no live server): chunk math, monotonic `bufferProgress`, aggregation-pass skip for empty stop sets, custom chunk sizes.
- `scenario.test.ts`: buffer passes run when the flag is `undefined` (CLI parity) and are skipped when `false`, with radius > 0.
- `buffer-fetcher.test.ts` (TEST_BUFFER-gated integration): asserts `bufferProgress` presence and completion.

## User test plan

- Run a default browse query (checkbox off): load completes faster, the loading modal shows no Demographics row, report tables have no demographic columns, the aggregation layer select has no "(needs radius = 0)" restrictions, and Show Agg. Areas still works with full ACS values.
- Open Filters → Fixed-Route Services and the Report tab's Stops/Routes/Agencies/Aggregated views: the "Load stop buffer demographics" notice appears in each. Click it once: the loading modal opens with the Demographics row advancing per pass; afterwards demographic columns and drill-down appear everywhere, all notices disappear, and the aggregation-layer restriction applies.
- After loading, change radius or buffer layer: the debounced auto-refetch fires as before this PR.
- Drag radius to 0 after loading: demographics clear without an error; raise it again: a refetch fires.
- Re-run a query with the Advanced Settings checkbox on: demographics load with the scenario and the modal shows the Demographics row during the initial load — end-to-end behavior matches pre-PR defaults.
- Share a URL with the checkbox on (`includeStopBufferDemographics=true`): the recipient's query includes demographics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
