### PR TITLE
Bump @interline-io/catenary to 0.3.0 (top-layer tooltips)

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -45,14 +45,6 @@ $duration: 1000ms;
     overflow: visible !important; /* so datetime picker isn't hidden */
 }
 
-.tooltip-trigger {
-    border: none;
-}
-.cat-tooltip::after {
-    text-transform: none; // Prevent inheriting text-transform from parent elements (e.g., menu-label)
-    font-weight: normal; // Reset font weight that might be inherited
-}
-
 // Ensure modal is always on top
 .cat-modal {
   z-index: 99999 !important;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@aitodotai/json-stringify-pretty-compact": "1.3.0",
-    "@interline-io/catenary": "0.2.0",
+    "@interline-io/catenary": "0.3.0",
     "@mdi/font": "7.4.47",
     "@interline-io/tlv2-auth": "0.1.0-sha.ad5c03e",
     "@apollo/client": "3.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 3.13.4
         version: 3.13.4(graphql@16.10.0)
       '@interline-io/catenary':
-        specifier: 0.2.0
-        version: 0.2.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
+        specifier: 0.3.0
+        version: 0.3.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       '@interline-io/tlv2-auth':
         specifier: 0.1.0-sha.ad5c03e
         version: 0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
@@ -735,8 +735,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@interline-io/catenary@0.2.0':
-    resolution: {integrity: sha512-PpPSD4//+uDBz/5EEkL/4Hi70K1JapdymYvkH8iiOy5PMtcP3KJpqAA4OkIOl+XkI7lHZqowDQEkKndngisKMQ==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.2.0/324cddb718db5a7f124fa5e509e4d9db4e6bef46}
+  '@interline-io/catenary@0.3.0':
+    resolution: {integrity: sha512-awh02KzQQahEhcDNHf5BOuEgYi8xroxHwC0SzHNTRa2DzK7sZ+LXosz7jv7TBroDcMSZvtuyPb0NGKZLqB68Sg==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.3.0/30da3cf17f04b8a82f640a3349f06ec4d535a99b}
     peerDependencies:
       '@mdi/font': ^7.4.0
       bulma: ^1.0.0
@@ -5699,7 +5699,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@interline-io/catenary@0.2.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/catenary@0.3.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@mdi/font': 7.4.47
       bulma: 1.0.4


### PR DESCRIPTION
## Summary

Updates `@interline-io/catenary` from 0.2.0 to 0.3.0, picking up the cat-tooltip rework ([interline-io/catenary#25](https://github.com/interline-io/catenary/pull/25)): tooltip bubbles now render in the browser's top layer via the Popover API, with self-contained typography. This fixes the two tooltip regressions reported in the Filters sidebar — bubbles clipped by the overflow-scrolling subpanel, and uppercase/letter-spacing inherited from Bulma's `.menu-label`. The now-redundant CSS overrides are removed from `main.scss`.

## User-facing changes

### Tooltips
- Tooltips in the Filters side panels (e.g. the "Stop statistical radius" info icon, Timeframes tooltips) are no longer cut off at the panel edges — bubbles float above the subpanel, tab bar, and any other overflow/stacking context.
- Tooltip text renders in normal sentence case everywhere, including inside uppercase menu labels.
- Bubbles flip and clamp to stay fully on-screen, with the arrow continuing to point at the trigger.
- Tooltips inside modals now reliably render above the modal.

## Implementation details

### Dependency bump
- `@interline-io/catenary` 0.2.0 → 0.3.0; lockfile updated. The release renders the tooltip bubble as a `popover="manual"` element in the top layer (escaping ancestor `overflow` clipping and z-index stacking while staying in the component subtree for ARIA and scoped styles), positions it from real measurements with viewport clamping, and hardens bubble typography (`text-transform`, `letter-spacing`, `font-weight`, `text-align`, `font-style`). Browsers without the Popover API keep the previous absolutely-positioned behavior.

### Stale override removal (`app/assets/main.scss`)
- Removed `.cat-tooltip::after { text-transform; font-weight }` — the bubble is no longer a pseudo-element and resets its own typography, so the rule matched nothing.
- Removed the oruga-era `.tooltip-trigger { border: none }` rule — the class no longer exists in catenary.
- Audited remaining tooltip CSS per the catenary changeset's CSS-impact notes: all other `cat-tooltip` references are template usages, and `datagrid.vue`'s `.col-header-tooltip` styles wrapper layout only (DOM-shape independent).

## User test plan

- Open Filters → Fixed-Route Services and hover the "Stop statistical radius" info icon: the tooltip renders fully visible (over the tab bar / panel boundary) in sentence case with normal letter spacing.
- Hover the Timeframes tab tooltips and the Buffer layer tooltip: no clipping at the left/right panel edges; the arrow points at the trigger.
- Hover tooltips near the viewport edges (e.g. datagrid column-header tooltips on the Report tab): bubbles flip/clamp to stay on-screen.
- Open the feed-version picker modal and hover any tooltip inside it: the bubble renders above the modal.
- Keyboard: Tab to a tooltip trigger (bubble appears on focus), press Escape (bubble dismisses).
- Spot-check non-tooltip Catenary widgets (buttons, selects, modal, datagrid) for visual regressions from the version bump.

closes https://github.com/interline-io/calact-network-analysis-tool/issues/384