### PR TITLE
Contain query panel overflow to prevent whole-page scroll

### DIFF
--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -509,6 +509,7 @@ const validQueryParams = computed(() => {
     flex-direction:column;
     background: var(--bulma-scheme-main);
     height:100%;
+    overflow-y: auto;
     padding-left: v-bind(panelPaddingPx);
     padding-right: v-bind(panelPaddingPx);
     > .cal-body {


### PR DESCRIPTION
## Summary
On the /tne Query tab, expanding the Advanced Settings panel produced a vertical scrollbar on the entire page instead of scrolling within the query panel.

The layout chain had no overflow handling: `.cal-tab-content` is `position: absolute; height: 100vh` and `.cal-query` is `height: 100%`, neither clipping nor scrolling overflow. The overflowing content, living in an absolutely-positioned element, extended the document's scroll region.

Fix: add `overflow-y: auto` to `.cal-query` (already exactly 100vh tall) so overflow scrolls inside the query panel. Scoped to the Query tab; filter/report/analysis tabs are unaffected.

## User test plan
- Open /tne, Query tab; toggle Advanced Settings open and confirm only the query panel scrolls (no whole-page scrollbar).
- Scroll the panel and confirm the Run Browse Query / Run Advanced Analysis buttons stay reachable.
- Confirm Filter, Report, and Analysis tabs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)