### PR TITLE
Integrate job status into main UI: sidebar icon, jobs index page, session badge

### DIFF
--- a/app/components/cal/feed-version-picker.vue
+++ b/app/components/cal/feed-version-picker.vue
@@ -333,7 +333,7 @@ async function submitJob (fvId: number, kind: FeedVersionPendingJobKind) {
     // Register with the session job tracker so the sidebar badge and the
     // /job-status index see this job (including from a new tab). The tracker
     // runs its own watcher; the per-row watcher below stays for modal UI.
-    jobTracker.registerJob({ queue, jobId: idStr, kind, feedVersionId: fvId })
+    jobTracker.registerJob({ queue, jobId: idStr })
     unsubscribeJob(fvId)
     watchHandles.set(fvId, watchJob({
       queue,

--- a/app/components/cal/feed-version-picker.vue
+++ b/app/components/cal/feed-version-picker.vue
@@ -268,6 +268,10 @@ const pendingJobs = ref<Record<number, FeedVersionPendingJob>>({})
 // One handle per fvId — replaced on resubmit, drained on unmount.
 const watchHandles = new Map<number, WatchJobHandle>()
 
+// Session-wide job tracker (localStorage-backed) behind the sidebar badge
+// and the /job-status index page.
+const jobTracker = useJobTracker()
+
 function queueForKind (kind: FeedVersionPendingJobKind): string {
   return kind === 'unimport' ? 'feed-version-unimport' : 'feed-version-import'
 }
@@ -326,6 +330,10 @@ async function submitJob (fvId: number, kind: FeedVersionPendingJobKind) {
       ...pendingJobs.value,
       [fvId]: { jobId: idStr, state: parsed.state || 'queued', kind },
     }
+    // Register with the session job tracker so the sidebar badge and the
+    // /job-status index see this job (including from a new tab). The tracker
+    // runs its own watcher; the per-row watcher below stays for modal UI.
+    jobTracker.registerJob({ queue, jobId: idStr, kind, feedVersionId: fvId })
     unsubscribeJob(fvId)
     watchHandles.set(fvId, watchJob({
       queue,

--- a/app/components/main-header.vue
+++ b/app/components/main-header.vue
@@ -57,6 +57,19 @@
 
             <li>
               <nuxt-link
+                to="/job-status"
+                :class="itemHelper('/job-status')"
+                class="cal-jobs-link"
+                title="Jobs"
+                aria-label="Jobs"
+              >
+                <cat-icon icon="clipboard-text-clock" size="large" class="is-fullwidth" variant="white" />
+                <span v-if="activeJobCount > 0" class="cal-jobs-badge" aria-hidden="true">{{ activeJobCount > 9 ? '9+' : activeJobCount }}</span>
+              </nuxt-link>
+            </li>
+
+            <li>
+              <nuxt-link
                 :to="{ name: 'admin-profile' }"
                 :class="itemHelper('/admin/profile')"
                 title="My user profile"
@@ -88,6 +101,11 @@ const toggleDarkMode = useToggle(isDark)
 
 const debugMenu = useDebugMenu()
 const debugMenuToggle = useToggle(debugMenu)
+
+const { activeCount: activeJobCount, ensureWatching } = useJobTracker()
+// Resume watching non-terminal session-started jobs in this tab — covers the
+// new-tab handoff from the Feed Archive modal's job links.
+onMounted(() => { ensureWatching() })
 
 function itemHelper (p: string): string {
   if (route.path.startsWith(p)) {
@@ -125,6 +143,26 @@ function itemHelper (p: string): string {
 
   .bottom-group {
     margin-top: auto;
+  }
+
+  .cal-jobs-link {
+    position: relative;
+  }
+
+  .cal-jobs-badge {
+    position: absolute;
+    top: 4px;
+    right: 16px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 8px;
+    background: var(--bulma-danger);
+    color: #fff;
+    font-size: 0.65rem;
+    line-height: 16px;
+    text-align: center;
+    pointer-events: none;
   }
 
   img.icon {

--- a/app/composables/useJobTracker.ts
+++ b/app/composables/useJobTracker.ts
@@ -1,0 +1,134 @@
+import { useStorage } from '@vueuse/core'
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
+import { JOB_TERMINAL_STATES, JOBS_USE_SSE, watchJob, type WatchJobHandle } from '~~/src/tl'
+
+// Jobs started from this browser, persisted to localStorage so the badge and
+// jobs list survive the open-in-new-tab handoff from the Feed Archive modal
+// and stay in sync across tabs (useStorage listens to the `storage` event).
+export interface TrackedJob {
+  queue: string
+  jobId: string
+  state: string
+  kind?: string
+  feedVersionId?: number
+  startedAtMs: number
+  updatedAtMs: number
+}
+
+// Entries that haven't been updated in this long are excluded from the badge
+// count — covers jobs whose watch 404'd (pruned server-side) before reaching
+// a terminal state, which would otherwise read "running" forever.
+const STALE_ACTIVE_MS = 24 * 60 * 60 * 1000
+// Terminal entries older than this are pruned from localStorage.
+const PRUNE_TERMINAL_MS = 7 * 24 * 60 * 60 * 1000
+const MAX_TRACKED_JOBS = 50
+
+const STORAGE_KEY = 'cal-tracked-jobs'
+
+// Module-level singleton so main-header, the feed-version picker, and the
+// jobs index page share one list and one set of watchers per tab.
+let trackedJobs: Ref<TrackedJob[]> | null = null
+const watchHandles = new Map<string, WatchJobHandle>()
+
+function jobKey (queue: string, jobId: string): string {
+  return `${queue}/${jobId}`
+}
+
+function isActive (j: TrackedJob, nowMs: number): boolean {
+  return !JOB_TERMINAL_STATES.has(j.state) && (nowMs - j.updatedAtMs) < STALE_ACTIVE_MS
+}
+
+function prune (jobs: TrackedJob[], nowMs: number): TrackedJob[] {
+  return jobs
+    .filter(j => !(JOB_TERMINAL_STATES.has(j.state) && (nowMs - j.updatedAtMs) > PRUNE_TERMINAL_MS))
+    .sort((a, b) => b.startedAtMs - a.startedAtMs)
+    .slice(0, MAX_TRACKED_JOBS)
+}
+
+export interface JobTracker {
+  trackedJobs: Ref<TrackedJob[]>
+  activeCount: ComputedRef<number>
+  registerJob: (job: { queue: string, jobId: string, kind?: string, feedVersionId?: number }) => void
+  ensureWatching: () => void
+}
+
+export const useJobTracker = (): JobTracker => {
+  if (import.meta.server) {
+    return {
+      trackedJobs: ref([]),
+      activeCount: computed(() => 0),
+      registerJob: () => {},
+      ensureWatching: () => {},
+    }
+  }
+
+  if (trackedJobs == null) {
+    trackedJobs = useStorage<TrackedJob[]>(STORAGE_KEY, [])
+  }
+  const jobs = trackedJobs
+
+  // Rewrite one entry, producing a new array so useStorage reserializes and
+  // other tabs receive the storage event.
+  function updateJob (queue: string, jobId: string, state: string) {
+    jobs.value = jobs.value.map(j =>
+      j.queue === queue && j.jobId === jobId
+        ? { ...j, state, updatedAtMs: Date.now() }
+        : j)
+  }
+
+  function startWatching (queue: string, jobId: string) {
+    const key = jobKey(queue, jobId)
+    if (watchHandles.has(key)) { return }
+    const handle = watchJob({
+      queue,
+      jobId,
+      useSSE: JOBS_USE_SSE,
+      onState: (state) => {
+        updateJob(queue, jobId, state)
+        if (JOB_TERMINAL_STATES.has(state)) {
+          watchHandles.delete(key)
+        }
+      },
+    })
+    watchHandles.set(key, handle)
+  }
+
+  function registerJob (job: { queue: string, jobId: string, kind?: string, feedVersionId?: number }) {
+    const nowMs = Date.now()
+    const entry: TrackedJob = {
+      queue: job.queue,
+      jobId: job.jobId,
+      state: 'queued',
+      kind: job.kind,
+      feedVersionId: job.feedVersionId,
+      startedAtMs: nowMs,
+      updatedAtMs: nowMs,
+    }
+    const rest = jobs.value.filter(j => !(j.queue === job.queue && j.jobId === job.jobId))
+    jobs.value = prune([entry, ...rest], nowMs)
+    startWatching(job.queue, job.jobId)
+  }
+
+  // Start watchers for any non-terminal tracked jobs not already watched in
+  // this tab — covers the new-tab handoff and tabs that outlive the
+  // originating one. Also prunes old terminal entries.
+  function ensureWatching () {
+    const nowMs = Date.now()
+    const pruned = prune(jobs.value, nowMs)
+    if (pruned.length !== jobs.value.length) {
+      jobs.value = pruned
+    }
+    for (const j of jobs.value) {
+      if (isActive(j, nowMs)) {
+        startWatching(j.queue, j.jobId)
+      }
+    }
+  }
+
+  const activeCount = computed(() => {
+    const nowMs = Date.now()
+    return jobs.value.filter(j => isActive(j, nowMs)).length
+  })
+
+  return { trackedJobs: jobs, activeCount, registerJob, ensureWatching }
+}

--- a/app/composables/useJobTracker.ts
+++ b/app/composables/useJobTracker.ts
@@ -1,5 +1,5 @@
 import { useStorage } from '@vueuse/core'
-import { computed, ref, type ComputedRef, type Ref } from 'vue'
+import { computed, type ComputedRef, type Ref } from 'vue'
 import { JOB_TERMINAL_STATES, JOBS_USE_SSE, watchJob, type WatchJobHandle } from '~~/src/tl'
 
 // Jobs started from this browser, persisted to localStorage so the badge and
@@ -9,8 +9,6 @@ export interface TrackedJob {
   queue: string
   jobId: string
   state: string
-  kind?: string
-  feedVersionId?: number
   startedAtMs: number
   updatedAtMs: number
 }
@@ -46,16 +44,14 @@ function prune (jobs: TrackedJob[], nowMs: number): TrackedJob[] {
 }
 
 export interface JobTracker {
-  trackedJobs: Ref<TrackedJob[]>
   activeCount: ComputedRef<number>
-  registerJob: (job: { queue: string, jobId: string, kind?: string, feedVersionId?: number }) => void
+  registerJob: (job: { queue: string, jobId: string }) => void
   ensureWatching: () => void
 }
 
 export const useJobTracker = (): JobTracker => {
   if (import.meta.server) {
     return {
-      trackedJobs: ref([]),
       activeCount: computed(() => 0),
       registerJob: () => {},
       ensureWatching: () => {},
@@ -68,12 +64,13 @@ export const useJobTracker = (): JobTracker => {
   const jobs = trackedJobs
 
   // Rewrite one entry, producing a new array so useStorage reserializes and
-  // other tabs receive the storage event.
+  // other tabs receive the storage event. The poller reports the state every
+  // tick, so skip the write (and the cross-tab event) when nothing changed.
   function updateJob (queue: string, jobId: string, state: string) {
+    const entry = jobs.value.find(j => j.queue === queue && j.jobId === jobId)
+    if (!entry || entry.state === state) { return }
     jobs.value = jobs.value.map(j =>
-      j.queue === queue && j.jobId === jobId
-        ? { ...j, state, updatedAtMs: Date.now() }
-        : j)
+      j === entry ? { ...j, state, updatedAtMs: Date.now() } : j)
   }
 
   function startWatching (queue: string, jobId: string) {
@@ -93,14 +90,12 @@ export const useJobTracker = (): JobTracker => {
     watchHandles.set(key, handle)
   }
 
-  function registerJob (job: { queue: string, jobId: string, kind?: string, feedVersionId?: number }) {
+  function registerJob (job: { queue: string, jobId: string }) {
     const nowMs = Date.now()
     const entry: TrackedJob = {
       queue: job.queue,
       jobId: job.jobId,
       state: 'queued',
-      kind: job.kind,
-      feedVersionId: job.feedVersionId,
       startedAtMs: nowMs,
       updatedAtMs: nowMs,
     }
@@ -130,5 +125,5 @@ export const useJobTracker = (): JobTracker => {
     return jobs.value.filter(j => isActive(j, nowMs)).length
   })
 
-  return { trackedJobs: jobs, activeCount, registerJob, ensureWatching }
+  return { activeCount, registerJob, ensureWatching }
 }

--- a/app/pages/job-status/[queue]/[jobId].vue
+++ b/app/pages/job-status/[queue]/[jobId].vue
@@ -71,6 +71,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
+import { useIntervalFn } from '@vueuse/core'
 import { useHead } from '#imports'
 import { capitalize } from '~~/src/core'
 import {
@@ -170,6 +171,10 @@ async function fetchStatus () {
   }
 }
 
+// 1s ticker so the `timing` computed updates while we wait. Paused on
+// terminal (no live duration to render); useIntervalFn cleans up on unmount.
+const nowTimer = useIntervalFn(() => { now.value = new Date() }, 1000, { immediate: false })
+
 async function start () {
   await fetchStatus()
   if (terminal.value || error.value || notFound.value) { return }
@@ -183,7 +188,7 @@ async function start () {
       lastPolledAt.value = new Date()
       if (JOB_TERMINAL_STATES.has(s)) {
         fetchStatus()
-        stopNowTicker()
+        nowTimer.pause()
       }
     },
   })
@@ -214,15 +219,6 @@ async function cancel () {
   }
 }
 
-// 1s ticker so the `timing` computed updates while we wait. Stopped on
-// terminal (no live duration to render) and on unmount.
-let nowTimer: ReturnType<typeof setInterval> | null = null
-function stopNowTicker () {
-  if (nowTimer != null) {
-    clearInterval(nowTimer)
-    nowTimer = null
-  }
-}
 // Await start() so the synchronous terminal check below sees the real
 // post-bootstrap state — otherwise a deep-link to an already-terminal job
 // starts the ticker before the fetch resolves and never stops it (watchJob
@@ -230,12 +226,11 @@ function stopNowTicker () {
 onMounted(async () => {
   await start()
   if (status.value && !terminal.value) {
-    nowTimer = setInterval(() => { now.value = new Date() }, 1000)
+    nowTimer.resume()
   }
 })
 onBeforeUnmount(() => {
   unsubscribe()
-  stopNowTicker()
 })
 </script>
 

--- a/app/pages/job-status/[queue]/[jobId].vue
+++ b/app/pages/job-status/[queue]/[jobId].vue
@@ -18,9 +18,11 @@
             <span>Job ID:</span>
             <cat-safelink :text="jobId" />
           </div>
-          <div v-if="!notFound">
-            State:
-            <strong>{{ stateLabel }}</strong>
+          <div v-if="!notFound" class="cal-job-status-field">
+            <span>State:</span>
+            <cat-tag :variant="jobStateVariant(state)" :light="state !== 'running'">
+              {{ stateLabel }}
+            </cat-tag>
           </div>
           <div v-if="timing" class="has-text-grey is-size-7">
             {{ timing }}
@@ -32,6 +34,9 @@
         </cat-notification>
         <cat-notification v-else-if="error" variant="danger">
           {{ error }}
+        </cat-notification>
+        <cat-notification v-if="jobError" variant="danger">
+          {{ jobError }}
         </cat-notification>
 
         <div class="cal-job-status-actions">
@@ -73,6 +78,7 @@ import {
   JOBS_USE_SSE,
   jobApiPath,
   jobHeading,
+  jobStateVariant,
   jobTiming,
   watchJob,
   type JobStatus,
@@ -97,6 +103,14 @@ const terminal = computed(() => JOB_TERMINAL_STATES.has(state.value))
 const stateLabel = computed(() => {
   if (!state.value) { return loading.value ? 'Loading…' : 'Unknown' }
   return capitalize(state.value)
+})
+
+// Worker-reported failure message (distinct from `error`, which is a fetch/
+// transport problem). Surfaced inline so failures don't require opening the
+// Advanced JSON dump.
+const jobError = computed(() => {
+  const msg = status.value?.error?.trim()
+  return msg ? `Job error: ${msg}` : ''
 })
 
 // Human-readable title derived from the queue and the job args (when the

--- a/app/pages/job-status/[queue]/[jobId].vue
+++ b/app/pages/job-status/[queue]/[jobId].vue
@@ -2,6 +2,9 @@
   <NuxtLayout name="default">
     <template #main>
       <div class="container is-fluid" style="padding: 16px 24px; max-width: 1000px;">
+        <nuxt-link to="/job-status" class="cal-job-status-back is-size-7">
+          ← All jobs
+        </nuxt-link>
         <h1 class="title">
           {{ heading }}
         </h1>
@@ -64,12 +67,13 @@
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useHead } from '#imports'
-import { formatDistance, formatDistanceStrict } from 'date-fns'
 import { capitalize } from '~~/src/core'
 import {
   JOB_TERMINAL_STATES,
   JOBS_USE_SSE,
   jobApiPath,
+  jobHeading,
+  jobTiming,
   watchJob,
   type JobStatus,
   type WatchJobHandle,
@@ -96,59 +100,18 @@ const stateLabel = computed(() => {
 })
 
 // Human-readable title derived from the queue and the job args (when the
-// JobStatus has landed). Pre-fetch we fall back to a queue-only label so
-// the heading isn't empty on first paint.
-const heading = computed(() => {
-  const q = queue.value
-  const fvId = status.value?.job?.args?.feed_version_id
-  if (q === 'feed-version-import') {
-    return fvId != null ? `Importing feed version ${fvId}` : 'Importing feed version'
-  }
-  if (q === 'feed-version-unimport') {
-    return fvId != null ? `Unimporting feed version ${fvId}` : 'Unimporting feed version'
-  }
-  return q ? `Job: ${q}` : 'Job status'
-})
+// JobStatus has landed) — shared with the jobs index page.
+const heading = computed(() => jobHeading(queue.value, status.value))
 
 // Browser tab title: state-first so the tab strip shows progress at a glance.
 useHead({
   title: () => `[${stateLabel.value}] ${heading.value}`,
 })
 
-function parseDateMaybe (s: string | null | undefined): Date | null {
-  if (!s) { return null }
-  const d = new Date(s)
-  return isNaN(d.getTime()) ? null : d
-}
-
-// "Submitted 2s ago" / "Running for 18s" / "Ran for 45s" depending on which
-// timestamps are populated. Reads `now` so it ticks once per second while
-// the job is still going. Guards against invalid dates and clock skew
-// (server timestamp slightly ahead of client clock) so the display never
-// reads "in 2 seconds".
-const timing = computed(() => {
-  const s = status.value
-  if (!s) { return '' }
-  const submittedAt = parseDateMaybe(s.submitted_at)
-  const startedAt = parseDateMaybe(s.started_at)
-  const finishedAt = parseDateMaybe(s.finished_at)
-  const nowTime = now.value
-  if (finishedAt) {
-    if (startedAt && finishedAt >= startedAt) {
-      return `Ran for ${formatDistanceStrict(startedAt, finishedAt)}`
-    }
-    return `Finished ${formatDistance(finishedAt, nowTime, { addSuffix: true })}`
-  }
-  if (startedAt) {
-    const safeStart = startedAt <= nowTime ? startedAt : nowTime
-    return `Running for ${formatDistanceStrict(safeStart, nowTime)}`
-  }
-  if (submittedAt) {
-    const safeSubmit = submittedAt <= nowTime ? submittedAt : nowTime
-    return `Submitted ${formatDistanceStrict(safeSubmit, nowTime, { addSuffix: true })}`
-  }
-  return ''
-})
+// "Submitted 2s ago" / "Running for 18s" / "Ran for 45s" — shared with the
+// jobs index page. Reads `now` so it ticks once per second while the job is
+// still going.
+const timing = computed(() => jobTiming(status.value, now.value))
 
 let watchHandle: WatchJobHandle | null = null
 
@@ -263,6 +226,10 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
+.cal-job-status-back {
+  display: inline-block;
+  margin-bottom: 8px;
+}
 .cal-job-status-header {
   margin: 16px 0;
   display: flex;

--- a/app/pages/job-status/[queue]/[jobId].vue
+++ b/app/pages/job-status/[queue]/[jobId].vue
@@ -20,11 +20,11 @@
           </div>
           <div v-if="!notFound" class="cal-job-status-field">
             <span>State:</span>
-            <cat-tag :variant="jobStateVariant(state)" :light="state !== 'running'">
+            <cat-tag :variant="jobStateVariant(state)">
               {{ stateLabel }}
             </cat-tag>
           </div>
-          <div v-if="timing" class="has-text-grey is-size-7">
+          <div v-if="timing" class="cal-job-status-field">
             {{ timing }}
           </div>
         </div>
@@ -53,7 +53,7 @@
         >
           <div class="cal-job-status-advanced-body">
             <div class="cal-job-status-actions">
-              <cat-button :disabled="loading" @click="refreshNow">
+              <cat-button :disabled="loading" icon-left="reload" @click="refreshNow">
                 Refresh now
               </cat-button>
             </div>

--- a/app/pages/job-status/index.vue
+++ b/app/pages/job-status/index.vue
@@ -7,7 +7,7 @@
         </h1>
 
         <div class="cal-jobs-index-actions">
-          <cat-button :disabled="loading" @click="refresh">
+          <cat-button :disabled="loading" icon-left="reload" @click="refresh">
             {{ loading ? 'Refreshing…' : 'Refresh' }}
           </cat-button>
           <span v-if="lastRefreshedAt" class="has-text-grey is-size-7">
@@ -35,7 +35,7 @@
           </template>
           <template #default="{ row }">
             <td>
-              <cat-tag :variant="jobStateVariant(row.state)" :light="row.state !== 'running'">
+              <cat-tag :variant="jobStateVariant(row.state)">
                 {{ capitalize(row.state) }}
               </cat-tag>
             </td>

--- a/app/pages/job-status/index.vue
+++ b/app/pages/job-status/index.vue
@@ -62,6 +62,10 @@
 </template>
 
 <script setup lang="ts">
+// NOTE: The job-status pages (this index and [queue]/[jobId].vue) plus the
+// src/tl/jobs.ts helpers are largely generic over the tlv2 jobs API. In the
+// future, consider moving them into a new tlv2-apps package so they can be
+// reused across multiple projects.
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useHead } from '#imports'
 import { capitalize, fmtDate } from '~~/src/core'

--- a/app/pages/job-status/index.vue
+++ b/app/pages/job-status/index.vue
@@ -19,29 +19,43 @@
           {{ error }}
         </cat-notification>
 
-        <cat-notification v-if="!loading && !error && rows.length === 0">
-          No recent jobs. Jobs are pruned from the store after completion.
-        </cat-notification>
-
-        <ul v-if="rows.length > 0" class="cal-jobs-index-list">
-          <li v-for="row in rows" :key="row.key" class="cal-jobs-index-row">
-            <span class="cal-jobs-index-state">
-              <span class="cal-jobs-index-dot" :class="`is-${row.state}`" />
-              {{ capitalize(row.state) }}
-            </span>
-            <span class="cal-jobs-index-heading">
+        <cat-table
+          :data="rows"
+          striped
+          hoverable
+          caption="Recent jobs"
+          caption-hidden
+        >
+          <template #columns>
+            <cat-table-column field="state" label="State" />
+            <cat-table-column field="heading" label="Job" />
+            <cat-table-column field="queue" label="Queue" />
+            <cat-table-column field="submitted_at" label="Submitted" />
+            <cat-table-column field="timing" label="Duration" />
+          </template>
+          <template #default="{ row }">
+            <td>
+              <cat-tag :variant="jobStateVariant(row.state)" :light="row.state !== 'running'">
+                {{ capitalize(row.state) }}
+              </cat-tag>
+            </td>
+            <td>
               <nuxt-link v-if="row.detailPath" :to="row.detailPath">
                 {{ jobHeading(row.queue, row) }}
               </nuxt-link>
               <template v-else>
                 {{ jobHeading(row.queue, row) }}
               </template>
-            </span>
-            <span class="has-text-grey is-size-7">
-              {{ jobTiming(row, now) }}
-            </span>
-          </li>
-        </ul>
+            </td>
+            <td>{{ row.queue }}</td>
+            <td>{{ fmtDate(row.submitted_at, 'yyyy-MM-dd HH:mm') }}</td>
+            <td>{{ jobTiming(row, now) }}</td>
+          </template>
+          <template #empty>
+            <span v-if="loading">Loading…</span>
+            <span v-else>No recent jobs. Jobs are pruned from the store after completion.</span>
+          </template>
+        </cat-table>
       </div>
     </template>
   </NuxtLayout>
@@ -50,12 +64,13 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useHead } from '#imports'
-import { capitalize } from '~~/src/core'
+import { capitalize, fmtDate } from '~~/src/core'
 import {
   JOB_TERMINAL_STATES,
   USER_JOB_QUEUES,
   fetchQueueJobs,
   jobHeading,
+  jobStateVariant,
   jobTiming,
   type JobStatus,
 } from '~~/src/tl'
@@ -167,46 +182,5 @@ onBeforeUnmount(() => { stopTimers() })
   align-items: center;
   gap: 12px;
   margin: 16px 0;
-}
-.cal-jobs-index-list {
-  display: flex;
-  flex-direction: column;
-}
-.cal-jobs-index-row {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-  padding: 8px 4px;
-  border-bottom: 1px solid var(--bulma-border, #e0e0e0);
-}
-.cal-jobs-index-state {
-  flex: 0 0 110px;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  white-space: nowrap;
-}
-.cal-jobs-index-heading {
-  flex: 1 1 auto;
-}
-.cal-jobs-index-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex: 0 0 auto;
-  background: var(--bulma-grey, #b5b5b5);
-}
-/* State drives the dot color via Bulma's semantic theme variables. */
-.cal-jobs-index-dot.is-succeeded {
-  background: var(--bulma-success, #48c78e);
-}
-.cal-jobs-index-dot.is-running {
-  background: var(--bulma-info, #1d6fb8);
-}
-.cal-jobs-index-dot.is-failed {
-  background: var(--bulma-danger, #f14668);
-}
-.cal-jobs-index-dot.is-cancelled {
-  background: var(--bulma-warning, #ffe08a);
 }
 </style>

--- a/app/pages/job-status/index.vue
+++ b/app/pages/job-status/index.vue
@@ -66,7 +66,8 @@
 // src/tl/jobs.ts helpers are largely generic over the tlv2 jobs API. In the
 // future, consider moving them into a new tlv2-apps package so they can be
 // reused across multiple projects.
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+import { useIntervalFn } from '@vueuse/core'
 import { useHead } from '#imports'
 import { capitalize, fmtDate } from '~~/src/core'
 import {
@@ -88,7 +89,6 @@ const AUTO_REFRESH_MS = 10000
 
 interface JobRow extends JobStatus {
   queue: string
-  key: string
   detailPath: string
 }
 
@@ -100,15 +100,12 @@ const now = ref(new Date())
 
 const anyActive = computed(() => rows.value.some(r => !JOB_TERMINAL_STATES.has(r.state)))
 
-function toRow (queue: string, status: JobStatus, index: number): JobRow {
+function toRow (queue: string, status: JobStatus): JobRow {
   const jobId = status.job?.id
   const idStr = jobId != null ? String(jobId) : ''
   return {
     ...status,
     queue,
-    // job.id should always be present in list responses; index-fallback keeps
-    // v-for keys unique if it ever isn't.
-    key: idStr ? `${queue}/${idStr}` : `${queue}#${index}`,
     detailPath: idStr ? `/job-status/${encodeURIComponent(queue)}/${encodeURIComponent(idStr)}` : '',
   }
 }
@@ -129,7 +126,7 @@ async function refresh () {
     results.forEach((result, i) => {
       const queue = USER_JOB_QUEUES[i] ?? ''
       if (result.status === 'fulfilled') {
-        merged.push(...result.value.map((s, j) => toRow(queue, s, j)))
+        merged.push(...result.value.map(s => toRow(queue, s)))
       } else {
         const msg = result.reason instanceof Error ? result.reason.message : String(result.reason)
         failures.push(`${queue}: ${msg}`)
@@ -149,35 +146,21 @@ async function refresh () {
 
 // Auto-refresh only while something is still running; the 1s ticker keeps
 // "Running for Ns" live. Both stop when every listed job is terminal.
-let refreshTimer: ReturnType<typeof setInterval> | null = null
-let nowTimer: ReturnType<typeof setInterval> | null = null
+// useIntervalFn cleans both up on unmount.
+const refreshTimer = useIntervalFn(() => { void refresh() }, AUTO_REFRESH_MS, { immediate: false })
+const nowTimer = useIntervalFn(() => { now.value = new Date() }, 1000, { immediate: false })
 
 function syncTimers () {
   if (anyActive.value) {
-    if (refreshTimer == null) {
-      refreshTimer = setInterval(() => { void refresh() }, AUTO_REFRESH_MS)
-    }
-    if (nowTimer == null) {
-      nowTimer = setInterval(() => { now.value = new Date() }, 1000)
-    }
+    refreshTimer.resume()
+    nowTimer.resume()
   } else {
-    stopTimers()
-  }
-}
-
-function stopTimers () {
-  if (refreshTimer != null) {
-    clearInterval(refreshTimer)
-    refreshTimer = null
-  }
-  if (nowTimer != null) {
-    clearInterval(nowTimer)
-    nowTimer = null
+    refreshTimer.pause()
+    nowTimer.pause()
   }
 }
 
 onMounted(() => { void refresh() })
-onBeforeUnmount(() => { stopTimers() })
 </script>
 
 <style scoped>

--- a/app/pages/job-status/index.vue
+++ b/app/pages/job-status/index.vue
@@ -1,0 +1,212 @@
+<template>
+  <NuxtLayout name="default">
+    <template #main>
+      <div class="container is-fluid" style="padding: 16px 24px; max-width: 1000px;">
+        <h1 class="title">
+          Jobs
+        </h1>
+
+        <div class="cal-jobs-index-actions">
+          <cat-button :disabled="loading" @click="refresh">
+            {{ loading ? 'Refreshing…' : 'Refresh' }}
+          </cat-button>
+          <span v-if="lastRefreshedAt" class="has-text-grey is-size-7">
+            Last refreshed: {{ lastRefreshedAt.toLocaleTimeString() }}
+          </span>
+        </div>
+
+        <cat-notification v-if="error" variant="danger">
+          {{ error }}
+        </cat-notification>
+
+        <cat-notification v-if="!loading && !error && rows.length === 0">
+          No recent jobs. Jobs are pruned from the store after completion.
+        </cat-notification>
+
+        <ul v-if="rows.length > 0" class="cal-jobs-index-list">
+          <li v-for="row in rows" :key="row.key" class="cal-jobs-index-row">
+            <span class="cal-jobs-index-state">
+              <span class="cal-jobs-index-dot" :class="`is-${row.state}`" />
+              {{ capitalize(row.state) }}
+            </span>
+            <span class="cal-jobs-index-heading">
+              <nuxt-link v-if="row.detailPath" :to="row.detailPath">
+                {{ jobHeading(row.queue, row) }}
+              </nuxt-link>
+              <template v-else>
+                {{ jobHeading(row.queue, row) }}
+              </template>
+            </span>
+            <span class="has-text-grey is-size-7">
+              {{ jobTiming(row, now) }}
+            </span>
+          </li>
+        </ul>
+      </div>
+    </template>
+  </NuxtLayout>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useHead } from '#imports'
+import { capitalize } from '~~/src/core'
+import {
+  JOB_TERMINAL_STATES,
+  USER_JOB_QUEUES,
+  fetchQueueJobs,
+  jobHeading,
+  jobTiming,
+  type JobStatus,
+} from '~~/src/tl'
+
+definePageMeta({ layout: false })
+
+useHead({ title: 'Jobs' })
+
+const MAX_ROWS = 50
+const AUTO_REFRESH_MS = 10000
+
+interface JobRow extends JobStatus {
+  queue: string
+  key: string
+  detailPath: string
+}
+
+const rows = ref<JobRow[]>([])
+const error = ref('')
+const loading = ref(false)
+const lastRefreshedAt = ref<Date | null>(null)
+const now = ref(new Date())
+
+const anyActive = computed(() => rows.value.some(r => !JOB_TERMINAL_STATES.has(r.state)))
+
+function toRow (queue: string, status: JobStatus, index: number): JobRow {
+  const jobId = status.job?.id
+  const idStr = jobId != null ? String(jobId) : ''
+  return {
+    ...status,
+    queue,
+    // job.id should always be present in list responses; index-fallback keeps
+    // v-for keys unique if it ever isn't.
+    key: idStr ? `${queue}/${idStr}` : `${queue}#${index}`,
+    detailPath: idStr ? `/job-status/${encodeURIComponent(queue)}/${encodeURIComponent(idStr)}` : '',
+  }
+}
+
+function submittedMs (s: JobStatus): number {
+  const d = s.submitted_at ? new Date(s.submitted_at) : null
+  return d && !isNaN(d.getTime()) ? d.getTime() : 0
+}
+
+async function refresh () {
+  loading.value = true
+  try {
+    const results = await Promise.allSettled(
+      USER_JOB_QUEUES.map(q => fetchQueueJobs(q))
+    )
+    const merged: JobRow[] = []
+    const failures: string[] = []
+    results.forEach((result, i) => {
+      const queue = USER_JOB_QUEUES[i] ?? ''
+      if (result.status === 'fulfilled') {
+        merged.push(...result.value.map((s, j) => toRow(queue, s, j)))
+      } else {
+        const msg = result.reason instanceof Error ? result.reason.message : String(result.reason)
+        failures.push(`${queue}: ${msg}`)
+      }
+    })
+    merged.sort((a, b) => submittedMs(b) - submittedMs(a))
+    rows.value = merged.slice(0, MAX_ROWS)
+    error.value = failures.length > 0 ? `Failed to fetch some queues — ${failures.join('; ')}` : ''
+    lastRefreshedAt.value = new Date()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+    syncTimers()
+  }
+}
+
+// Auto-refresh only while something is still running; the 1s ticker keeps
+// "Running for Ns" live. Both stop when every listed job is terminal.
+let refreshTimer: ReturnType<typeof setInterval> | null = null
+let nowTimer: ReturnType<typeof setInterval> | null = null
+
+function syncTimers () {
+  if (anyActive.value) {
+    if (refreshTimer == null) {
+      refreshTimer = setInterval(() => { void refresh() }, AUTO_REFRESH_MS)
+    }
+    if (nowTimer == null) {
+      nowTimer = setInterval(() => { now.value = new Date() }, 1000)
+    }
+  } else {
+    stopTimers()
+  }
+}
+
+function stopTimers () {
+  if (refreshTimer != null) {
+    clearInterval(refreshTimer)
+    refreshTimer = null
+  }
+  if (nowTimer != null) {
+    clearInterval(nowTimer)
+    nowTimer = null
+  }
+}
+
+onMounted(() => { void refresh() })
+onBeforeUnmount(() => { stopTimers() })
+</script>
+
+<style scoped>
+.cal-jobs-index-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 16px 0;
+}
+.cal-jobs-index-list {
+  display: flex;
+  flex-direction: column;
+}
+.cal-jobs-index-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--bulma-border, #e0e0e0);
+}
+.cal-jobs-index-state {
+  flex: 0 0 110px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.cal-jobs-index-heading {
+  flex: 1 1 auto;
+}
+.cal-jobs-index-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--bulma-grey, #b5b5b5);
+}
+/* State drives the dot color via Bulma's semantic theme variables. */
+.cal-jobs-index-dot.is-succeeded {
+  background: var(--bulma-success, #48c78e);
+}
+.cal-jobs-index-dot.is-running {
+  background: var(--bulma-info, #1d6fb8);
+}
+.cal-jobs-index-dot.is-failed {
+  background: var(--bulma-danger, #f14668);
+}
+.cal-jobs-index-dot.is-cancelled {
+  background: var(--bulma-warning, #ffe08a);
+}
+</style>

--- a/src/tl/jobs.test.ts
+++ b/src/tl/jobs.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { jobHeading, jobTiming, type JobStatus } from './jobs'
+
+function status (overrides: Partial<JobStatus> = {}): JobStatus {
+  return { state: 'running', job: { kind: 'feed-version-import' }, ...overrides }
+}
+
+describe('jobHeading', () => {
+  it('labels import jobs with the feed version id when present', () => {
+    const s = status({ job: { kind: 'feed-version-import', args: { feed_version_id: 1234 } } })
+    expect(jobHeading('feed-version-import', s)).toBe('Importing feed version 1234')
+  })
+
+  it('labels unimport jobs with the feed version id when present', () => {
+    const s = status({ job: { kind: 'feed-version-unimport', args: { feed_version_id: 99 } } })
+    expect(jobHeading('feed-version-unimport', s)).toBe('Unimporting feed version 99')
+  })
+
+  it('falls back to a queue-only label before the status has landed', () => {
+    expect(jobHeading('feed-version-import', null)).toBe('Importing feed version')
+    expect(jobHeading('feed-version-unimport', undefined)).toBe('Unimporting feed version')
+  })
+
+  it('labels unknown queues generically', () => {
+    expect(jobHeading('rt-fetch', status())).toBe('Job: rt-fetch')
+    expect(jobHeading('', null)).toBe('Job status')
+  })
+})
+
+describe('jobTiming', () => {
+  const now = new Date('2026-06-09T12:00:00Z')
+
+  it('returns empty for missing status or timestamps', () => {
+    expect(jobTiming(null, now)).toBe('')
+    expect(jobTiming(status(), now)).toBe('')
+  })
+
+  it('shows run duration when started and finished', () => {
+    const s = status({
+      started_at: '2026-06-09T11:59:00Z',
+      finished_at: '2026-06-09T11:59:45Z',
+    })
+    expect(jobTiming(s, now)).toBe('Ran for 45 seconds')
+  })
+
+  it('falls back to finished-ago when finished precedes started', () => {
+    const s = status({
+      started_at: '2026-06-09T11:59:45Z',
+      finished_at: '2026-06-09T11:59:00Z',
+    })
+    expect(jobTiming(s, now)).toMatch(/^Finished .* ago$/)
+  })
+
+  it('shows running duration relative to now', () => {
+    const s = status({ started_at: '2026-06-09T11:59:42Z' })
+    expect(jobTiming(s, now)).toBe('Running for 18 seconds')
+  })
+
+  it('clamps a started_at slightly ahead of the client clock', () => {
+    const s = status({ started_at: '2026-06-09T12:00:02Z' })
+    expect(jobTiming(s, now)).toBe('Running for 0 seconds')
+  })
+
+  it('shows submitted-ago when only submitted', () => {
+    const s = status({ submitted_at: '2026-06-09T11:59:58Z' })
+    expect(jobTiming(s, now)).toBe('Submitted 2 seconds ago')
+  })
+
+  it('ignores invalid timestamps', () => {
+    const s = status({ submitted_at: 'not-a-date' })
+    expect(jobTiming(s, now)).toBe('')
+  })
+})

--- a/src/tl/jobs.test.ts
+++ b/src/tl/jobs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { jobHeading, jobTiming, type JobStatus } from './jobs'
+import { jobHeading, jobStateVariant, jobTiming, type JobStatus } from './jobs'
 
 function status (overrides: Partial<JobStatus> = {}): JobStatus {
   return { state: 'running', job: { kind: 'feed-version-import' }, ...overrides }
@@ -69,5 +69,16 @@ describe('jobTiming', () => {
   it('ignores invalid timestamps', () => {
     const s = status({ submitted_at: 'not-a-date' })
     expect(jobTiming(s, now)).toBe('')
+  })
+})
+
+describe('jobStateVariant', () => {
+  it('maps each state to its Bulma color', () => {
+    expect(jobStateVariant('succeeded')).toBe('success')
+    expect(jobStateVariant('running')).toBe('info')
+    expect(jobStateVariant('failed')).toBe('danger')
+    expect(jobStateVariant('cancelled')).toBe('warning')
+    expect(jobStateVariant('queued')).toBe('light')
+    expect(jobStateVariant('')).toBe('light')
   })
 })

--- a/src/tl/jobs.ts
+++ b/src/tl/jobs.ts
@@ -8,7 +8,8 @@ export const JOB_TERMINAL_STATES: ReadonlySet<string> = new Set(['succeeded', 'f
 
 // Queues surfaced in the user-facing jobs list (/job-status). The full set of
 // queues (rt-fetch, gbfs-fetch, ...) is system noise; debug-jobs.vue keeps its
-// own KNOWN_QUEUES for the debug view.
+// own KNOWN_QUEUES for the debug view. When adding a feed-version operation,
+// also update jobHeading() below and queueForKind() in feed-version-picker.vue.
 export const USER_JOB_QUEUES = ['feed-version-import', 'feed-version-unimport'] as const
 
 // Single toggle: true → /watch SSE; false → JobGet polling. Polling is

--- a/src/tl/jobs.ts
+++ b/src/tl/jobs.ts
@@ -66,6 +66,18 @@ export function jobHeading (queue: string, status?: JobStatus | null): string {
   return queue ? `Job: ${queue}` : 'Job status'
 }
 
+// Bulma/Catenary tag color for a job state, shared by the jobs index and
+// detail pages so the same state always reads the same color.
+export function jobStateVariant (state: string): 'success' | 'info' | 'danger' | 'warning' | 'light' {
+  switch (state) {
+    case 'succeeded': return 'success'
+    case 'running': return 'info'
+    case 'failed': return 'danger'
+    case 'cancelled': return 'warning'
+    default: return 'light'
+  }
+}
+
 function parseDateMaybe (s: string | null | undefined): Date | null {
   if (!s) { return null }
   const d = new Date(s)

--- a/src/tl/jobs.ts
+++ b/src/tl/jobs.ts
@@ -1,8 +1,15 @@
 // Shared subscription helper and types for the tlv2 jobs API. Used by the
-// job-status page, the feed-version picker, and the debug-jobs page so the
+// job-status pages, the feed-version picker, and the debug-jobs page so the
 // proxy URL shape, SSE/poll switch, and wire types live in one place.
 
+import { formatDistance, formatDistanceStrict } from 'date-fns'
+
 export const JOB_TERMINAL_STATES: ReadonlySet<string> = new Set(['succeeded', 'failed', 'cancelled'])
+
+// Queues surfaced in the user-facing jobs list (/job-status). The full set of
+// queues (rt-fetch, gbfs-fetch, ...) is system noise; debug-jobs.vue keeps its
+// own KNOWN_QUEUES for the debug view.
+export const USER_JOB_QUEUES = ['feed-version-import', 'feed-version-unimport'] as const
 
 // Single toggle: true → /watch SSE; false → JobGet polling. Polling is
 // pod-independent (reads postgres) and was the more reliable path during
@@ -24,6 +31,8 @@ export function jobApiPath (queue: string, jobId?: string, action?: 'cancel' | '
 // JobEvent is the per-event payload over SSE /watch. `args` is worker-
 // specific so left as Record<string, unknown>.
 export interface Job {
+  // Present in API responses (JobGet, list, submit); absent on submit payloads.
+  id?: string | number
   kind: string
   args?: Record<string, unknown>
   opts?: {
@@ -41,6 +50,66 @@ export interface JobStatus {
   finished_at?: string
   error?: string
   attempt?: number
+}
+
+// Human-readable title derived from the queue and the job args (when the
+// JobStatus has landed). Pre-fetch we fall back to a queue-only label so
+// headings aren't empty on first paint.
+export function jobHeading (queue: string, status?: JobStatus | null): string {
+  const fvId = status?.job?.args?.feed_version_id
+  if (queue === 'feed-version-import') {
+    return fvId != null ? `Importing feed version ${fvId}` : 'Importing feed version'
+  }
+  if (queue === 'feed-version-unimport') {
+    return fvId != null ? `Unimporting feed version ${fvId}` : 'Unimporting feed version'
+  }
+  return queue ? `Job: ${queue}` : 'Job status'
+}
+
+function parseDateMaybe (s: string | null | undefined): Date | null {
+  if (!s) { return null }
+  const d = new Date(s)
+  return isNaN(d.getTime()) ? null : d
+}
+
+// "Submitted 2s ago" / "Running for 18s" / "Ran for 45s" depending on which
+// timestamps are populated. Callers pass `now` so a ticking ref can drive
+// live updates. Guards against invalid dates and clock skew (server timestamp
+// slightly ahead of client clock) so the display never reads "in 2 seconds".
+export function jobTiming (status: JobStatus | null | undefined, now: Date): string {
+  if (!status) { return '' }
+  const submittedAt = parseDateMaybe(status.submitted_at)
+  const startedAt = parseDateMaybe(status.started_at)
+  const finishedAt = parseDateMaybe(status.finished_at)
+  if (finishedAt) {
+    if (startedAt && finishedAt >= startedAt) {
+      return `Ran for ${formatDistanceStrict(startedAt, finishedAt)}`
+    }
+    return `Finished ${formatDistance(finishedAt, now, { addSuffix: true })}`
+  }
+  if (startedAt) {
+    const safeStart = startedAt <= now ? startedAt : now
+    return `Running for ${formatDistanceStrict(safeStart, now)}`
+  }
+  if (submittedAt) {
+    const safeSubmit = submittedAt <= now ? submittedAt : now
+    return `Submitted ${formatDistanceStrict(safeSubmit, now, { addSuffix: true })}`
+  }
+  return ''
+}
+
+// One-shot list fetch for a queue. Returns [] on 404 (unknown/empty queue),
+// throws on other non-OK responses so callers can surface the error.
+export async function fetchQueueJobs (queue: string, states?: string): Promise<JobStatus[]> {
+  const qs = states ? `?states=${encodeURIComponent(states)}` : ''
+  const res = await fetch(`${jobApiPath(queue)}${qs}`)
+  if (res.status === 404) { return [] }
+  const text = await res.text()
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText} — ${text}`)
+  }
+  const parsed = JSON.parse(text)
+  return Array.isArray(parsed?.jobs) ? parsed.jobs : []
 }
 
 export interface JobEvent {


### PR DESCRIPTION
## Summary

Feed Archive import jobs open their status page in a new tab (the modal stays open in the original tab), but that new tab had no navigation into or out of the job-status area, and there was no way to find a job again once its tab was closed. This PR works job status into the larger UI: a Jobs icon in the sidebar bottom group (above the user icon) linking to a new `/job-status` index page, plus a badge that shows while jobs started from this browser are still running.

## User-facing changes

### Sidebar
- New Jobs icon (clipboard-with-clock) in the bottom tier of sidebar icons, between Help and the user profile icon, visible to all logged-in users
- The icon highlights when on any `/job-status` page (index or detail), making it clear where job links from the Feed Archive land
- A small red count badge appears on the icon while jobs started from this browser are queued or running, and clears when they finish — including across tabs

### Jobs index page
- New page at `/job-status` listing recent feed-version import and unimport jobs, sorted newest first
- Each row shows a colored state dot (succeeded/running/failed/cancelled), a human-readable heading ("Importing feed version 1234") linking to the existing job detail page, and live timing ("Running for 18 seconds")
- Auto-refreshes every 10 seconds while any listed job is still running; manual Refresh button; empty state explains that jobs are pruned from the store after completion

### Job detail page
- New "← All jobs" back link for navigating to the index

## Implementation details

### Shared job helpers (`src/tl/jobs.ts`)
- Extracted `jobHeading()` and `jobTiming()` from the job detail page so the index page reuses identical logic; detail page refactored to call them (no behavior change)
- Added `fetchQueueJobs()` (one-shot list fetch, `[]` on 404) and `USER_JOB_QUEUES` (import/unimport only — system queues stay on the debug page)
- Added `id` to the `Job` wire type, which the API returns but the type previously omitted
- New unit tests in `src/tl/jobs.test.ts` covering heading and timing edge cases (clock skew, invalid dates, finished-before-started)

### Session job tracker (`app/composables/useJobTracker.ts`)
- localStorage-backed list (`cal-tracked-jobs`) of jobs started from this browser, using `useStorage` from vueuse so state survives the open-in-new-tab handoff and syncs across tabs via the storage event
- Watches non-terminal tracked jobs with the existing `watchJob()` poller; module-level handle map dedupes watchers per tab; `ensureWatching()` is called from the sidebar on mount so any tab can resume watching
- Entries not updated in 24h are excluded from the badge count (covers jobs pruned server-side before reaching a terminal state); terminal entries older than 7 days are pruned, capped at 50 entries
- `feed-version-picker.vue` registers each submitted job with the tracker; the picker's own per-row watcher is intentionally left as-is (two lightweight polls per active job)

## User test plan
1. Open the Feed Archive modal and submit an import — the sidebar badge appears with count 1 without closing the modal
2. Click the job's open-in-new-tab link — the new tab shows the jobs icon highlighted in the sidebar, with the same badge count
3. Click the sidebar Jobs icon from any page — `/job-status` lists the running job with a ticking duration; clicking the heading navigates (same tab) to the detail page; "← All jobs" navigates back
4. When the job completes: the badge clears in both tabs, the index page shows the terminal state on the next refresh, and the original tab's modal still shows its inline status and toast
5. Reload after completion — the badge stays cleared and the index page still lists the job until the server prunes it; with no jobs at all, the empty state notification renders
6. Verify the index page lists `job.id`-based detail links correctly (the list endpoint response shape was typed from the submit response; confirm ids are present in list items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)