### PR TITLE
Feed Archive: combined date range and historical feed version selection

### DIFF
--- a/app/components/cal/end-date-field.vue
+++ b/app/components/cal/end-date-field.vue
@@ -1,0 +1,97 @@
+<template>
+  <cat-field>
+    <template #label>
+      <slot name="label">
+        End date
+      </slot>
+    </template>
+    <div v-if="!singleDay" class="cal-end-date-field-range">
+      <cat-datepicker
+        ref="endPickerRef"
+        v-model="endModel"
+        :min-date="minDate"
+        :max-date="maxDate"
+        :years-range="yearsRange"
+        :variant="invalid ? 'danger' : undefined"
+        readonly
+      />
+      <!-- TODO: catenary >0.3.0 declares aria-label/title as cat-button
+           props; on the next bump, replace this v-bind workaround with
+           plain attributes. -->
+      <cat-button
+        icon="close"
+        v-bind="{ 'aria-label': 'Remove end date', 'title': singleDayTitle }"
+        @click="emit('update:singleDay', true)"
+      />
+    </div>
+    <cat-button v-else ref="setEndButtonRef" @click="emit('update:singleDay', false)">
+      Set an end date
+    </cat-button>
+    <p v-if="beforeStart" class="help is-danger">
+      End date must be on or after the start date.
+    </p>
+  </cat-field>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch, type ComponentPublicInstance } from 'vue'
+
+// Shared end-date control: a date picker plus a single-day toggle, used by both
+// the Query panel and the Feed Archive modal so the toggle markup, the
+// catenary aria/title workaround, the "on or after" validity help, and the
+// keyboard-focus handling (#361) live in one place. The owner keeps the
+// single-day data invariant (e.g. end === start, or bumping to a default end);
+// this component only emits the intent.
+const props = withDefaults(defineProps<{
+  end: Date
+  singleDay: boolean
+  minDate: Date
+  maxDate: Date
+  // Relative year offsets [before, after] from the current year, for the
+  // picker's year dropdown.
+  yearsRange: [number, number]
+  // Renders the end picker in a danger variant (e.g. out of range / before start).
+  invalid?: boolean
+  // Shows the "End date must be on or after the start date" help.
+  beforeStart?: boolean
+  // Title/tooltip on the "remove end date" button.
+  singleDayTitle?: string
+}>(), {
+  invalid: false,
+  beforeStart: false,
+  singleDayTitle: 'Remove end date (analyze a single day)',
+})
+
+const emit = defineEmits<{
+  (e: 'update:end', value: Date): void
+  (e: 'update:singleDay', value: boolean): void
+}>()
+
+const endModel = computed<Date>({
+  get: () => props.end,
+  set: (v) => { emit('update:end', v) },
+})
+
+const endPickerRef = ref<{ focus: () => void } | null>(null)
+const setEndButtonRef = ref<ComponentPublicInstance | null>(null)
+
+// #361 — keep keyboard focus sensible across the toggle: move into the end
+// picker when it appears, onto the "Set an end date" button when it replaces it.
+watch(() => props.singleDay, async (single) => {
+  await nextTick()
+  if (single) {
+    const el = setEndButtonRef.value?.$el as HTMLElement | undefined
+    el?.focus?.()
+  } else {
+    endPickerRef.value?.focus()
+  }
+})
+</script>
+
+<style scoped>
+.cal-end-date-field-range {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+</style>

--- a/app/components/cal/end-date-field.vue
+++ b/app/components/cal/end-date-field.vue
@@ -15,12 +15,12 @@
         :variant="invalid ? 'danger' : undefined"
         readonly
       />
-      <!-- TODO: catenary >0.3.0 declares aria-label/title as cat-button
-           props; on the next bump, replace this v-bind workaround with
-           plain attributes. -->
+      <!-- camelCase keys in a v-bind object: matches the ariaLabel/title props
+           (catenary 0.4.0) and avoids vue/attribute-hyphenation rewriting a
+           camelCase attribute back to kebab (which vue-tsc won't map to the prop). -->
       <cat-button
         icon="close"
-        v-bind="{ 'aria-label': 'Remove end date', 'title': singleDayTitle }"
+        v-bind="{ ariaLabel: 'Remove end date', title: singleDayTitle }"
         @click="emit('update:singleDay', true)"
       />
     </div>

--- a/app/components/cal/feed-version-import-button.vue
+++ b/app/components/cal/feed-version-import-button.vue
@@ -41,6 +41,7 @@
 import { computed } from 'vue'
 import {
   effectiveImportStatus,
+  FEED_VERSION_IMPORT_STATUS_LABELS,
   JOB_TERMINAL_STATES,
   type FeedVersionDetail,
   type FeedVersionImportStatus,
@@ -58,13 +59,6 @@ const emit = defineEmits<{
   (e: 'import', fvId: number): void
   (e: 'unimport', fvId: number): void
 }>()
-
-const STATUS_LABELS: Record<FeedVersionImportStatus, string> = {
-  imported: 'Imported',
-  in_progress: 'In progress…',
-  error: 'Error',
-  not_imported: 'Not imported',
-}
 
 // Bulma-ish palette: success green, info blue, danger red, neutral grey.
 const STATUS_COLORS: Record<FeedVersionImportStatus, string> = {
@@ -88,7 +82,7 @@ const isWatching = computed(() => {
 // (Queued / Running) instead of the generic "In progress…".
 const statusLabel = computed(() => {
   if (isWatching.value) { return capitalize(props.pendingJob?.state || '') }
-  return STATUS_LABELS[status.value]
+  return FEED_VERSION_IMPORT_STATUS_LABELS[status.value]
 })
 const statusColor = computed(() => STATUS_COLORS[status.value])
 

--- a/app/components/cal/feed-version-import-button.vue
+++ b/app/components/cal/feed-version-import-button.vue
@@ -5,13 +5,13 @@
          action is a regular bordered button. -->
     <cat-tooltip v-if="errorTooltip" :text="errorTooltip">
       <span class="cal-fv-import-status">
-        <span class="cal-fv-import-status-dot" :style="{ background: statusColor }" />
+        <span class="cal-fv-import-status-dot" :class="`is-${status}`" />
         {{ statusLabel }}
       </span>
     </cat-tooltip>
     <span v-else class="cal-fv-import-status">
       <cat-icon v-if="isWatching" icon="clock" size="small" />
-      <span v-else class="cal-fv-import-status-dot" :style="{ background: statusColor }" />
+      <span v-else class="cal-fv-import-status-dot" :class="`is-${status}`" />
       {{ statusLabel }}
     </span>
 
@@ -44,7 +44,6 @@ import {
   FEED_VERSION_IMPORT_STATUS_LABELS,
   JOB_TERMINAL_STATES,
   type FeedVersionDetail,
-  type FeedVersionImportStatus,
   type FeedVersionPendingJob,
 } from '~~/src/tl'
 import { capitalize } from '~~/src/core'
@@ -59,14 +58,6 @@ const emit = defineEmits<{
   (e: 'import', fvId: number): void
   (e: 'unimport', fvId: number): void
 }>()
-
-// Bulma-ish palette: success green, info blue, danger red, neutral grey.
-const STATUS_COLORS: Record<FeedVersionImportStatus, string> = {
-  imported: '#48c78e',
-  in_progress: '#1d6fb8',
-  error: '#f14668',
-  not_imported: '#b5b5b5',
-}
 
 const status = computed(() => effectiveImportStatus(props.fv, props.pendingJob))
 const canImport = computed(() => status.value === 'not_imported' || status.value === 'error')
@@ -84,8 +75,6 @@ const statusLabel = computed(() => {
   if (isWatching.value) { return capitalize(props.pendingJob?.state || '') }
   return FEED_VERSION_IMPORT_STATUS_LABELS[status.value]
 })
-const statusColor = computed(() => STATUS_COLORS[status.value])
-
 const actionLabel = computed(() => {
   if (isWatching.value) { return '' }
   if (status.value === 'error') { return 'Retry' }
@@ -147,6 +136,20 @@ function onAction () {
   height: 8px;
   border-radius: 50%;
   flex: 0 0 auto;
+  background: var(--bulma-grey, #b5b5b5);
+}
+/* Status drives the dot color via Bulma's semantic theme variables. */
+.cal-fv-import-status-dot.is-imported {
+  background: var(--bulma-success, #48c78e);
+}
+.cal-fv-import-status-dot.is-in_progress {
+  background: var(--bulma-info, #1d6fb8);
+}
+.cal-fv-import-status-dot.is-error {
+  background: var(--bulma-danger, #f14668);
+}
+.cal-fv-import-status-dot.is-not_imported {
+  background: var(--bulma-grey, #b5b5b5);
 }
 .cal-fv-import-action {
   flex: 0 0 auto;

--- a/app/components/cal/feed-version-import-button.vue
+++ b/app/components/cal/feed-version-import-button.vue
@@ -1,24 +1,29 @@
 <template>
   <div class="cal-fv-import-button">
+    <!-- Status is read-only — a plain dot + label (same visual language as
+         the row's "active" dot) so it can't be mistaken for a control. The
+         action is a regular bordered button. -->
     <cat-tooltip v-if="errorTooltip" :text="errorTooltip">
-      <cat-button
-        class="cal-fv-import-button-cta"
-        variant="danger"
-        :disabled="!canAct"
-        @click="onClick"
-      >
-        {{ buttonLabel }}
-      </cat-button>
+      <span class="cal-fv-import-status">
+        <span class="cal-fv-import-status-dot" :style="{ background: statusColor }" />
+        {{ statusLabel }}
+      </span>
     </cat-tooltip>
+    <span v-else class="cal-fv-import-status">
+      <cat-icon v-if="isWatching" icon="clock" size="small" />
+      <span v-else class="cal-fv-import-status-dot" :style="{ background: statusColor }" />
+      {{ statusLabel }}
+    </span>
+
     <cat-button
-      v-else
-      class="cal-fv-import-button-cta"
-      :disabled="!canAct"
-      :icon-left="isWatching ? 'clock' : undefined"
-      @click="onClick"
+      v-if="actionLabel"
+      size="small"
+      class="cal-fv-import-action"
+      @click="onAction"
     >
-      {{ buttonLabel }}
+      {{ actionLabel }}
     </cat-button>
+
     <a
       v-if="statusUrl"
       :href="statusUrl"
@@ -54,26 +59,46 @@ const emit = defineEmits<{
   (e: 'unimport', fvId: number): void
 }>()
 
-const ACTION_LABELS: Record<FeedVersionImportStatus, string> = {
+const STATUS_LABELS: Record<FeedVersionImportStatus, string> = {
   imported: 'Imported',
   in_progress: 'In progress…',
-  error: 'Retry',
-  not_imported: 'Import',
+  error: 'Error',
+  not_imported: 'Not imported',
+}
+
+// Bulma-ish palette: success green, info blue, danger red, neutral grey.
+const STATUS_COLORS: Record<FeedVersionImportStatus, string> = {
+  imported: '#48c78e',
+  in_progress: '#1d6fb8',
+  error: '#f14668',
+  not_imported: '#b5b5b5',
 }
 
 const status = computed(() => effectiveImportStatus(props.fv, props.pendingJob))
 const canImport = computed(() => status.value === 'not_imported' || status.value === 'error')
 // Active FVs are protected — unimporting one would orphan the feed's pointer.
 const canUnimport = computed(() => status.value === 'imported' && !props.isActive)
-const canAct = computed(() => canImport.value || canUnimport.value)
 
 const isWatching = computed(() => {
   const p = props.pendingJob
   return !!p && !JOB_TERMINAL_STATES.has(p.state)
 })
-const watchLabel = computed(() => capitalize(props.pendingJob?.state || ''))
 
-const buttonLabel = computed(() => isWatching.value ? watchLabel.value : ACTION_LABELS[status.value])
+// While a job submitted this session is live, the tag tracks the job state
+// (Queued / Running) instead of the generic "In progress…".
+const statusLabel = computed(() => {
+  if (isWatching.value) { return capitalize(props.pendingJob?.state || '') }
+  return STATUS_LABELS[status.value]
+})
+const statusColor = computed(() => STATUS_COLORS[status.value])
+
+const actionLabel = computed(() => {
+  if (isWatching.value) { return '' }
+  if (status.value === 'error') { return 'Retry' }
+  if (canImport.value) { return 'Import' }
+  if (canUnimport.value) { return 'Unimport' }
+  return ''
+})
 
 const statusUrl = computed(() => {
   // Empty jobId is the optimistic-submit placeholder window; suppress the
@@ -98,7 +123,7 @@ const errorTooltip = computed(() => {
     : msg
 })
 
-function onClick () {
+function onAction () {
   if (canImport.value) {
     emit('import', props.fv.id)
   } else if (canUnimport.value) {
@@ -114,8 +139,23 @@ function onClick () {
   gap: 6px;
   width: 100%;
 }
-.cal-fv-import-button-cta {
-  flex: 1 1 auto;
+.cal-fv-import-status {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #555;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+.cal-fv-import-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.cal-fv-import-action {
+  flex: 0 0 auto;
 }
 .cal-fv-import-button-link {
   flex: 0 0 auto;

--- a/app/components/cal/feed-version-list.vue
+++ b/app/components/cal/feed-version-list.vue
@@ -53,9 +53,11 @@
       :excluded="excluded"
       :radio-group="feed.onestop_id"
       :pending-job="pendingJobs?.[fv.id] ?? null"
+      :range-editable="rangeEditable"
       @import="emit('import', $event)"
       @unimport="emit('unimport', $event)"
       @select="emit('select', $event)"
+      @update:analysis-range="emit('update:analysisRange', $event)"
     />
   </cat-card>
 </template>
@@ -77,6 +79,8 @@ const props = defineProps<{
   excluded?: boolean
   // Keyed by feed-version id; owner (picker) drives the map.
   pendingJobs?: Record<number, FeedVersionPendingJob>
+  // Modal context: rows render a draggable analysis window.
+  rangeEditable?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -84,6 +88,7 @@ const emit = defineEmits<{
   (e: 'unimport', fvId: number): void
   (e: 'select', fvId: number): void
   (e: 'exclude', value: boolean): void
+  (e: 'update:analysisRange', value: { start: string, end: string }): void
 }>()
 
 const activeFvId = computed(() => props.feed.feed_state?.feed_version?.id ?? null)

--- a/app/components/cal/feed-version-override-summary.vue
+++ b/app/components/cal/feed-version-override-summary.vue
@@ -76,7 +76,9 @@ const pickItems = computed<PickItem[]>(() => {
       detail: row
         ? {
             fetched: fmtDate(row.fetched_at, 'MMM d, yyyy') || row.fetched_at,
-            coverage: `${row.earliest_calendar_date} – ${row.latest_calendar_date}`,
+            coverage: row.earliest_calendar_date && row.latest_calendar_date
+              ? `${row.earliest_calendar_date} – ${row.latest_calendar_date}`
+              : 'no calendar dates',
             sha1Short: (row.sha1 || '').slice(0, 7),
           }
         : null,

--- a/app/components/cal/feed-version-override-summary.vue
+++ b/app/components/cal/feed-version-override-summary.vue
@@ -1,0 +1,103 @@
+<template>
+  <div v-if="overrideCount > 0" class="cal-fv-override-summary">
+    <ul v-if="pickItems.length > 0" class="cal-fv-override-summary-list">
+      <li v-for="item in pickItems" :key="item.onestopId">
+        <strong>{{ item.feedLabel }}</strong>
+        <template v-if="item.detail">
+          — fetched {{ item.detail.fetched }} ·
+          covers {{ item.detail.coverage }} ·
+          <code>{{ item.detail.sha1Short }}</code>
+        </template>
+        <template v-else-if="loading">
+          — loading…
+        </template>
+        <template v-else>
+          — <span class="has-text-danger">feed version #{{ item.fvId }} not found</span>
+        </template>
+      </li>
+    </ul>
+    <p v-if="excludedList.length > 0" class="cal-fv-override-summary-excluded">
+      <strong>Excluded:</strong> {{ excludedList.join(', ') }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import {
+  feedVersionsByIdsQuery,
+  parseFvids,
+  type FeedVersionSummaryRow,
+} from '~~/src/tl'
+import { fmtDate } from '~~/src/core'
+
+// Quick-reference list of the active feed version overrides — enough detail
+// per pick (feed, fetched date, coverage, sha1) that the user doesn't have to
+// reopen the modal to recall what their query will run against.
+const props = defineProps<{
+  // fvids CSV — see parseFvids for the encoding.
+  fvids: string
+}>()
+
+const parsed = computed(() => parseFvids(props.fvids))
+const overrideCount = computed(() => parsed.value.picks.size + parsed.value.excluded.size)
+const pickIds = computed(() => [...parsed.value.picks.values()])
+
+const { result, loading } = useQuery<{ feed_versions: FeedVersionSummaryRow[] }>(
+  feedVersionsByIdsQuery,
+  () => ({ ids: pickIds.value }),
+  () => ({ enabled: pickIds.value.length > 0 })
+)
+
+const detailById = computed<Map<number, FeedVersionSummaryRow>>(() => {
+  const out = new Map<number, FeedVersionSummaryRow>()
+  for (const fv of result.value?.feed_versions || []) {
+    out.set(Number(fv.id), fv)
+  }
+  return out
+})
+
+interface PickItem {
+  onestopId: string
+  fvId: number
+  feedLabel: string
+  detail: { fetched: string, coverage: string, sha1Short: string } | null
+}
+
+const pickItems = computed<PickItem[]>(() => {
+  const items: PickItem[] = []
+  for (const [onestopId, fvId] of parsed.value.picks) {
+    const row = detailById.value.get(fvId)
+    items.push({
+      onestopId,
+      fvId,
+      feedLabel: row?.feed?.name || onestopId,
+      detail: row
+        ? {
+            fetched: fmtDate(row.fetched_at, 'MMM d, yyyy') || row.fetched_at,
+            coverage: `${row.earliest_calendar_date} – ${row.latest_calendar_date}`,
+            sha1Short: (row.sha1 || '').slice(0, 7),
+          }
+        : null,
+    })
+  }
+  return items
+})
+
+const excludedList = computed(() => [...parsed.value.excluded].sort())
+</script>
+
+<style scoped>
+.cal-fv-override-summary {
+  font-size: 0.85rem;
+  color: #444;
+}
+.cal-fv-override-summary-list {
+  list-style: disc;
+  margin-left: 1.2em;
+}
+.cal-fv-override-summary-excluded {
+  margin-top: 2px;
+}
+</style>

--- a/app/components/cal/feed-version-picker-modal.vue
+++ b/app/components/cal/feed-version-picker-modal.vue
@@ -104,6 +104,8 @@ import CalFeedVersionPicker from '~/components/cal/feed-version-picker.vue'
 import { parseFvids, serializeFvids } from '~~/src/tl'
 import {
   asDateString,
+  defaultEndDate,
+  defaultStartDate,
   fmtDate,
   normalizeDate,
   parseDate,
@@ -114,7 +116,6 @@ import {
   wideMinAllowedDate,
   type Bbox,
 } from '~~/src/core'
-import { defaultEndDate, defaultStartDate } from '~/composables/useScenarioInputs'
 
 const props = withDefaults(defineProps<{
   open: boolean

--- a/app/components/cal/feed-version-picker-modal.vue
+++ b/app/components/cal/feed-version-picker-modal.vue
@@ -20,35 +20,16 @@
           readonly
         />
       </cat-field>
-      <cat-field>
-        <template #label>
-          End date
-        </template>
-        <div v-if="!stagedSingleDay" class="cal-fv-modal-end-date">
-          <cat-datepicker
-            v-model="stagedEnd"
-            :min-date="wideMinDate"
-            :max-date="wideMaxDate"
-            :years-range="wideYearsRange"
-            :variant="stagedEndValid ? undefined : 'danger'"
-            readonly
-          />
-          <!-- TODO: catenary >0.3.0 declares aria-label/title as cat-button
-               props; on the next bump, replace this v-bind workaround with
-               plain attributes. -->
-          <cat-button
-            icon="close"
-            v-bind="{ 'aria-label': 'Remove end date', 'title': 'Remove end date (analyze a single day)' }"
-            @click="toggleStagedSingleDay"
-          />
-        </div>
-        <cat-button v-else @click="toggleStagedSingleDay">
-          Set an end date
-        </cat-button>
-        <p v-if="!stagedEndValid" class="help is-danger">
-          End date must be on or after the start date.
-        </p>
-      </cat-field>
+      <cal-end-date-field
+        v-model:end="stagedEnd"
+        :single-day="stagedSingleDay"
+        :min-date="wideMinDate"
+        :max-date="wideMaxDate"
+        :years-range="wideYearsRange"
+        :invalid="!stagedEndValid"
+        :before-start="!stagedEndValid"
+        @update:single-day="onToggleSingleDay"
+      />
       <div class="cal-fv-modal-dates-summary">
         <p>
           Analysis window:
@@ -90,7 +71,7 @@
         <cat-button variant="light" :disabled="feedOnestopIds.length === 0" @click="onExcludeAll">
           Exclude all
         </cat-button>
-        <cat-button variant="primary" :disabled="!stagedEndValid" @click="onApply">
+        <cat-button variant="primary" :disabled="!stagedEndValid || !stagedDatesInRange" @click="onApply">
           Apply
         </cat-button>
       </div>
@@ -101,6 +82,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import CalFeedVersionPicker from '~/components/cal/feed-version-picker.vue'
+import CalEndDateField from '~/components/cal/end-date-field.vue'
 import { parseFvids, serializeFvids } from '~~/src/tl'
 import {
   asDateString,
@@ -179,27 +161,54 @@ const stagedEndEffective = computed<Date>(() =>
 
 const stagedEndValid = computed(() => validEndDate(stagedStart.value, stagedEnd.value, stagedSingleDay.value))
 
+// Staged dates must stay within the wide allowed range. The header pickers
+// enforce this via min/max, but timeline drags and arrow-key nudges write
+// dates directly (onAnalysisRange) — clamp there and guard Apply so the modal
+// can never commit a window the Query panel would reject.
+function inWideRange (d: Date | undefined): boolean {
+  const n = normalizeDate(d)
+  if (!n) { return false }
+  return n >= wideMinDate && n <= wideMaxDate
+}
+function clampToWide (d: Date): Date {
+  if (d.valueOf() < wideMinDate.valueOf()) { return new Date(wideMinDate) }
+  if (d.valueOf() > wideMaxDate.valueOf()) { return new Date(wideMaxDate) }
+  return d
+}
+const stagedDatesInRange = computed(() =>
+  inWideRange(stagedStart.value) && (stagedSingleDay.value || inWideRange(stagedEnd.value)))
+
 const windowLabel = computed(() => {
   const s = fmtDate(stagedStart.value, 'MMM d, yyyy')
   if (stagedSingleDay.value) { return s }
   return `${s} – ${fmtDate(stagedEndEffective.value, 'MMM d, yyyy')}`
 })
 
-function toggleStagedSingleDay () {
-  stagedSingleDay.value = !stagedSingleDay.value
-  if (!stagedSingleDay.value && normalizeDate(stagedEnd.value)! < normalizeDate(stagedStart.value)!) {
-    stagedEnd.value = defaultEndDate(stagedStart.value)
+// Toggling off single-day always leaves a real multi-day window: bump the end
+// to the default (start + 6) whenever it isn't already after the start, so the
+// user never lands in range mode showing a zero-length end === start window.
+function onToggleSingleDay (single: boolean) {
+  stagedSingleDay.value = single
+  if (!single) {
+    const s = normalizeDate(stagedStart.value)!
+    const e = normalizeDate(stagedEnd.value)
+    if (!e || e <= s) {
+      stagedEnd.value = defaultEndDate(stagedStart.value)
+    }
   }
 }
 
-// Snap actions and timeline window drags land here as ISO date strings.
+// Snap actions and timeline window drags land here as ISO date strings,
+// clamped to the wide allowed range (the drag domain can extend past it).
 function onAnalysisRange (range: { start: string, end: string }) {
   const start = parseDate(range.start)
   const end = parseDate(range.end)
   if (!start || !end) { return }
-  stagedStart.value = start
-  stagedEnd.value = end
-  stagedSingleDay.value = range.start === range.end
+  const clampedStart = clampToWide(start)
+  const clampedEnd = clampToWide(end)
+  stagedStart.value = clampedStart
+  stagedEnd.value = clampedEnd
+  stagedSingleDay.value = asDateString(clampedStart) === asDateString(clampedEnd)
 }
 
 function onFeedList (ids: string[]) {
@@ -251,11 +260,6 @@ function onReset () {
 }
 .cal-fv-modal-dates-summary {
   flex: 1 1 280px;
-}
-.cal-fv-modal-end-date {
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
 .cal-fv-modal-count {
   margin-right: auto;

--- a/app/components/cal/feed-version-picker-modal.vue
+++ b/app/components/cal/feed-version-picker-modal.vue
@@ -1,16 +1,79 @@
 <template>
   <cat-modal
     v-model="modelOpen"
-    title="Pick feed versions"
+    title="Feed Archive: dates & feed versions"
     full-screen
   >
+    <div class="cal-fv-modal-dates">
+      <cat-field>
+        <template #label>
+          <cat-tooltip text="The start date is used to define which week is used to calculate the days-of-week on which a route runs or a stop is served.">
+            Start date
+            <cat-icon size="small" icon="information" />
+          </cat-tooltip>
+        </template>
+        <cat-datepicker
+          v-model="stagedStart"
+          :min-date="wideMinDate"
+          :max-date="wideMaxDate"
+          :years-range="wideYearsRange"
+          readonly
+        />
+      </cat-field>
+      <cat-field>
+        <template #label>
+          End date
+        </template>
+        <div v-if="!stagedSingleDay" class="cal-fv-modal-end-date">
+          <cat-datepicker
+            v-model="stagedEnd"
+            :min-date="wideMinDate"
+            :max-date="wideMaxDate"
+            :years-range="wideYearsRange"
+            :variant="stagedEndValid ? undefined : 'danger'"
+            readonly
+          />
+          <!-- TODO: catenary >0.3.0 declares aria-label/title as cat-button
+               props; on the next bump, replace this v-bind workaround with
+               plain attributes. -->
+          <cat-button
+            icon="close"
+            v-bind="{ 'aria-label': 'Remove end date', 'title': 'Remove end date (analyze a single day)' }"
+            @click="toggleStagedSingleDay"
+          />
+        </div>
+        <cat-button v-else @click="toggleStagedSingleDay">
+          Set an end date
+        </cat-button>
+        <p v-if="!stagedEndValid" class="help is-danger">
+          End date must be on or after the start date.
+        </p>
+      </cat-field>
+      <div class="cal-fv-modal-dates-summary">
+        <p>
+          Analysis window:
+          <strong>{{ windowLabel }}</strong>
+          <span v-if="overrideCount > 0"> · {{ overrideCount }} feed version override{{ overrideCount === 1 ? '' : 's' }}</span>
+        </p>
+        <p class="help">
+          The Feed Archive holds every fetched version of each feed. Pin a
+          version per feed, exclude feeds, or import an older version to
+          analyze historical dates. Drag the highlighted window on a timeline
+          to retarget the analysis dates. Changes take effect when you click
+          <em>Apply</em>.
+        </p>
+      </div>
+    </div>
+
     <cal-feed-version-picker
-      v-model="staged"
+      v-model="stagedFvids"
       :bbox="bbox"
-      :analysis-start="analysisStart"
-      :analysis-end="analysisEnd"
+      :analysis-start="stagedStart"
+      :analysis-end="stagedEndEffective"
       selectable
+      range-editable
       @update:feed-onestop-ids="onFeedList"
+      @update:analysis-range="onAnalysisRange"
     />
 
     <template #footer>
@@ -21,13 +84,13 @@
         <cat-button variant="light" @click="onCancel">
           Cancel
         </cat-button>
-        <cat-button variant="light" :disabled="!staged && !modelValue" @click="onReset">
+        <cat-button variant="light" @click="onReset">
           Reset to defaults
         </cat-button>
         <cat-button variant="light" :disabled="feedOnestopIds.length === 0" @click="onExcludeAll">
           Exclude all
         </cat-button>
-        <cat-button variant="primary" @click="onApply">
+        <cat-button variant="primary" :disabled="!stagedEndValid" @click="onApply">
           Apply
         </cat-button>
       </div>
@@ -39,22 +102,41 @@
 import { computed, ref, watch } from 'vue'
 import CalFeedVersionPicker from '~/components/cal/feed-version-picker.vue'
 import { parseFvids, serializeFvids } from '~~/src/tl'
-import type { Bbox } from '~~/src/core'
+import {
+  asDateString,
+  fmtDate,
+  normalizeDate,
+  parseDate,
+  WIDE_DATE_YEARS_BACK,
+  WIDE_DATE_YEARS_FORWARD,
+  wideMaxAllowedDate,
+  wideMinAllowedDate,
+  type Bbox,
+} from '~~/src/core'
+import { defaultEndDate, defaultStartDate } from '~/composables/useScenarioInputs'
 
 const props = withDefaults(defineProps<{
   open: boolean
-  // v-model: committed fvids CSV.
-  modelValue?: string
+  // Committed values — staged copies are taken when the modal opens and only
+  // pushed back (atomically, via the apply event) when the user clicks Apply.
+  startDate: Date
+  endDate: Date
+  fvids?: string
   bbox: Bbox
-  analysisStart: Date
-  analysisEnd: Date
 }>(), {
-  modelValue: '',
+  fvids: '',
 })
+
+interface FeedVersionModalApplyPayload {
+  startDate: Date
+  endDate: Date
+  fvids: string
+  singleDay: boolean
+}
 
 const emit = defineEmits<{
   (e: 'update:open', value: boolean): void
-  (e: 'update:modelValue', value: string): void
+  (e: 'apply', value: FeedVersionModalApplyPayload): void
 }>()
 
 const modelOpen = computed<boolean>({
@@ -62,9 +144,63 @@ const modelOpen = computed<boolean>({
   set: (v) => { emit('update:open', v) }
 })
 
+// Much wider than the Query panel's inline pickers — historical dates are
+// the whole point of picking/importing older feed versions.
+const wideMinDate = wideMinAllowedDate()
+const wideMaxDate = wideMaxAllowedDate()
+const wideYearsRange: [number, number] = [-WIDE_DATE_YEARS_BACK, WIDE_DATE_YEARS_FORWARD]
+
 // Staged so Cancel discards in-modal edits. Reset on each open below.
-const staged = ref<string>(props.modelValue)
+const stagedStart = ref<Date>(props.startDate)
+const stagedEnd = ref<Date>(props.endDate)
+// Single-day mode is derived from the committed dates rather than tracked as
+// separate state: it simply means "end date equals start date".
+const stagedSingleDay = ref<boolean>(false)
+const stagedFvids = ref<string>(props.fvids)
 const feedOnestopIds = ref<string[]>([])
+
+watch(() => props.open, (open) => {
+  if (open) {
+    stagedStart.value = props.startDate
+    stagedEnd.value = props.endDate
+    stagedSingleDay.value = asDateString(props.startDate) === asDateString(props.endDate)
+    stagedFvids.value = props.fvids
+  }
+})
+
+const stagedEndEffective = computed<Date>(() =>
+  stagedSingleDay.value ? stagedStart.value : stagedEnd.value)
+
+const stagedEndValid = computed(() => {
+  if (stagedSingleDay.value) { return true }
+  const start = normalizeDate(stagedStart.value)
+  const end = normalizeDate(stagedEnd.value)
+  if (!start || !end) { return false }
+  return end >= start
+})
+
+const windowLabel = computed(() => {
+  const s = fmtDate(stagedStart.value, 'MMM d, yyyy')
+  if (stagedSingleDay.value) { return s }
+  return `${s} – ${fmtDate(stagedEndEffective.value, 'MMM d, yyyy')}`
+})
+
+function toggleStagedSingleDay () {
+  stagedSingleDay.value = !stagedSingleDay.value
+  if (!stagedSingleDay.value && normalizeDate(stagedEnd.value)! < normalizeDate(stagedStart.value)!) {
+    stagedEnd.value = defaultEndDate(stagedStart.value)
+  }
+}
+
+// Snap actions and timeline window drags land here as ISO date strings.
+function onAnalysisRange (range: { start: string, end: string }) {
+  const start = parseDate(range.start)
+  const end = parseDate(range.end)
+  if (!start || !end) { return }
+  stagedStart.value = start
+  stagedEnd.value = end
+  stagedSingleDay.value = range.start === range.end
+}
 
 function onFeedList (ids: string[]) {
   feedOnestopIds.value = ids
@@ -73,36 +209,54 @@ function onFeedList (ids: string[]) {
 function onExcludeAll () {
   // Sets up opt-in-by-row by excluding everything currently in view.
   const excluded = new Set(feedOnestopIds.value)
-  staged.value = serializeFvids({ picks: new Map(), excluded })
+  stagedFvids.value = serializeFvids({ picks: new Map(), excluded })
 }
 
-watch(() => props.open, (open) => {
-  if (open) {
-    staged.value = props.modelValue
-  }
-})
-
 const overrideCount = computed(() => {
-  const parsed = parseFvids(staged.value)
+  const parsed = parseFvids(stagedFvids.value)
   return parsed.picks.size + parsed.excluded.size
 })
 
 function onApply () {
-  emit('update:modelValue', staged.value)
+  emit('apply', {
+    startDate: stagedStart.value,
+    endDate: stagedEndEffective.value,
+    fvids: stagedFvids.value,
+    singleDay: stagedSingleDay.value,
+  })
   emit('update:open', false)
 }
 
 function onCancel () {
-  staged.value = props.modelValue
   emit('update:open', false)
 }
 
+// Restages the scenario defaults (next Monday + 6 days, no overrides); the
+// user still has to Apply for them to take effect.
 function onReset () {
-  staged.value = ''
+  stagedFvids.value = ''
+  stagedStart.value = defaultStartDate()
+  stagedEnd.value = defaultEndDate(stagedStart.value)
+  stagedSingleDay.value = false
 }
 </script>
 
 <style scoped>
+.cal-fv-modal-dates {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0 24px;
+  margin-bottom: 12px;
+}
+.cal-fv-modal-dates-summary {
+  flex: 1 1 280px;
+}
+.cal-fv-modal-end-date {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
 .cal-fv-modal-count {
   margin-right: auto;
   color: #1d6fb8;

--- a/app/components/cal/feed-version-picker-modal.vue
+++ b/app/components/cal/feed-version-picker-modal.vue
@@ -107,6 +107,7 @@ import {
   fmtDate,
   normalizeDate,
   parseDate,
+  validEndDate,
   WIDE_DATE_YEARS_BACK,
   WIDE_DATE_YEARS_FORWARD,
   wideMaxAllowedDate,
@@ -171,13 +172,7 @@ watch(() => props.open, (open) => {
 const stagedEndEffective = computed<Date>(() =>
   stagedSingleDay.value ? stagedStart.value : stagedEnd.value)
 
-const stagedEndValid = computed(() => {
-  if (stagedSingleDay.value) { return true }
-  const start = normalizeDate(stagedStart.value)
-  const end = normalizeDate(stagedEnd.value)
-  if (!start || !end) { return false }
-  return end >= start
-})
+const stagedEndValid = computed(() => validEndDate(stagedStart.value, stagedEnd.value, stagedSingleDay.value))
 
 const windowLabel = computed(() => {
   const s = fmtDate(stagedStart.value, 'MMM d, yyyy')

--- a/app/components/cal/feed-version-picker-modal.vue
+++ b/app/components/cal/feed-version-picker-modal.vue
@@ -110,7 +110,6 @@ import {
   normalizeDate,
   parseDate,
   validEndDate,
-  WIDE_DATE_YEARS_BACK,
   WIDE_DATE_YEARS_FORWARD,
   wideMaxAllowedDate,
   wideMinAllowedDate,
@@ -147,10 +146,15 @@ const modelOpen = computed<boolean>({
 })
 
 // Much wider than the Query panel's inline pickers — historical dates are
-// the whole point of picking/importing older feed versions.
+// the whole point of picking/importing older feed versions. yearsRange is
+// relative year offsets for the picker's year dropdown; it must reach back
+// to the Feed Archive floor year.
 const wideMinDate = wideMinAllowedDate()
 const wideMaxDate = wideMaxAllowedDate()
-const wideYearsRange: [number, number] = [-WIDE_DATE_YEARS_BACK, WIDE_DATE_YEARS_FORWARD]
+const wideYearsRange: [number, number] = [
+  wideMinDate.getFullYear() - new Date().getFullYear(),
+  WIDE_DATE_YEARS_FORWARD,
+]
 
 // Staged so Cancel discards in-modal edits. Reset on each open below.
 const stagedStart = ref<Date>(props.startDate)

--- a/app/components/cal/feed-version-picker-modal.vue
+++ b/app/components/cal/feed-version-picker-modal.vue
@@ -13,7 +13,7 @@
           </cat-tooltip>
         </template>
         <cat-datepicker
-          v-model="stagedStart"
+          v-model="stagedStartModel"
           :min-date="wideMinDate"
           :max-date="wideMaxDate"
           :years-range="wideYearsRange"
@@ -81,6 +81,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { addDays, differenceInDays } from 'date-fns'
 import CalFeedVersionPicker from '~/components/cal/feed-version-picker.vue'
 import CalEndDateField from '~/components/cal/end-date-field.vue'
 import { parseFvids, serializeFvids } from '~~/src/tl'
@@ -177,6 +178,30 @@ function clampToWide (d: Date): Date {
 }
 const stagedDatesInRange = computed(() =>
   inWideRange(stagedStart.value) && (stagedSingleDay.value || inWideRange(stagedEnd.value)))
+
+// Changing the start date *shifts* the window rather than stretching its left
+// edge: the end moves by the same delta so the analysis keeps its length. The
+// wide pickers reach back years, so without this, moving the start to a past
+// year while the end stays put would momentarily create a multi-year range —
+// blowing out the timeline scale and triggering a huge service-level fetch.
+// (Single-day mode has no separate end to carry along.) Use the timeline
+// resize handles or the end picker to change the window's length.
+const stagedStartModel = computed<Date>({
+  get: () => stagedStart.value,
+  set: (v) => {
+    if (!stagedSingleDay.value) {
+      const oldStart = normalizeDate(stagedStart.value)
+      const newStart = normalizeDate(v)
+      if (oldStart && newStart) {
+        const delta = differenceInDays(newStart, oldStart)
+        if (delta !== 0) {
+          stagedEnd.value = clampToWide(addDays(stagedEnd.value, delta))
+        }
+      }
+    }
+    stagedStart.value = v
+  },
+})
 
 const windowLabel = computed(() => {
   const s = fmtDate(stagedStart.value, 'MMM d, yyyy')

--- a/app/components/cal/feed-version-picker.vue
+++ b/app/components/cal/feed-version-picker.vue
@@ -52,7 +52,9 @@ import {
   isoToOrdinal,
   ordinalToIso,
   parseFvids,
+  pinnedFeedVersionsQuery,
   serializeFvids,
+  type FeedVersionDetailWithFeed,
   HIDDEN_FEED_ONESTOP_IDS,
   DEPRIORITIZED_FEED_ONESTOP_IDS,
   watchJob,
@@ -159,11 +161,17 @@ const fetchEndIso = computed(() => snapOrdinal(fmtDate(domainEnd.value), 1))
 
 const queryVars = computed(() => {
   if (!bboxValid.value) { return null }
-  // serviceLevel{Start,End} are intentionally swapped — see feedsForImportQuery.
+  // serviceLevel{Start,End} and covers{Start,End} are both intentionally
+  // swapped (windowEnd → start, windowStart → end) for overlap — see
+  // feedsForImportQuery. service_levels use the padded fetch window (for
+  // timeline context); covers uses the actual analysis window so the FV list
+  // reflects the dates being queried.
   return {
     bbox: convertBbox(props.bbox),
     serviceLevelStart: fetchEndIso.value,
     serviceLevelEnd: fetchStartIso.value,
+    coversStart: fmtDate(analysisEndDebounced.value),
+    coversEnd: fmtDate(analysisStartDebounced.value),
   }
 })
 
@@ -184,6 +192,28 @@ watch(feeds, (fs) => {
   emit('update:feedOnestopIds', ids)
 }, { immediate: true })
 
+// Explicitly-pinned versions are fetched by id so the user's current selection
+// always stays visible — even when it falls outside the browsed window, where
+// the browse query's `covers` filter would otherwise drop it. Keyed by feed
+// onestop_id for merging back into the matching row (one pick per feed).
+const pinnedIds = computed(() => [...explicitPicks.value.values()])
+const { result: pinnedResult } = useQuery<{ feed_versions: FeedVersionDetailWithFeed[] }>(
+  pinnedFeedVersionsQuery,
+  () => ({
+    ids: pinnedIds.value,
+    serviceLevelStart: fetchEndIso.value,
+    serviceLevelEnd: fetchStartIso.value,
+  }),
+  () => ({ enabled: pinnedIds.value.length > 0 })
+)
+const pinnedByOnestop = computed<Map<string, FeedVersionDetailWithFeed>>(() => {
+  const out = new Map<string, FeedVersionDetailWithFeed>()
+  for (const fv of pinnedResult.value?.feed_versions || []) {
+    out.set(fv.feed.onestop_id, fv)
+  }
+  return out
+})
+
 // Sort by busiest FV's in-window service. Active FV is always kept even when
 // it has no in-window service, so operators can see what's currently running.
 const visibleFeeds = computed<FeedWithVersions[]>(() => {
@@ -200,6 +230,16 @@ const visibleFeeds = computed<FeedWithVersions[]>(() => {
     const kept = f.feed_versions.filter(fv =>
       fv.id === activeId || feedVersionHasServiceInRange(fv.service_levels, startIso, endIso)
     )
+    // Always surface the user's pinned selection (at the top), even when it
+    // falls outside the browsed window and the browse query's covers filter
+    // dropped it from this feed's versions.
+    const pinnedId = explicitPicks.value.get(f.onestop_id)
+    if (pinnedId != null && !kept.some(fv => fv.id === pinnedId)) {
+      const pinned = pinnedByOnestop.value.get(f.onestop_id)
+      if (pinned && pinned.id === pinnedId) {
+        kept.unshift(pinned)
+      }
+    }
     if (kept.length === 0) { continue }
     let sortKey = 0
     for (const fv of kept) {

--- a/app/components/cal/feed-version-picker.vue
+++ b/app/components/cal/feed-version-picker.vue
@@ -28,16 +28,19 @@
       :selected-fv-id="explicitPicks.get(feed.onestop_id) ?? null"
       :excluded="excludedFeeds.has(feed.onestop_id)"
       :pending-jobs="pendingJobs"
+      :range-editable="rangeEditable"
       @import="onImport"
       @unimport="onUnimport"
       @select="(fvId) => onSelect(feed, fvId)"
       @exclude="(v) => onExclude(feed, v)"
+      @update:analysis-range="emit('update:analysisRange', $event)"
     />
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { refDebounced } from '@vueuse/core'
 import { useQuery } from '@vue/apollo-composable'
 import { addDays, differenceInDays, subDays } from 'date-fns'
 import CalFeedVersionList from '~/components/cal/feed-version-list.vue'
@@ -72,25 +75,38 @@ const props = withDefaults(defineProps<{
   analysisEnd: Date
   selectable?: boolean
   modelValue?: string
+  // Modal context: rows render a draggable analysis window.
+  rangeEditable?: boolean
 }>(), {
   selectable: false,
   modelValue: '',
+  rangeEditable: false,
 })
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void
   // Lets the parent drive bulk actions ("Exclude all") without re-fetching.
   (e: 'update:feedOnestopIds', value: string[]): void
+  // Bubbled from the timelines' window drag; the modal
+  // owns the staged dates, the picker just relays.
+  (e: 'update:analysisRange', value: { start: string, end: string }): void
 }>()
 
 const bboxValid = computed(() => !!props.bbox?.valid)
 
+// The analysis window (overlay) tracks props live so dragging feels glued to
+// the pointer, but everything derived from it that would reshuffle the page —
+// the timeline scale (domain), the feed sort order, the GraphQL query — runs
+// off a debounced copy so rows don't rescale or resort mid-drag.
+const analysisStartDebounced = refDebounced(computed(() => props.analysisStart), 300)
+const analysisEndDebounced = refDebounced(computed(() => props.analysisEnd), 300)
+
 const bufferDays = computed(() => Math.max(
   MIN_BUFFER_DAYS,
-  differenceInDays(props.analysisEnd, props.analysisStart)
+  differenceInDays(analysisEndDebounced.value, analysisStartDebounced.value)
 ))
-const domainStart = computed(() => subDays(props.analysisStart, bufferDays.value))
-const domainEnd = computed(() => addDays(props.analysisEnd, bufferDays.value))
+const domainStart = computed(() => subDays(analysisStartDebounced.value, bufferDays.value))
+const domainEnd = computed(() => addDays(analysisEndDebounced.value, bufferDays.value))
 
 const parsed = computed(() => parseFvids(props.modelValue))
 const explicitPicks = computed<Map<string, number>>(() => parsed.value.picks)
@@ -126,13 +142,26 @@ function onExclude (feed: FeedWithVersions, value: boolean) {
   emitParsed(picks, excluded)
 }
 
+// The GraphQL fetch window is padded well beyond the visible domain and only
+// re-expands when the domain escapes it, so date edits (drag, pickers)
+// rarely trigger a refetch.
+const FETCH_PAD_DAYS = 90
+const fetchStart = ref<Date>(subDays(domainStart.value, FETCH_PAD_DAYS))
+const fetchEnd = ref<Date>(addDays(domainEnd.value, FETCH_PAD_DAYS))
+watch([domainStart, domainEnd], ([ds, de]) => {
+  if (ds.valueOf() < fetchStart.value.valueOf() || de.valueOf() > fetchEnd.value.valueOf()) {
+    fetchStart.value = subDays(ds, FETCH_PAD_DAYS)
+    fetchEnd.value = addDays(de, FETCH_PAD_DAYS)
+  }
+})
+
 const queryVars = computed(() => {
   if (!bboxValid.value) { return null }
   // serviceLevel{Start,End} are intentionally swapped — see feedsForImportQuery.
   return {
     bbox: convertBbox(props.bbox),
-    serviceLevelStart: fmtDate(domainEnd.value),
-    serviceLevelEnd: fmtDate(domainStart.value),
+    serviceLevelStart: fmtDate(fetchEnd.value),
+    serviceLevelEnd: fmtDate(fetchStart.value),
   }
 })
 
@@ -158,8 +187,9 @@ watch(feeds, (fs) => {
 const visibleFeeds = computed<FeedWithVersions[]>(() => {
   const startIso = fmtDate(domainStart.value)
   const endIso = fmtDate(domainEnd.value)
-  const sortStart = fmtDate(props.analysisStart)
-  const sortEnd = fmtDate(props.analysisEnd)
+  // Debounced so the list doesn't resort under an in-flight window drag.
+  const sortStart = fmtDate(analysisStartDebounced.value)
+  const sortEnd = fmtDate(analysisEndDebounced.value)
 
   const decorated: { feed: FeedWithVersions, sortKey: number, demoted: boolean }[] = []
   for (const f of feeds.value) {

--- a/app/components/cal/feed-version-picker.vue
+++ b/app/components/cal/feed-version-picker.vue
@@ -49,6 +49,8 @@ import {
   feedsForImportQuery,
   feedVersionHasServiceInRange,
   feedVersionServiceSecondsInRange,
+  isoToOrdinal,
+  ordinalToIso,
   parseFvids,
   serializeFvids,
   HIDDEN_FEED_ONESTOP_IDS,
@@ -142,26 +144,26 @@ function onExclude (feed: FeedWithVersions, value: boolean) {
   emitParsed(picks, excluded)
 }
 
-// The GraphQL fetch window is padded well beyond the visible domain and only
-// re-expands when the domain escapes it, so date edits (drag, pickers)
-// rarely trigger a refetch.
-const FETCH_PAD_DAYS = 90
-const fetchStart = ref<Date>(subDays(domainStart.value, FETCH_PAD_DAYS))
-const fetchEnd = ref<Date>(addDays(domainEnd.value, FETCH_PAD_DAYS))
-watch([domainStart, domainEnd], ([ds, de]) => {
-  if (ds.valueOf() < fetchStart.value.valueOf() || de.valueOf() > fetchEnd.value.valueOf()) {
-    fetchStart.value = subDays(ds, FETCH_PAD_DAYS)
-    fetchEnd.value = addDays(de, FETCH_PAD_DAYS)
-  }
-})
+// The GraphQL fetch window snaps the visible domain out to a coarse grid: small
+// date edits within the same cell keep identical query vars (so Apollo doesn't
+// refetch), while the window stays proportional to the current domain — a
+// far-and-back excursion can't permanently bloat it the way a grow-only window
+// would.
+const FETCH_GRID_DAYS = 90
+function snapOrdinal (iso: string, dir: -1 | 1): string {
+  const cell = Math.floor(isoToOrdinal(iso) / FETCH_GRID_DAYS)
+  return ordinalToIso((dir < 0 ? cell : cell + 1) * FETCH_GRID_DAYS)
+}
+const fetchStartIso = computed(() => snapOrdinal(fmtDate(domainStart.value), -1))
+const fetchEndIso = computed(() => snapOrdinal(fmtDate(domainEnd.value), 1))
 
 const queryVars = computed(() => {
   if (!bboxValid.value) { return null }
   // serviceLevel{Start,End} are intentionally swapped — see feedsForImportQuery.
   return {
     bbox: convertBbox(props.bbox),
-    serviceLevelStart: fmtDate(fetchEnd.value),
-    serviceLevelEnd: fmtDate(fetchStart.value),
+    serviceLevelStart: fetchEndIso.value,
+    serviceLevelEnd: fetchStartIso.value,
   }
 })
 

--- a/app/components/cal/feed-version-row.vue
+++ b/app/components/cal/feed-version-row.vue
@@ -34,6 +34,8 @@
       :latest-calendar-date="fv.latest_calendar_date"
       :feed-info-start-date="fv.service_window?.feed_start_date"
       :feed-info-end-date="fv.service_window?.feed_end_date"
+      :editable="rangeEditable"
+      @update:analysis-range="emit('update:analysisRange', $event)"
     />
     <div class="cal-fv-row-action">
       <cal-feed-version-import-button
@@ -76,12 +78,15 @@ const props = defineProps<{
   // Overrides the GraphQL-derived status so the UI tracks the live job state
   // without a refetch.
   pendingJob?: FeedVersionPendingJob | null
+  // Modal context: enables the timeline window drag.
+  rangeEditable?: boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'import', fvId: number): void
   (e: 'unimport', fvId: number): void
   (e: 'select', fvId: number): void
+  (e: 'update:analysisRange', value: { start: string, end: string }): void
 }>()
 
 const fetchedAtShort = computed(() => fmtDate(props.fv.fetched_at) || props.fv.fetched_at)
@@ -143,7 +148,8 @@ const tooltip = computed(() => {
 }
 .cal-fv-row-action {
   flex: 0 0 auto;
-  width: 140px;
+  /* Status tag + action button + job-status link, side by side. */
+  width: 220px;
   display: flex;
   justify-content: flex-start;
 }

--- a/app/components/cal/feed-version-row.vue
+++ b/app/components/cal/feed-version-row.vue
@@ -55,8 +55,8 @@ import CalFeedVersionTimeline from '~/components/cal/feed-version-timeline.vue'
 import CalFeedVersionImportButton from '~/components/cal/feed-version-import-button.vue'
 import {
   effectiveImportStatus,
+  FEED_VERSION_IMPORT_STATUS_LABELS,
   type FeedVersionDetail,
-  type FeedVersionImportStatus,
   type FeedVersionPendingJob,
 } from '~~/src/tl'
 import { fmtDate } from '~~/src/core'
@@ -91,13 +91,6 @@ const emit = defineEmits<{
 
 const fetchedAtShort = computed(() => fmtDate(props.fv.fetched_at) || props.fv.fetched_at)
 
-const STATUS_TOOLTIP_LABELS: Record<FeedVersionImportStatus, string> = {
-  imported: 'Imported',
-  in_progress: 'In progress',
-  error: 'Import error',
-  not_imported: 'Not imported',
-}
-
 const status = computed(() => effectiveImportStatus(props.fv, props.pendingJob))
 
 const tooltip = computed(() => {
@@ -105,7 +98,7 @@ const tooltip = computed(() => {
     `Fetched: ${fetchedAtShort.value}`,
     `SHA1: ${props.fv.sha1}`,
     `Range: ${props.fv.earliest_calendar_date} – ${props.fv.latest_calendar_date}`,
-    `Status: ${STATUS_TOOLTIP_LABELS[status.value]}`,
+    `Status: ${FEED_VERSION_IMPORT_STATUS_LABELS[status.value]}`,
   ]
   if (props.isActive) { lines.push('Active feed version') }
   const errLog = props.fv.feed_version_gtfs_import?.exception_log

--- a/app/components/cal/feed-version-timeline.vue
+++ b/app/components/cal/feed-version-timeline.vue
@@ -237,6 +237,10 @@ let dragAnchorOrd = 0
 let dragInitStartOrd = 0
 let dragInitEndOrd = 0
 let rafId: number | null = null
+// Cached at pointerdown — the root's geometry can't change mid-drag (pointer
+// captured, static layout), so we avoid a getBoundingClientRect() reflow on
+// every pointermove.
+let dragRect: DOMRect | null = null
 
 const displayRect = computed(() => {
   if (dragMode.value !== null && dragStartOrd.value != null && dragEndOrd.value != null) {
@@ -251,7 +255,7 @@ function clampOrd (ord: number): number {
 
 // Day under the pointer, clamped to the visible domain.
 function ordAtPointer (clientX: number): number {
-  const rect = rootEl.value?.getBoundingClientRect()
+  const rect = dragRect ?? rootEl.value?.getBoundingClientRect()
   if (!rect || rect.width <= 0) { return domainStartOrd.value }
   const frac = (clientX - rect.left) / rect.width
   return clampOrd(domainStartOrd.value + Math.floor(frac * domainDays.value))
@@ -262,6 +266,7 @@ function onPointerDown (e: PointerEvent, mode: DragMode) {
   e.preventDefault()
   const target = e.currentTarget as HTMLElement
   target.setPointerCapture(e.pointerId)
+  dragRect = rootEl.value?.getBoundingClientRect() ?? null
   dragMode.value = mode
   dragAnchorOrd = ordAtPointer(e.clientX)
   dragInitStartOrd = analysisStartOrd.value
@@ -300,6 +305,7 @@ function onPointerUp (e: PointerEvent) {
   dragMode.value = null
   dragStartOrd.value = null
   dragEndOrd.value = null
+  dragRect = null
 }
 
 // rAF-throttled so a fast drag emits at most once per frame.

--- a/app/components/cal/feed-version-timeline.vue
+++ b/app/components/cal/feed-version-timeline.vue
@@ -1,14 +1,48 @@
 <template>
   <div
+    ref="rootEl"
     class="cal-fv-timeline"
     role="img"
     :aria-label="`Service intensity from ${domainStartIso} to ${domainEndIso}`"
   >
     <div
-      v-if="analysisRect"
+      v-if="displayRect"
       class="cal-fv-timeline-window"
-      :style="{ left: analysisRect.left, width: analysisRect.width }"
-    />
+      :class="{ 'is-editable': editable, 'is-dragging': dragMode !== null }"
+      :style="{ left: displayRect.left, width: displayRect.width }"
+      :tabindex="editable ? 0 : undefined"
+      :role="editable ? 'slider' : undefined"
+      :aria-label="editable ? 'Analysis window — drag to move, drag edges to resize, arrow keys to nudge (Shift+arrow resizes), or use the date pickers above' : undefined"
+      :aria-valuemin="editable ? domainStartOrd : undefined"
+      :aria-valuemax="editable ? domainEndOrd : undefined"
+      :aria-valuenow="editable ? analysisStartOrd ?? undefined : undefined"
+      :aria-valuetext="editable ? `${analysisStartIso} to ${analysisEndIso}` : undefined"
+      @keydown="onWindowKeydown"
+    >
+      <template v-if="editable">
+        <div
+          class="cal-fv-timeline-window-handle is-left"
+          @pointerdown="onPointerDown($event, 'resize-left')"
+          @pointermove="onPointerMove"
+          @pointerup="onPointerUp"
+          @pointercancel="onPointerUp"
+        />
+        <div
+          class="cal-fv-timeline-window-move"
+          @pointerdown="onPointerDown($event, 'move')"
+          @pointermove="onPointerMove"
+          @pointerup="onPointerUp"
+          @pointercancel="onPointerUp"
+        />
+        <div
+          class="cal-fv-timeline-window-handle is-right"
+          @pointerdown="onPointerDown($event, 'resize-right')"
+          @pointermove="onPointerMove"
+          @pointerup="onPointerUp"
+          @pointercancel="onPointerUp"
+        />
+      </template>
+    </div>
 
     <!-- Coverage stripe keeps the FV range visible even when service_levels is empty. -->
     <div
@@ -31,7 +65,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
 import {
   isoToOrdinal,
   maxServiceSecondsPerDay,
@@ -55,6 +89,13 @@ const props = defineProps<{
   latestCalendarDate?: string | null
   feedInfoStartDate?: string | null
   feedInfoEndDate?: string | null
+  // When true (picker modal context), the analysis window becomes a
+  // drag-to-move / drag-edges-to-resize control that emits date updates.
+  editable?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:analysisRange', value: { start: string, end: string }): void
 }>()
 
 // asDateString handles both Date and 'YYYY-MM-DD' string inputs without
@@ -160,16 +201,146 @@ function ordToPct (ord: number): number {
   return (ord - domainStartOrd.value) / domainDays.value
 }
 
-const analysisRect = computed(() => {
-  const sIso = toIso(props.analysisStart ?? null)
-  const eIso = toIso(props.analysisEnd ?? null)
-  if (!sIso || !eIso) { return null }
-  const p1 = ordToPct(isoToOrdinal(sIso))
-  const p2 = ordToPct(isoToOrdinal(eIso) + 1)
+const analysisStartIso = computed(() => toIso(props.analysisStart ?? null))
+const analysisEndIso = computed(() => toIso(props.analysisEnd ?? null))
+const analysisStartOrd = computed<number | null>(() =>
+  analysisStartIso.value ? isoToOrdinal(analysisStartIso.value) : null)
+const analysisEndOrd = computed<number | null>(() =>
+  analysisEndIso.value ? isoToOrdinal(analysisEndIso.value) : null)
+
+function rectForOrds (startOrd: number, endOrd: number) {
+  const p1 = ordToPct(startOrd)
+  const p2 = ordToPct(endOrd + 1)
   if (p2 <= 0 || p1 >= 1) { return null }
   const left = Math.max(0, p1)
   const right = Math.min(1, p2)
   return { left: pct(left), width: pct(Math.max(0.001, right - left)) }
+}
+
+const analysisRect = computed(() => {
+  if (analysisStartOrd.value == null || analysisEndOrd.value == null) { return null }
+  return rectForOrds(analysisStartOrd.value, analysisEndOrd.value)
+})
+
+// --- Drag-to-edit analysis window (editable mode) ---
+
+type DragMode = 'move' | 'resize-left' | 'resize-right'
+
+const rootEl = ref<HTMLElement | null>(null)
+const dragMode = ref<DragMode | null>(null)
+// Window ordinals while a drag is in flight — rendering from these keeps the
+// overlay glued to the pointer instead of waiting for the staged props to
+// round-trip through the parent.
+const dragStartOrd = ref<number | null>(null)
+const dragEndOrd = ref<number | null>(null)
+let dragAnchorOrd = 0
+let dragInitStartOrd = 0
+let dragInitEndOrd = 0
+let rafId: number | null = null
+
+const displayRect = computed(() => {
+  if (dragMode.value !== null && dragStartOrd.value != null && dragEndOrd.value != null) {
+    return rectForOrds(dragStartOrd.value, dragEndOrd.value)
+  }
+  return analysisRect.value
+})
+
+function clampOrd (ord: number): number {
+  return Math.min(domainEndOrd.value, Math.max(domainStartOrd.value, ord))
+}
+
+// Day under the pointer, clamped to the visible domain.
+function ordAtPointer (clientX: number): number {
+  const rect = rootEl.value?.getBoundingClientRect()
+  if (!rect || rect.width <= 0) { return domainStartOrd.value }
+  const frac = (clientX - rect.left) / rect.width
+  return clampOrd(domainStartOrd.value + Math.floor(frac * domainDays.value))
+}
+
+function onPointerDown (e: PointerEvent, mode: DragMode) {
+  if (!props.editable || analysisStartOrd.value == null || analysisEndOrd.value == null) { return }
+  e.preventDefault();
+  (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+  dragMode.value = mode
+  dragAnchorOrd = ordAtPointer(e.clientX)
+  dragInitStartOrd = analysisStartOrd.value
+  dragInitEndOrd = analysisEndOrd.value
+  dragStartOrd.value = dragInitStartOrd
+  dragEndOrd.value = dragInitEndOrd
+}
+
+function onPointerMove (e: PointerEvent) {
+  if (dragMode.value === null) { return }
+  const ord = ordAtPointer(e.clientX)
+  if (dragMode.value === 'resize-left') {
+    dragStartOrd.value = Math.min(ord, dragEndOrd.value ?? ord)
+  } else if (dragMode.value === 'resize-right') {
+    dragEndOrd.value = Math.max(ord, dragStartOrd.value ?? ord)
+  } else {
+    // Shift the whole window, preserving width, clamped inside the domain.
+    const width = dragInitEndOrd - dragInitStartOrd
+    let start = dragInitStartOrd + (ord - dragAnchorOrd)
+    start = Math.max(domainStartOrd.value, Math.min(domainEndOrd.value - width, start))
+    dragStartOrd.value = start
+    dragEndOrd.value = start + width
+  }
+  scheduleEmit()
+}
+
+function onPointerUp (e: PointerEvent) {
+  if (dragMode.value === null) { return }
+  (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
+  if (rafId != null) {
+    cancelAnimationFrame(rafId)
+    rafId = null
+  }
+  emitDragRange()
+  dragMode.value = null
+  dragStartOrd.value = null
+  dragEndOrd.value = null
+}
+
+// rAF-throttled so a fast drag emits at most once per frame.
+function scheduleEmit () {
+  if (rafId != null) { return }
+  rafId = requestAnimationFrame(() => {
+    rafId = null
+    emitDragRange()
+  })
+}
+
+function emitDragRange () {
+  if (dragStartOrd.value == null || dragEndOrd.value == null) { return }
+  emit('update:analysisRange', {
+    start: ordinalToIso(dragStartOrd.value),
+    end: ordinalToIso(dragEndOrd.value),
+  })
+}
+
+// Arrow keys move the window one day; Shift+arrow resizes the end edge. The
+// modal's header date pickers remain the primary accessible path.
+function onWindowKeydown (e: KeyboardEvent) {
+  if (!props.editable || analysisStartOrd.value == null || analysisEndOrd.value == null) { return }
+  const delta = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0
+  if (delta === 0) { return }
+  e.preventDefault()
+  const start = analysisStartOrd.value
+  const end = analysisEndOrd.value
+  if (e.shiftKey) {
+    const newEnd = Math.min(domainEndOrd.value, Math.max(start, end + delta))
+    emit('update:analysisRange', { start: ordinalToIso(start), end: ordinalToIso(newEnd) })
+  } else {
+    const width = end - start
+    const newStart = Math.max(domainStartOrd.value, Math.min(domainEndOrd.value - width, start + delta))
+    emit('update:analysisRange', { start: ordinalToIso(newStart), end: ordinalToIso(newStart + width) })
+  }
+}
+
+onBeforeUnmount(() => {
+  if (rafId != null) {
+    cancelAnimationFrame(rafId)
+    rafId = null
+  }
 })
 
 const coverageRect = computed(() => {
@@ -219,6 +390,32 @@ function isOutsideFeedInfo (ord: number): boolean {
   /* Above the cells so the outline frames them rather than being painted over. */
   z-index: 5;
   pointer-events: none;
+}
+.cal-fv-timeline-window.is-editable {
+  pointer-events: auto;
+  display: flex;
+}
+.cal-fv-timeline-window.is-editable:focus-visible {
+  outline: 2px solid #1d6fb8;
+  outline-offset: 1px;
+}
+.cal-fv-timeline-window.is-dragging {
+  background: rgba(216, 180, 64, 0.12);
+}
+.cal-fv-timeline-window-handle {
+  flex: 0 0 6px;
+  cursor: ew-resize;
+  /* Prevent touch scrolling from hijacking the drag. */
+  touch-action: none;
+}
+.cal-fv-timeline-window-move {
+  flex: 1 1 auto;
+  min-width: 0;
+  cursor: grab;
+  touch-action: none;
+}
+.is-dragging .cal-fv-timeline-window-move {
+  cursor: grabbing;
 }
 .cal-fv-timeline-coverage {
   position: absolute;

--- a/app/components/cal/feed-version-timeline.vue
+++ b/app/components/cal/feed-version-timeline.vue
@@ -259,8 +259,9 @@ function ordAtPointer (clientX: number): number {
 
 function onPointerDown (e: PointerEvent, mode: DragMode) {
   if (!props.editable || analysisStartOrd.value == null || analysisEndOrd.value == null) { return }
-  e.preventDefault();
-  (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+  e.preventDefault()
+  const target = e.currentTarget as HTMLElement
+  target.setPointerCapture(e.pointerId)
   dragMode.value = mode
   dragAnchorOrd = ordAtPointer(e.clientX)
   dragInitStartOrd = analysisStartOrd.value
@@ -289,7 +290,8 @@ function onPointerMove (e: PointerEvent) {
 
 function onPointerUp (e: PointerEvent) {
   if (dragMode.value === null) { return }
-  (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
+  const target = e.currentTarget as HTMLElement
+  target.releasePointerCapture(e.pointerId)
   if (rafId != null) {
     cancelAnimationFrame(rafId)
     rafId = null

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -25,8 +25,8 @@
           </template>
           <cat-datepicker
             v-model="startDate"
-            :min-date="minAllowedDate"
-            :max-date="maxAllowedDate"
+            :min-date="pickerMinDate"
+            :max-date="pickerMaxDate"
             :years-range="datePickerYearsRange"
             :variant="isStartDateInRange ? undefined : 'danger'"
             readonly
@@ -39,26 +39,64 @@
               <cat-icon size="small" icon="information" />
             </cat-tooltip>
           </template>
-          <cat-datepicker
-            v-if="!selectSingleDay"
-            ref="endDateRef"
-            v-model="endDate"
-            :min-date="minAllowedDate"
-            :max-date="maxAllowedDate"
-            :years-range="datePickerYearsRange"
-            :variant="isEndDateInRange && isEndDateValid ? undefined : 'danger'"
-            readonly
-          />
-          <cat-button @click="toggleSelectSingleDay()">
-            {{ selectSingleDay ? 'Set an end date' : 'Remove end date' }}
+          <div v-if="!selectSingleDay" class="cal-query-end-date">
+            <cat-datepicker
+              ref="endDateRef"
+              v-model="endDate"
+              :min-date="pickerMinDate"
+              :max-date="pickerMaxDate"
+              :years-range="datePickerYearsRange"
+              :variant="isEndDateInRange && isEndDateValid ? undefined : 'danger'"
+              readonly
+            />
+            <!-- TODO: catenary >0.3.0 declares aria-label/title as cat-button
+                 props; on the next bump, replace this v-bind workaround with
+                 plain attributes. -->
+            <cat-button
+              icon="close"
+              v-bind="{ 'aria-label': 'Remove end date', 'title': 'Remove end date (query a single day)' }"
+              @click="toggleSelectSingleDay()"
+            />
+          </div>
+          <cat-button v-else ref="setEndDateRef" @click="toggleSelectSingleDay()">
+            Set an end date
           </cat-button>
           <p v-if="!isEndDateValid" class="help is-danger">
             End date must be on or after the start date.
           </p>
         </cat-field>
         <p v-if="!isStartDateInRange || !isEndDateInRange" class="help is-danger">
-          Dates must be within the last 90 days or next year.
+          Dates must be within the last {{ WIDE_DATE_YEARS_BACK }} years or next {{ WIDE_DATE_YEARS_FORWARD }} years.
         </p>
+        <p v-else-if="datesOutsidePickerRange" class="help">
+          Dates are outside the default range (last 90 days to next year) —
+          results depend on feed versions imported from the Feed Archive.
+        </p>
+
+        <div class="cal-query-archive">
+          <p class="help">
+            Querying past dates? Pin exact feed versions from the Feed Archive.
+          </p>
+          <div class="cal-query-archive-actions">
+            <cat-button variant="ghost" class="cal-query-archive-link" @click="showFvPicker = true">
+              Open Feed Archive…
+              <span v-if="fvOverrideCount > 0" class="cal-query-fv-badge">{{ fvOverrideCount }}</span>
+            </cat-button>
+            <cat-button
+              v-if="fvOverrideCount > 0"
+              variant="ghost"
+              class="cal-query-archive-link"
+              @click="fvids = ''"
+            >
+              Clear overrides
+            </cat-button>
+          </div>
+          <cal-feed-version-override-summary
+            v-if="fvOverrideCount > 0"
+            :fvids="fvids"
+            class="mt-2"
+          />
+        </div>
       </cat-msg>
 
       <cat-msg title="Geographic Bounds">
@@ -213,25 +251,6 @@
               </option>
             </cat-select>
           </cat-field>
-
-          <!-- Feed Versions Section -->
-          <cat-field>
-            <template #label>
-              <cat-tooltip text="By default the analysis uses each feed's currently-active feed version. Override that here to pin specific versions or exclude individual feeds.">
-                Feed versions
-                <cat-icon icon="information" />
-              </cat-tooltip>
-            </template>
-            <div class="cal-query-fv-actions">
-              <cat-button @click="showFvPicker = true">
-                Pick feed versions
-                <span v-if="fvOverrideCount > 0" class="cal-query-fv-badge">{{ fvOverrideCount }}</span>
-              </cat-button>
-              <cat-button v-if="fvOverrideCount > 0" variant="light" @click="fvids = ''">
-                Clear
-              </cat-button>
-            </div>
-          </cat-field>
         </div>
       </cat-msg>
 
@@ -262,22 +281,34 @@
 
     <cal-feed-version-picker-modal
       v-model:open="showFvPicker"
-      v-model="fvids"
+      :start-date="startDate"
+      :end-date="endDate"
+      :fvids="fvids"
       :bbox="bbox"
-      :analysis-start="startDate"
-      :analysis-end="endDate"
+      @apply="onModalApply"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref } from 'vue'
+import { computed, nextTick, ref, type ComponentPublicInstance } from 'vue'
 import { useToggle } from '@vueuse/core'
 import { useLazyQuery } from '@vue/apollo-composable'
 import type { Point } from '~~/src/core'
-import { cannedBboxes, geomSources, normalizeDate, PANEL_PADDING, QUERY_PANEL_WIDTH } from '~~/src/core'
+import {
+  cannedBboxes,
+  geomSources,
+  normalizeDate,
+  PANEL_PADDING,
+  QUERY_PANEL_WIDTH,
+  WIDE_DATE_YEARS_BACK,
+  WIDE_DATE_YEARS_FORWARD,
+  wideMaxAllowedDate,
+  wideMinAllowedDate,
+} from '~~/src/core'
 import { type CensusDataset, type CensusGeography, geographySearchQuery, parseFvids } from '~~/src/tl'
 import CalFeedVersionPickerModal from '~/components/cal/feed-version-picker-modal.vue'
+import CalFeedVersionOverrideSummary from '~/components/cal/feed-version-override-summary.vue'
 
 const emit = defineEmits([
   'fitToGeographies',
@@ -317,6 +348,7 @@ const {
   includeFixedRoute,
   includeFlexAreas,
   fvids,
+  applyDatesAndFvids,
 } = useScenarioInputs()
 
 const showFvPicker = ref(false)
@@ -330,15 +362,17 @@ const geomSearch = ref('')
 const selectSingleDay = ref(true)
 const toggleSelectSingleDay = useToggle(selectSingleDay)
 
-// Transitland API results are currently based on only active feed versions,
-// so we want to constrain possible query dates.
-// In future, user-controlled import of historical feeds will be a fuller solution,
-// see https://github.com/interline-io/calact-network-analysis-tool/issues/223
+// The inline pickers steer users to recent dates, where active feed versions
+// have coverage. Validation accepts the much wider window the "Dates & feed
+// versions" modal can set (#223) — picking/importing historical feed versions
+// is what makes older dates meaningful.
 const today = new Date()
-const minAllowedDate = new Date(today)
-minAllowedDate.setDate(today.getDate() - 90)
-const maxAllowedDate = new Date(today)
-maxAllowedDate.setFullYear(today.getFullYear() + 1)
+const pickerMinDate = new Date(today)
+pickerMinDate.setDate(today.getDate() - 90)
+const pickerMaxDate = new Date(today)
+pickerMaxDate.setFullYear(today.getFullYear() + 1)
+const validMinDate = wideMinAllowedDate()
+const validMaxDate = wideMaxAllowedDate()
 // yearsRange is relative offsets [before, after] from current year for the year dropdown
 const datePickerYearsRange: [number, number] = [-1, 1]
 
@@ -347,11 +381,24 @@ function isDateInRange (d: Date | undefined): boolean {
   if (!date) {
     return true
   }
-  return date >= minAllowedDate && date <= maxAllowedDate
+  return date >= validMinDate && date <= validMaxDate
+}
+
+function isDateInPickerRange (d: Date | undefined): boolean {
+  const date = normalizeDate(d)
+  if (!date) {
+    return true
+  }
+  return date >= pickerMinDate && date <= pickerMaxDate
 }
 
 const isStartDateInRange = computed(() => isDateInRange(startDate.value))
 const isEndDateInRange = computed(() => isDateInRange(endDate.value))
+
+// Informational only — flags a (valid) window beyond what the inline pickers
+// offer, i.e. one set via the "Dates & feed versions" modal.
+const datesOutsidePickerRange = computed(() =>
+  !isDateInPickerRange(startDate.value) || !isDateInPickerRange(endDate.value))
 
 const isEndDateValid = computed(() => {
   if (selectSingleDay.value) {
@@ -391,20 +438,47 @@ const {
 )
 
 const endDateRef = ref<{ focus: () => void } | null>(null)
+const setEndDateRef = ref<ComponentPublicInstance | null>(null)
 
 // When toggling single-day mode, sync endDate to the URL query params.
 // In single-day mode, endDate matches startDate. When switching to range mode,
 // we create a copy so Vue detects a change and persists the value to the URL.
 // When the end-date picker appears, move focus into it for keyboard users (#361).
+// Suppressed during a modal Apply — the modal commits its own (already
+// consistent) dates in a single batched URL write.
+let suppressSingleDayWatch = false
 watch(selectSingleDay, async (newVal) => {
+  if (suppressSingleDayWatch) {
+    return
+  }
   if (newVal) {
     endDate.value = startDate.value
+    // The icon button that was clicked unmounts with the picker; move focus
+    // to the "Set an end date" button so keyboard focus isn't dropped.
+    await nextTick()
+    const el = setEndDateRef.value?.$el as HTMLElement | undefined
+    el?.focus?.()
   } else {
     endDate.value = new Date(endDate.value)
     await nextTick()
     endDateRef.value?.focus()
   }
 })
+
+// The "Dates & feed versions" modal stages dates + fvids and commits them
+// here atomically — one setQuery navigation so the params can't race.
+function onModalApply (payload: { startDate: Date, endDate: Date, fvids: string, singleDay: boolean }) {
+  if (selectSingleDay.value !== payload.singleDay) {
+    suppressSingleDayWatch = true
+    selectSingleDay.value = payload.singleDay
+    void nextTick(() => { suppressSingleDayWatch = false })
+  }
+  applyDatesAndFvids({
+    startDate: payload.startDate,
+    endDate: payload.endDate,
+    fvids: payload.fvids,
+  })
+}
 
 watch(geomSearchVars, () => {
   if ((geomSearch.value || '').length >= 2 && geomLayer.value) {
@@ -531,11 +605,30 @@ const validQueryParams = computed(() => {
     }
   }
 
-  .cal-query-fv-actions {
+  .cal-query-end-date {
     display: flex;
-    gap: 8px;
     align-items: center;
-    margin-top: 8px;
+    gap: 4px;
+  }
+
+  .cal-query-archive {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--bulma-border-weak, #ededed);
+  }
+
+  .cal-query-archive-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  // Ghost buttons carry default button padding; trim so the link text
+  // aligns with the help copy above it.
+  .cal-query-archive-link :deep(.button) {
+    padding-left: 0;
+    padding-right: 0;
+    height: auto;
   }
   .cal-query-fv-badge {
     display: inline-flex;

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -32,39 +32,23 @@
             readonly
           />
         </cat-field>
-        <cat-field>
+        <cal-end-date-field
+          v-model:end="endDate"
+          v-model:single-day="selectSingleDay"
+          :min-date="pickerMinDate"
+          :max-date="pickerMaxDate"
+          :years-range="datePickerYearsRange"
+          :invalid="!(isEndDateInRange && isEndDateValid)"
+          :before-start="!isEndDateValid"
+          single-day-title="Remove end date (query a single day)"
+        >
           <template #label>
             <cat-tooltip text="By default, the end date is one week after the start date.">
               End date
               <cat-icon size="small" icon="information" />
             </cat-tooltip>
           </template>
-          <div v-if="!selectSingleDay" class="cal-query-end-date">
-            <cat-datepicker
-              ref="endDateRef"
-              v-model="endDate"
-              :min-date="pickerMinDate"
-              :max-date="pickerMaxDate"
-              :years-range="datePickerYearsRange"
-              :variant="isEndDateInRange && isEndDateValid ? undefined : 'danger'"
-              readonly
-            />
-            <!-- TODO: catenary >0.3.0 declares aria-label/title as cat-button
-                 props; on the next bump, replace this v-bind workaround with
-                 plain attributes. -->
-            <cat-button
-              icon="close"
-              v-bind="{ 'aria-label': 'Remove end date', 'title': 'Remove end date (query a single day)' }"
-              @click="toggleSelectSingleDay()"
-            />
-          </div>
-          <cat-button v-else ref="setEndDateRef" @click="toggleSelectSingleDay()">
-            Set an end date
-          </cat-button>
-          <p v-if="!isEndDateValid" class="help is-danger">
-            End date must be on or after the start date.
-          </p>
-        </cat-field>
+        </cal-end-date-field>
         <p v-if="!isStartDateInRange || !isEndDateInRange" class="help is-danger">
           Dates must be between {{ fmtDate(validMinDate, 'MMM d, yyyy') }} (the
           start of the Feed Archive) and {{ fmtDate(validMaxDate, 'MMM d, yyyy') }}.
@@ -292,8 +276,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, type ComponentPublicInstance } from 'vue'
-import { useToggle } from '@vueuse/core'
+import { computed, nextTick, ref } from 'vue'
 import { useLazyQuery } from '@vue/apollo-composable'
 import type { Point } from '~~/src/core'
 import {
@@ -311,6 +294,7 @@ import {
 import { type CensusDataset, type CensusGeography, geographySearchQuery, parseFvids } from '~~/src/tl'
 import CalFeedVersionPickerModal from '~/components/cal/feed-version-picker-modal.vue'
 import CalFeedVersionOverrideSummary from '~/components/cal/feed-version-override-summary.vue'
+import CalEndDateField from '~/components/cal/end-date-field.vue'
 
 const emit = defineEmits([
   'fitToGeographies',
@@ -367,7 +351,6 @@ const geomSearch = ref('')
 // weekday/weekend levels, stop visit summaries — assumes a 7-day window, so
 // the default range stays start + 6 days.
 const selectSingleDay = ref(asDateString(startDate.value) === asDateString(endDate.value))
-const toggleSelectSingleDay = useToggle(selectSingleDay)
 
 // The inline pickers steer users to recent dates, where active feed versions
 // have coverage. Validation accepts the much wider window the "Dates & feed
@@ -433,31 +416,21 @@ const {
   }
 )
 
-const endDateRef = ref<{ focus: () => void } | null>(null)
-const setEndDateRef = ref<ComponentPublicInstance | null>(null)
-
 // When toggling single-day mode, sync endDate to the URL query params.
 // In single-day mode, endDate matches startDate. When switching to range mode,
 // we create a copy so Vue detects a change and persists the value to the URL.
-// When the end-date picker appears, move focus into it for keyboard users (#361).
+// (Keyboard focus across the toggle is handled inside cal-end-date-field, #361.)
 // Suppressed during a modal Apply — the modal commits its own (already
 // consistent) dates in a single batched URL write.
 let suppressSingleDayWatch = false
-watch(selectSingleDay, async (newVal) => {
+watch(selectSingleDay, (newVal) => {
   if (suppressSingleDayWatch) {
     return
   }
   if (newVal) {
     endDate.value = startDate.value
-    // The icon button that was clicked unmounts with the picker; move focus
-    // to the "Set an end date" button so keyboard focus isn't dropped.
-    await nextTick()
-    const el = setEndDateRef.value?.$el as HTMLElement | undefined
-    el?.focus?.()
   } else {
     endDate.value = new Date(endDate.value)
-    await nextTick()
-    endDateRef.value?.focus()
   }
 })
 
@@ -608,12 +581,6 @@ const validQueryParams = computed(() => {
     :deep(.control) {
       flex-grow: 1;
     }
-  }
-
-  .cal-query-end-date {
-    display: flex;
-    align-items: center;
-    gap: 4px;
   }
 
   .cal-query-archive {

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -301,6 +301,7 @@ import {
   normalizeDate,
   PANEL_PADDING,
   QUERY_PANEL_WIDTH,
+  validEndDate,
   WIDE_DATE_YEARS_BACK,
   WIDE_DATE_YEARS_FORWARD,
   wideMaxAllowedDate,
@@ -400,18 +401,7 @@ const isEndDateInRange = computed(() => isDateInRange(endDate.value))
 const datesOutsidePickerRange = computed(() =>
   !isDateInPickerRange(startDate.value) || !isDateInPickerRange(endDate.value))
 
-const isEndDateValid = computed(() => {
-  if (selectSingleDay.value) {
-    return true
-  }
-  // Both dates should already be normalized, but compare date portions to be safe
-  const start = normalizeDate(startDate.value)
-  const end = normalizeDate(endDate.value)
-  if (!start || !end) {
-    return false
-  }
-  return end >= start
-})
+const isEndDateValid = computed(() => validEndDate(startDate.value, endDate.value, selectSingleDay.value))
 
 const geomSearchVars = computed(() => {
   return {

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -66,7 +66,8 @@
           </p>
         </cat-field>
         <p v-if="!isStartDateInRange || !isEndDateInRange" class="help is-danger">
-          Dates must be within the last {{ WIDE_DATE_YEARS_BACK }} years or next {{ WIDE_DATE_YEARS_FORWARD }} years.
+          Dates must be between {{ fmtDate(validMinDate, 'MMM d, yyyy') }} (the
+          start of the Feed Archive) and {{ fmtDate(validMaxDate, 'MMM d, yyyy') }}.
         </p>
         <p v-else-if="datesOutsidePickerRange" class="help">
           Dates are outside the default range (last 90 days to next year) —
@@ -298,13 +299,12 @@ import type { Point } from '~~/src/core'
 import {
   asDateString,
   cannedBboxes,
+  fmtDate,
   geomSources,
   normalizeDate,
   PANEL_PADDING,
   QUERY_PANEL_WIDTH,
   validEndDate,
-  WIDE_DATE_YEARS_BACK,
-  WIDE_DATE_YEARS_FORWARD,
   wideMaxAllowedDate,
   wideMinAllowedDate,
 } from '~~/src/core'

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -296,6 +296,7 @@ import { useToggle } from '@vueuse/core'
 import { useLazyQuery } from '@vue/apollo-composable'
 import type { Point } from '~~/src/core'
 import {
+  asDateString,
   cannedBboxes,
   geomSources,
   normalizeDate,
@@ -452,6 +453,15 @@ watch(selectSingleDay, async (newVal) => {
     endDate.value = new Date(endDate.value)
     await nextTick()
     endDateRef.value?.focus()
+  }
+})
+
+// In single-day mode the end-date picker is hidden, so a start-date change
+// must carry endDate along — otherwise the URL keeps a stale endDate that no
+// longer matches the selected single day.
+watch(startDate, (v) => {
+  if (selectSingleDay.value && asDateString(endDate.value) !== asDateString(v)) {
+    endDate.value = v
   }
 })
 

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -361,7 +361,12 @@ const fvOverrideCount = computed(() => {
 const { aggregateLayer } = useScenarioDisplay()
 const debugMenu = useDebugMenu()
 const geomSearch = ref('')
-const selectSingleDay = ref(true)
+// Single-day mode is an explicit opt-in: derived from the committed dates on
+// load (a shared single-day link shows single-day mode), defaulting to the
+// full week otherwise. Downstream analysis — day-of-week filters, WSDOT
+// weekday/weekend levels, stop visit summaries — assumes a 7-day window, so
+// the default range stays start + 6 days.
+const selectSingleDay = ref(asDateString(startDate.value) === asDateString(endDate.value))
 const toggleSelectSingleDay = useToggle(selectSingleDay)
 
 // The inline pickers steer users to recent dates, where active feed versions

--- a/app/composables/useScenarioInputs.ts
+++ b/app/composables/useScenarioInputs.ts
@@ -14,6 +14,19 @@ import {
 } from '~~/src/core'
 import { useUrlQuery } from './useUrlQuery'
 
+// Default analysis window: next Monday through the following Sunday. Shared
+// by the URL-backed getters below and the "Dates & feed versions" modal's
+// Reset action so both agree on what "default" means.
+// endOfYesterday() so that if today is Monday, nextMonday returns today (not next week).
+// normalizeDate strips the time component so the date serializes consistently across timezones.
+export function defaultStartDate (): Date {
+  return normalizeDate(nextMonday(endOfYesterday()))!
+}
+
+export function defaultEndDate (start: Date): Date {
+  return addDays(start, 6)
+}
+
 interface ScenarioInputs {
   bbox: WritableComputedRef<Bbox>
   cannedBbox: WritableComputedRef<string>
@@ -31,6 +44,10 @@ interface ScenarioInputs {
   // #315 — 0 disables the feature.
   stopBufferRadius: WritableComputedRef<number>
   stopBufferLayer: WritableComputedRef<string>
+  // Atomic commit of the "Dates & feed versions" modal's staged state —
+  // setQuery is only race-safe within a single call, so the three params
+  // must land in one navigation.
+  applyDatesAndFvids: (v: { startDate: Date, endDate: Date, fvids: string }) => void
 }
 
 // URL-backed inputs that drive scenario fetching.
@@ -53,14 +70,12 @@ export function useScenarioInputs (): ScenarioInputs {
   })
 
   const startDate = computed<Date>({
-    // endOfYesterday() so that if today is Monday, nextMonday returns today (not next week).
-    // normalizeDate strips the time component so the date serializes consistently across timezones.
-    get: () => parseDate(route.query.startDate?.toString()) || normalizeDate(nextMonday(endOfYesterday()))!,
+    get: () => parseDate(route.query.startDate?.toString()) || defaultStartDate(),
     set: (v) => { setQuery({ startDate: asDateString(v) }) }
   })
 
   const endDate = computed<Date>({
-    get: () => parseDate(route.query.endDate?.toString()) || addDays(startDate.value, 6),
+    get: () => parseDate(route.query.endDate?.toString()) || defaultEndDate(startDate.value),
     set: (v) => { setQuery({ endDate: asDateString(v) }) }
   })
 
@@ -127,6 +142,14 @@ export function useScenarioInputs (): ScenarioInputs {
     }
   })
 
+  function applyDatesAndFvids (v: { startDate: Date, endDate: Date, fvids: string }) {
+    setQuery({
+      startDate: asDateString(v.startDate),
+      endDate: asDateString(v.endDate),
+      fvids: v.fvids || undefined,
+    })
+  }
+
   return {
     bbox,
     cannedBbox,
@@ -142,5 +165,6 @@ export function useScenarioInputs (): ScenarioInputs {
     fvids,
     stopBufferRadius,
     stopBufferLayer,
+    applyDatesAndFvids,
   }
 }

--- a/app/composables/useScenarioInputs.ts
+++ b/app/composables/useScenarioInputs.ts
@@ -1,10 +1,10 @@
-import { addDays, endOfYesterday, nextMonday } from 'date-fns'
 import { computed, type WritableComputedRef } from 'vue'
 import {
   asDateString,
   bboxString,
   cannedBboxes,
-  normalizeDate,
+  defaultEndDate,
+  defaultStartDate,
   parseBbox,
   parseDate,
   SCENARIO_DEFAULTS,
@@ -13,19 +13,6 @@ import {
   type Bbox,
 } from '~~/src/core'
 import { useUrlQuery } from './useUrlQuery'
-
-// Default analysis window: next Monday through the following Sunday. Shared
-// by the URL-backed getters below and the "Dates & feed versions" modal's
-// Reset action so both agree on what "default" means.
-// endOfYesterday() so that if today is Monday, nextMonday returns today (not next week).
-// normalizeDate strips the time component so the date serializes consistently across timezones.
-export function defaultStartDate (): Date {
-  return normalizeDate(nextMonday(endOfYesterday()))!
-}
-
-export function defaultEndDate (start: Date): Date {
-  return addDays(start, 6)
-}
 
 interface ScenarioInputs {
   bbox: WritableComputedRef<Bbox>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@aitodotai/json-stringify-pretty-compact": "1.3.0",
-    "@interline-io/catenary": "0.3.0",
+    "@interline-io/catenary": "0.4.0",
     "@mdi/font": "7.4.47",
     "@interline-io/tlv2-auth": "0.1.0-sha.ad5c03e",
     "@apollo/client": "3.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,17 +15,17 @@ importers:
         specifier: 3.13.4
         version: 3.13.4(graphql@16.10.0)
       '@interline-io/catenary':
-        specifier: 0.3.0
-        version: 0.3.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
+        specifier: 0.4.0
+        version: 0.4.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       '@interline-io/tlv2-auth':
         specifier: 0.1.0-sha.ad5c03e
-        version: 0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
+        version: 0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
       '@mdi/font':
         specifier: 7.4.47
         version: 7.4.47
       '@nuxt/eslint':
         specifier: 1.10.0
-        version: 1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))
+        version: 1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(magicast@0.3.5)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))
       '@nuxt/eslint-config':
         specifier: 1.10.0
         version: 1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
@@ -79,7 +79,7 @@ importers:
         version: 5.2.0
       nuxt:
         specifier: 4.2.0
-        version: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
       protomaps-themes-base:
         specifier: 1.3.1
         version: 1.3.1
@@ -735,8 +735,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@interline-io/catenary@0.3.0':
-    resolution: {integrity: sha512-awh02KzQQahEhcDNHf5BOuEgYi8xroxHwC0SzHNTRa2DzK7sZ+LXosz7jv7TBroDcMSZvtuyPb0NGKZLqB68Sg==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.3.0/30da3cf17f04b8a82f640a3349f06ec4d535a99b}
+  '@interline-io/catenary@0.4.0':
+    resolution: {integrity: sha512-mIvvqgQKAFrAPFvVk9huVmnCCtR05OW5PU82FEN9VO0cR1qxS66JnOtNeZpHAzYn4jA1OOYZT8VP8zmOlSoB4g==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.4.0/6d1eb95f9338b518eef058ab60114851f25c3927}
     peerDependencies:
       '@mdi/font': ^7.4.0
       bulma: ^1.0.0
@@ -5417,10 +5417,10 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
-  '@dxup/nuxt@0.2.2(magicast@0.5.2)':
+  '@dxup/nuxt@0.2.2(magicast@0.3.5)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
       chokidar: 4.0.3
       pathe: 2.0.3
       tinyglobby: 0.2.15
@@ -5699,7 +5699,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@interline-io/catenary@0.3.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/catenary@0.4.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@mdi/font': 7.4.47
       bulma: 1.0.4
@@ -5708,12 +5708,12 @@ snapshots:
       vue: 3.5.22(typescript@5.9.3)
       vue-router: 4.6.4(vue@3.5.22(typescript@5.9.3))
 
-  '@interline-io/tlv2-auth@0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/tlv2-auth@0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@auth0/auth0-nuxt': 1.0.1
       defu: 6.1.4
       h3: 1.15.8
-      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
       vue: 3.5.22(typescript@5.9.3)
 
   '@ioredis/commands@1.5.1': {}
@@ -5835,11 +5835,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.2.0)(cac@6.7.14)(magicast@0.5.2)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.2.0)(cac@6.7.14)(magicast@0.3.5)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -5883,9 +5883,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@3.2.4(magicast@0.3.5)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
       execa: 8.0.1
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -5983,13 +5983,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))':
+  '@nuxt/eslint@1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(magicast@0.3.5)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))':
     dependencies:
       '@eslint/config-inspector': 1.5.0(eslint@9.39.1(jiti@2.6.1))
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.3.5)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))
       '@nuxt/eslint-config': 1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/eslint-plugin': 1.10.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
       chokidar: 4.0.3
       eslint: 9.39.1(jiti@2.6.1)
       eslint-flat-config-utils: 2.1.4
@@ -6037,9 +6037,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.2.0(magicast@0.5.2)':
+  '@nuxt/kit@4.2.0(magicast@0.3.5)':
     dependencies:
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -6062,9 +6062,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.4.2(magicast@0.5.2)':
+  '@nuxt/kit@4.4.2(magicast@0.3.5)':
     dependencies:
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -6087,10 +6087,10 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.2.0(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.2.0(db0@0.3.4)(ioredis@5.10.0)(magicast@0.3.5)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.2.0(magicast@0.5.2)
+      '@nuxt/kit': 4.2.0(magicast@0.3.5)
       '@unhead/vue': 2.1.12(vue@3.5.22(typescript@5.9.3))
       '@vue/shared': 3.5.30
       consola: 3.4.2
@@ -6105,7 +6105,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.1
-      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
       pathe: 2.0.3
       pkg-types: 2.3.0
       radix3: 1.1.2
@@ -6160,18 +6160,18 @@ snapshots:
       pkg-types: 2.3.0
       std-env: 3.10.0
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.2.0(magicast@0.5.2))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.2.0(magicast@0.3.5))':
     dependencies:
-      '@nuxt/kit': 4.2.0(magicast@0.5.2)
+      '@nuxt/kit': 4.2.0(magicast@0.3.5)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/vite-builder@4.2.0(@types/node@25.5.0)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.2.0(@types/node@25.5.0)(eslint@9.39.1(jiti@2.6.1))(magicast@0.3.5)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
-      '@nuxt/kit': 4.2.0(magicast@0.5.2)
+      '@nuxt/kit': 4.2.0(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
@@ -6189,7 +6189,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.8
@@ -8966,19 +8966,19 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2):
+  nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
-      '@dxup/nuxt': 0.2.2(magicast@0.5.2)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.2.0)(cac@6.7.14)(magicast@0.5.2)
+      '@dxup/nuxt': 0.2.2(magicast@0.3.5)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.2.0)(cac@6.7.14)(magicast@0.3.5)
       '@nuxt/devtools': 2.7.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
-      '@nuxt/kit': 4.2.0(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.2.0(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)
+      '@nuxt/kit': 4.2.0(magicast@0.3.5)
+      '@nuxt/nitro-server': 4.2.0(db0@0.3.4)(ioredis@5.10.0)(magicast@0.3.5)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)
       '@nuxt/schema': 4.2.0
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.2.0(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.2.0(@types/node@25.5.0)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.2.0(magicast@0.3.5))
+      '@nuxt/vite-builder': 4.2.0(@types/node@25.5.0)(eslint@9.39.1(jiti@2.6.1))(magicast@0.3.5)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.12(vue@3.5.22(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2

--- a/src/core/datetime.test.ts
+++ b/src/core/datetime.test.ts
@@ -20,7 +20,7 @@ import {
   formatGtfsTimeFull,
   formatDuration,
   validEndDate,
-  WIDE_DATE_YEARS_BACK,
+  FEED_ARCHIVE_MIN_DATE,
   WIDE_DATE_YEARS_FORWARD,
   wideMaxAllowedDate,
   wideMinAllowedDate
@@ -657,10 +657,13 @@ describe('wide date bounds', () => {
     vi.useRealTimers()
   })
 
-  it('span WIDE_DATE_YEARS_BACK/FORWARD around today', () => {
+  it('floor is the fixed Feed Archive start date', () => {
+    expect(asDateString(wideMinAllowedDate())).toBe(FEED_ARCHIVE_MIN_DATE)
+  })
+
+  it('ceiling is WIDE_DATE_YEARS_FORWARD years from today', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 5, 6, 12, 0))
-    expect(asDateString(wideMinAllowedDate())).toBe(`${2026 - WIDE_DATE_YEARS_BACK}-06-06`)
     expect(asDateString(wideMaxAllowedDate())).toBe(`${2026 + WIDE_DATE_YEARS_FORWARD}-06-06`)
   })
 })

--- a/src/core/datetime.test.ts
+++ b/src/core/datetime.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import {
   normalizeDate,
   normalizeTime,
@@ -10,13 +10,20 @@ import {
   asTime,
   asDateString,
   asTimeString,
+  defaultEndDate,
+  defaultStartDate,
   getLocalDateNoTime,
   getUTCDateNoTime,
   parseHMS,
   dateToSeconds,
   formatGtfsTime,
   formatGtfsTimeFull,
-  formatDuration
+  formatDuration,
+  validEndDate,
+  WIDE_DATE_YEARS_BACK,
+  WIDE_DATE_YEARS_FORWARD,
+  wideMaxAllowedDate,
+  wideMinAllowedDate
 } from './datetime'
 
 describe('normalizeDate', () => {
@@ -584,5 +591,76 @@ describe('roundtrip consistency', () => {
 
   it('asTimeString roundtrips a time string', () => {
     expect(asTimeString('08:00:00')).toBe('08:00:00')
+  })
+})
+
+describe('defaultStartDate', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns the next Monday with no time component', () => {
+    vi.useFakeTimers()
+    // 2024-07-17 was a Wednesday; next Monday is 2024-07-22.
+    vi.setSystemTime(new Date(2024, 6, 17, 15, 30))
+    const d = defaultStartDate()
+    expect(d.getDay()).toBe(1)
+    expect(asDateString(d)).toBe('2024-07-22')
+    expect(d.getHours()).toBe(0)
+  })
+
+  it('returns today when today is a Monday', () => {
+    vi.useFakeTimers()
+    // 2024-07-15 was a Monday.
+    vi.setSystemTime(new Date(2024, 6, 15, 9, 0))
+    expect(asDateString(defaultStartDate())).toBe('2024-07-15')
+  })
+})
+
+describe('defaultEndDate', () => {
+  it('returns six days after the start (a one-week window)', () => {
+    const start = new Date(2024, 6, 15)
+    expect(asDateString(defaultEndDate(start))).toBe('2024-07-21')
+  })
+})
+
+describe('validEndDate', () => {
+  const start = new Date(2024, 6, 15)
+
+  it('is always valid in single-day mode', () => {
+    expect(validEndDate(start, new Date(2024, 6, 1), true)).toBe(true)
+    expect(validEndDate(start, undefined, true)).toBe(true)
+  })
+
+  it('accepts an end on or after the start', () => {
+    expect(validEndDate(start, new Date(2024, 6, 15), false)).toBe(true)
+    expect(validEndDate(start, new Date(2024, 6, 22), false)).toBe(true)
+  })
+
+  it('rejects an end before the start', () => {
+    expect(validEndDate(start, new Date(2024, 6, 14), false)).toBe(false)
+  })
+
+  it('compares date portions only', () => {
+    // Same calendar day, later wall-clock time on the start.
+    expect(validEndDate(new Date(2024, 6, 15, 23, 59), new Date(2024, 6, 15, 0, 0), false)).toBe(true)
+  })
+
+  it('rejects missing dates outside single-day mode', () => {
+    expect(validEndDate(undefined, new Date(2024, 6, 15), false)).toBe(false)
+    expect(validEndDate(start, undefined, false)).toBe(false)
+  })
+})
+
+describe('wide date bounds', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('span WIDE_DATE_YEARS_BACK/FORWARD around today', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 6, 12, 0))
+    expect(asDateString(wideMinAllowedDate())).toBe(`${2026 - WIDE_DATE_YEARS_BACK}-06-06`)
+    expect(asDateString(wideMaxAllowedDate())).toBe(`${2026 + WIDE_DATE_YEARS_FORWARD}-06-06`)
   })
 })

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -1,4 +1,4 @@
-import { isValid, parse, format, set } from 'date-fns'
+import { addDays, endOfYesterday, isValid, nextMonday, parse, format, set } from 'date-fns'
 
 const dateFmt = 'yyyy-MM-dd'
 const timeFmt = 'HH:mm:ss'
@@ -150,6 +150,19 @@ export function wideMaxAllowedDate (): Date {
   const d = getLocalDateNoTime()
   d.setFullYear(d.getFullYear() + WIDE_DATE_YEARS_FORWARD)
   return d
+}
+
+// Default analysis window: next Monday through the following Sunday. Shared
+// by the URL-backed scenario-input getters and the Feed Archive modal's
+// Reset action so both agree on what "default" means.
+// endOfYesterday() so that if today is Monday, nextMonday returns today (not next week).
+// normalizeDate strips the time component so the date serializes consistently across timezones.
+export function defaultStartDate (): Date {
+  return normalizeDate(nextMonday(endOfYesterday()))!
+}
+
+export function defaultEndDate (start: Date): Date {
+  return addDays(start, 6)
 }
 
 /**

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -130,6 +130,28 @@ export function getLocalDateNoTime (): Date {
   return normalizeDate(new Date()) as Date
 }
 
+// The "Dates & feed versions" modal allows a much wider analysis window than
+// the Query panel's inline date pickers, for use with imported historical
+// feed versions (#223). Shared between the modal's pickers and the Query
+// panel's validation so a range set in the modal is never rejected outside it.
+// Generously past the oldest archived feed versions (2016 as of mid-2026,
+// with older archive imports expected) — an over-wide bound is harmless since
+// the timeline makes empty periods obvious.
+export const WIDE_DATE_YEARS_BACK = 15
+export const WIDE_DATE_YEARS_FORWARD = 2
+
+export function wideMinAllowedDate (): Date {
+  const d = getLocalDateNoTime()
+  d.setFullYear(d.getFullYear() - WIDE_DATE_YEARS_BACK)
+  return d
+}
+
+export function wideMaxAllowedDate (): Date {
+  const d = getLocalDateNoTime()
+  d.setFullYear(d.getFullYear() + WIDE_DATE_YEARS_FORWARD)
+  return d
+}
+
 /**
  * Get current date in UTC timezone with time set to midnight.
  * @returns Date object representing today at 00:00:00 UTC

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -130,20 +130,18 @@ export function getLocalDateNoTime (): Date {
   return normalizeDate(new Date()) as Date
 }
 
-// The "Dates & feed versions" modal allows a much wider analysis window than
-// the Query panel's inline date pickers, for use with imported historical
-// feed versions (#223). Shared between the modal's pickers and the Query
-// panel's validation so a range set in the modal is never rejected outside it.
-// Generously past the oldest archived feed versions (2016 as of mid-2026,
-// with older archive imports expected) — an over-wide bound is harmless since
-// the timeline makes empty periods obvious.
-export const WIDE_DATE_YEARS_BACK = 15
+// The Feed Archive modal allows a much wider analysis window than the Query
+// panel's inline date pickers, for use with imported historical feed versions
+// (#223). Shared between the modal's pickers and the Query panel's validation
+// so a range set in the modal is never rejected outside it.
+//
+// The floor is the start of the Feed Archive's holdings — hardcoded for now;
+// it may move earlier as historical archive imports extend further back.
+export const FEED_ARCHIVE_MIN_DATE = '2016-01-01'
 export const WIDE_DATE_YEARS_FORWARD = 2
 
 export function wideMinAllowedDate (): Date {
-  const d = getLocalDateNoTime()
-  d.setFullYear(d.getFullYear() - WIDE_DATE_YEARS_BACK)
-  return d
+  return parseDate(FEED_ARCHIVE_MIN_DATE)!
 }
 
 export function wideMaxAllowedDate (): Date {

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -153,6 +153,24 @@ export function wideMaxAllowedDate (): Date {
 }
 
 /**
+ * Whether an end date is valid for a date range: on or after the start date,
+ * comparing date portions only. In single-day mode there is no separate end
+ * date to validate. Shared by the Query panel and the Feed Archive modal so
+ * the invariant can't drift.
+ */
+export function validEndDate (start: Date | undefined, end: Date | undefined, singleDay: boolean): boolean {
+  if (singleDay) {
+    return true
+  }
+  const s = normalizeDate(start)
+  const e = normalizeDate(end)
+  if (!s || !e) {
+    return false
+  }
+  return e >= s
+}
+
+/**
  * Get current date in UTC timezone with time set to midnight.
  * @returns Date object representing today at 00:00:00 UTC
  */

--- a/src/tl/feed-version.ts
+++ b/src/tl/feed-version.ts
@@ -74,11 +74,13 @@ query ($ids: [Int!]) {
 }`
 
 // Response row of feedVersionsByIdsQuery with the display fields included.
+// Calendar dates are nullable — a feed version with no calendar entries (e.g.
+// a flex-only or empty feed) returns null for both.
 export interface FeedVersionSummaryRow extends FeedVersion {
   fetched_at: string
   name: string | null
-  earliest_calendar_date: string
-  latest_calendar_date: string
+  earliest_calendar_date: string | null
+  latest_calendar_date: string | null
   feed: {
     id: number
     onestop_id: string

--- a/src/tl/feed-version.ts
+++ b/src/tl/feed-version.ts
@@ -53,17 +53,38 @@ export const DEPRIORITIZED_FEED_ONESTOP_IDS: ReadonlySet<string> = new Set([
 
 // Batched lookup for the picker overrides — fetches the explicit feed
 // version ids the user picked so the scenario fetcher knows their sha1s.
+// Also carries display fields (fetched_at, calendar range, names) so the
+// Query panel's override summary can describe each pick without a second
+// query; the scenario-side consumer just ignores the extras.
 export const feedVersionsByIdsQuery = gql`
 query ($ids: [Int!]) {
   feed_versions(ids: $ids) {
     id
     sha1
+    fetched_at
+    name
+    earliest_calendar_date
+    latest_calendar_date
     feed {
       id
       onestop_id
+      name
     }
   }
 }`
+
+// Response row of feedVersionsByIdsQuery with the display fields included.
+export interface FeedVersionSummaryRow extends FeedVersion {
+  fetched_at: string
+  name: string | null
+  earliest_calendar_date: string
+  latest_calendar_date: string
+  feed: {
+    id: number
+    onestop_id: string
+    name: string | null
+  }
+}
 
 // --- Feed version browser (used by the picker on the Query tab) ---
 
@@ -252,7 +273,6 @@ export function ordinalToIso (ord: number): string {
   const d = String(dt.getUTCDate()).padStart(2, '0')
   return `${y}-${m}-${d}`
 }
-
 // --- fvids URL param ---
 //
 // The /tne Query tab's picker modal persists explicit feed version picks

--- a/src/tl/feed-version.ts
+++ b/src/tl/feed-version.ts
@@ -149,8 +149,70 @@ export interface FeedWithVersions {
   feed_versions: FeedVersionDetail[]
 }
 
-// `covers` is intentionally NOT applied so operators can see FVs that almost
-// cover and import one anyway.
+// A feed version's full picker detail plus its owning feed's onestop_id, so a
+// pinned version fetched by id can be merged back into the right feed row.
+export interface FeedVersionDetailWithFeed extends FeedVersionDetail {
+  feed: { id: number, onestop_id: string }
+}
+
+// Full detail for explicitly-pinned feed versions, fetched by id so the picker
+// can always show the user's current selection even when it falls outside the
+// browsed date window (where feedsForImportQuery's `covers` filter would
+// otherwise drop it). service_levels use the same window/swap as the browse
+// query so the timeline renders consistently.
+export const pinnedFeedVersionsQuery = gql`
+query ($ids: [Int!], $serviceLevelStart: Date, $serviceLevelEnd: Date) {
+  feed_versions(ids: $ids) {
+    id
+    sha1
+    fetched_at
+    name
+    earliest_calendar_date
+    latest_calendar_date
+    feed {
+      id
+      onestop_id
+    }
+    service_window {
+      feed_start_date
+      feed_end_date
+      earliest_calendar_date
+      latest_calendar_date
+      fallback_week
+      default_timezone
+    }
+    service_levels(limit: 1000, where: { start_date: $serviceLevelStart, end_date: $serviceLevelEnd }) {
+      start_date
+      end_date
+      monday
+      tuesday
+      wednesday
+      thursday
+      friday
+      saturday
+      sunday
+    }
+    feed_version_gtfs_import {
+      id
+      in_progress
+      success
+      exception_log
+      entity_count
+      warning_count
+      created_at
+      updated_at
+    }
+  }
+}`
+
+// feed_versions is scoped to versions whose coverage OVERLAPS the analysis
+// window, so changing the query dates surfaces the versions relevant to that
+// period (older versions for historical dates) instead of always the newest 10.
+// Overlap is lenient — a version covering only part of the window still shows,
+// so an operator can import a near-miss — and uses the same start/end swap as
+// the service_levels filter below: covers.start_date = windowEnd and
+// covers.end_date = windowStart selects versions whose coverage begins on or
+// before windowEnd AND ends on or after windowStart.
 //
 // service_levels filter is overlap-via-swap: server treats
 // where.start_date as `row.start_date <= X` and where.end_date as
@@ -158,7 +220,7 @@ export interface FeedWithVersions {
 // windowStart → end_date to get rows overlapping [windowStart, windowEnd].
 // See transitland-lib/server/finders/dbfinder/feed_version.go.
 export const feedsForImportQuery = gql`
-query ($bbox: BoundingBox!, $serviceLevelStart: Date, $serviceLevelEnd: Date) {
+query ($bbox: BoundingBox!, $serviceLevelStart: Date, $serviceLevelEnd: Date, $coversStart: Date, $coversEnd: Date) {
   feeds(limit: 100, where: { bbox: $bbox, spec: [GTFS] }) {
     id
     onestop_id
@@ -170,7 +232,7 @@ query ($bbox: BoundingBox!, $serviceLevelStart: Date, $serviceLevelEnd: Date) {
         agencies { agency_name }
       }
     }
-    feed_versions(limit: 10) {
+    feed_versions(limit: 10, where: { covers: { start_date: $coversStart, end_date: $coversEnd } }) {
       id
       sha1
       fetched_at

--- a/src/tl/feed-version.ts
+++ b/src/tl/feed-version.ts
@@ -366,6 +366,15 @@ export function serializeFvids (parsed: ParsedFvids): string {
 
 export type FeedVersionImportStatus = 'not_imported' | 'in_progress' | 'imported' | 'error'
 
+// Human-readable labels, shared by the import status badge and row tooltips
+// so the wording can't drift between them.
+export const FEED_VERSION_IMPORT_STATUS_LABELS: Record<FeedVersionImportStatus, string> = {
+  imported: 'Imported',
+  in_progress: 'In progress',
+  error: 'Import error',
+  not_imported: 'Not imported',
+}
+
 // Transient state for a feed-version-import/unimport job submitted in the
 // current session — picker watches and propagates this down to the row so
 // the UI tracks progress without a graphql refetch. `state` is the


### PR DESCRIPTION
## Summary

Integrates query date-range selection with feed-version selection into a single "Feed Archive" experience, and makes historical queries work end to end. The feed-version picker modal becomes a combined selector for analysis dates and pinned feed versions, and its version list is now scoped to the queried dates — so older versions surface for past dates instead of always showing the newest. The Feed Archive holds every fetched version of each feed (back to a 2016-01-01 floor, and earlier as the archive grows). The modal is reached from the Date range panel; the previous Advanced Settings entry point is removed. Closes #360.

## User-facing changes

### Feed Archive modal (formerly "Pick feed versions")
- Titled "Feed Archive: dates & feed versions"; edits the query date range alongside feed-version picks — start/end date pickers in the header (with a much wider allowed range than the Query panel: back to the Feed Archive floor of 2016-01-01, and 2 years forward) plus a single-day toggle.
- The version list is scoped to the analysis window — it shows versions whose coverage overlaps the queried dates — so moving the dates (e.g. several years back) surfaces the relevant historical versions rather than always the newest.
- A version you have explicitly pinned stays visible and selected even after you move the window away from its coverage, so your selection is never silently hidden.
- The highlighted analysis window on each timeline row is draggable and resizable; dragging updates the staged dates live across all rows, and arrow keys nudge it when focused. Changing the start date shifts the whole window (preserving its length) instead of stretching it into a giant range.
- Date edits, picks, and exclusions are staged together: Apply commits them all at once, Cancel discards, Reset restages the default next-Monday week with no overrides. Edits are clamped to the allowed range, so the modal can't commit a window the Query panel would reject.
- Import status and actions are separated: status is a colored dot + label (Imported, Not imported, Error, or live job state), and Import / Retry / Unimport are explicit buttons.

### Date range panel
- New entry point below the date controls: explanatory text, an "Open Feed Archive…" link, an override-count badge, and a "Clear overrides" action.
- Active overrides render as a quick-reference list: each pinned version shows feed name, fetched date, coverage range, and short sha1 (or "no calendar dates" when a version has none), plus any excluded feeds.
- Date validation accepts the modal's wider range; dates outside the default picker window show an informational note instead of a blocking error. The inline pickers keep their conservative bounds for direct use.
- The end-date control and single-day toggle are shared with the modal (one `cal-end-date-field` component), so the "Remove end date" / "Set an end date" affordance and keyboard focus behave consistently. Single-day mode is derived from the dates (a single-day link opens in single-day mode); the default query is a full next-Monday week.

## Implementation details

### Date-scoped version list
- `feedsForImportQuery` filters `feed_versions` with `where: { covers: { start_date, end_date } }`, fed the analysis window with the same start/end swap the `service_levels` filter uses, so it matches versions whose coverage overlaps the window (lenient — partial overlaps still show, so an operator can import a near-miss).
- Explicitly-pinned versions are fetched by id (`pinnedFeedVersionsQuery`) and merged back into their feed's row, so a pin outside the browsed window stays visible and selectable.

### Staged date editing
- The modal owns staged copies of startDate/endDate/singleDay/fvids, snapshotted on open; an `apply` event carries them back and `useScenarioInputs.applyDatesAndFvids()` commits all URL params in one navigation (setQuery is only race-safe within a single call). Changing the start date shifts the end to preserve the window length.

### Timeline window drag
- `feed-version-timeline.vue` gains an `editable` mode: pointer-capture drag with move/resize hit zones, px-to-ordinal-day conversion (with the bounding rect cached at pointerdown to avoid a per-move layout reflow), a transient local rect for lag-free feedback, rAF-throttled `update:analysisRange` emits, and keyboard support.

### Picker stability during edits
- The timeline scale and feed sort order run off debounced dates so rows don't rescale or resort mid-drag. The `service_levels` fetch window snaps to a coarse grid so it stays proportional to the visible domain rather than growing unbounded across a session.

### Shared pieces and bounds
- `cal-end-date-field` is shared by the Query panel and the modal. `defaultStartDate()` / `defaultEndDate()` / `validEndDate()` and `FEED_ARCHIVE_MIN_DATE` / `WIDE_DATE_YEARS_FORWARD` live in `src/core/datetime.ts` (with unit tests) as the single source for defaults, validation, and the wide picker bounds. Import-status colors come from Bulma theme variables rather than inline JS hex.

### Dependency
- Bumps `@interline-io/catenary` to **0.4.0**, which fixes `cat-datepicker` close-on-select (the calendar now dismisses when a date is picked) and declares `aria-label` / `title` as `cat-button` props (consumed by `cal-end-date-field`'s "remove end date" button).

## User test plan

1. Query tab: confirm the Date range panel shows the Feed Archive help text and "Open Feed Archive…" link; Advanced Settings no longer lists feed versions.
2. Open the modal and set the dates several years back. Confirm the feed-version rows update to show versions whose coverage overlaps those dates (not just the newest), and that dragging/resizing the highlighted window on a row updates all rows live.
3. Change the start date in the modal to a different year; confirm the end date moves with it (the window keeps its length) rather than producing a multi-year range.
4. Pin an older version, then move the window away from its coverage; confirm the pinned version stays visible and selected at the top of its row.
5. Apply: confirm the URL gains startDate/endDate/fvids together, the Query panel shows the informational (non-blocking) note, and the override summary lists the pin with fetched date, coverage, and sha1. Run a browse query and confirm results reflect the pinned version.
6. Confirm Cancel discards staged edits, Reset restages defaults without closing, and "Clear overrides" removes all picks.
7. For a not-imported version, press Import: the status dot shows the live job state with a link to the job-status page; after success the row updates. Confirm an imported non-active version offers Unimport and the active version shows status only.
8. Toggle single-day mode in both the panel and the modal; confirm startDate equals endDate in the URL after Apply, that a fresh load with no dates defaults to a full week, and that selecting a date in any picker closes the calendar.
9. Confirm flex / no-calendar feeds still appear in the picker (the coverage filter relies on feed dates, so verify nothing relevant is filtered out).

## Known follow-ups

- **Flex / no-calendar feed coverage (needs verification).** The new `covers` filter matches feed versions by `feed_info` dates or calculated calendar dates. A version with neither would be filtered out where it previously appeared. Flex feeds normally have calendar data, so this likely doesn't bite, but confirm expected flex feeds still show in the picker before relying on it (see test plan step 9).

