### PR TITLE
Option to skip static departures

### DIFF
--- a/app/components/cal/map-share.vue
+++ b/app/components/cal/map-share.vue
@@ -31,9 +31,10 @@ import type { ScenarioFilterResult } from '~~/src/scenario'
 const props = defineProps<{
   scenarioFilterResult?: ScenarioFilterResult
   censusGeographiesSelected: CensusGeography[]
+  // From map.vue's exportFeatures computed: marked features from the layers
+  // currently displayed (fixed-route and/or flex), with CSV columns merged in.
+  exportFeatures?: Feature[]
 }>()
-
-const exportFeatures = ref<Feature[]>([])
 
 const windowUrl = computed(() => {
   return window.location.href

--- a/app/components/cal/map.vue
+++ b/app/components/cal/map.vue
@@ -10,6 +10,7 @@
       <cal-map-share
         :scenario-filter-result="scenarioFilterResult"
         :census-geographies-selected="censusGeographiesSelected"
+        :export-features="exportFeatures"
       />
     </div>
 
@@ -822,7 +823,9 @@ const displayFeatures = computed((): Feature[] => {
   return forDisplay
 })
 
-// Features for export include only the "marked" features and the csv column data.
+// Features for export: the marked features from the layers currently
+// displayed on the map (fixedRouteEnabled / flexServicesEnabled), with the
+// csv column data merged in.
 const exportFeatures = computed((): Feature[] => {
   const bgColor = '#aaa'
   const bgOpacity = 0.4
@@ -831,50 +834,62 @@ const exportFeatures = computed((): Feature[] => {
   const routeBufferGeographies = props.scenarioFilterResult?.routeBufferGeographies
   const stopBufferGeographies = props.scenarioFilterResult?.stopBufferGeographies
 
-  // Gather routes
-  for (const rp of props.scenarioFilterResult?.routes || []) {
-    if (!rp.marked) {
-      continue
+  if (fixedRouteEnabled.value !== false) {
+    // Gather routes
+    for (const rp of props.scenarioFilterResult?.routes || []) {
+      if (!rp.marked) {
+        continue
+      }
+
+      const style = styleRules.find(rule => rule.match(rp))
+      const feature = {
+        type: 'Feature',
+        id: rp.id.toString(),
+        geometry: rp.geometry,
+        properties: {
+          'id': rp.id,
+          'stroke': style?.color || bgColor,
+          'stroke-width': rp.marked ? 3 : 0.75,
+          'stroke-opacity': rp.marked ? 1 : bgOpacity,
+          'agency_name': rp.agency?.agency_name,
+          'agency_id': rp.agency?.agency_id
+        }
+      }
+      Object.assign(feature.properties, routeToRouteCsv(rp, routeBufferGeographies?.get(rp.id)))
+      forExport.push(feature)
     }
 
-    const style = styleRules.find(rule => rule.match(rp))
-    const feature = {
-      type: 'Feature',
-      id: rp.id.toString(),
-      geometry: rp.geometry,
-      properties: {
-        'id': rp.id,
-        'stroke': style?.color || bgColor,
-        'stroke-width': rp.marked ? 3 : 0.75,
-        'stroke-opacity': rp.marked ? 1 : bgOpacity,
-        'agency_name': rp.agency?.agency_name,
-        'agency_id': rp.agency?.agency_id
+    // Gather stops
+    for (const sp of props.scenarioFilterResult?.stops || []) {
+      if (!sp.marked) {
+        continue
       }
+
+      const style = styleRules.find(rule => rule.match(sp))
+      const feature = {
+        type: 'Feature',
+        id: sp.id.toString(),
+        geometry: sp.geometry,
+        properties: {
+          'id': sp.id,
+          'marker-radius': sp.marked ? 8 : 4,
+          'marker-color': style?.color || bgColor,
+          'marker-opacity': sp.marked ? 1 : bgOpacity
+        }
+      }
+      Object.assign(feature.properties, stopToStopCsv(sp, stopBufferGeographies?.get(sp.id)))
+      forExport.push(feature)
     }
-    Object.assign(feature.properties, routeToRouteCsv(rp, routeBufferGeographies?.get(rp.id)))
-    forExport.push(feature)
   }
 
-  // Gather stops
-  for (const sp of props.scenarioFilterResult?.stops || []) {
-    if (!sp.marked) {
-      continue
-    }
-
-    const style = styleRules.find(rule => rule.match(sp))
-    const feature = {
-      type: 'Feature',
-      id: sp.id.toString(),
-      geometry: sp.geometry,
-      properties: {
-        'id': sp.id,
-        'marker-radius': sp.marked ? 8 : 4,
-        'marker-color': style?.color || bgColor,
-        'marker-opacity': sp.marked ? 1 : bgOpacity
+  // Flex areas: marked only — flexDisplayFeatures includes unmarked (dashed)
+  // areas when hideUnmarked is off. buildFlexAreaProperties carries the csv fields.
+  if (flexServicesEnabled.value) {
+    for (const f of props.flexDisplayFeatures || []) {
+      if (f.properties?.marked) {
+        forExport.push(f)
       }
     }
-    Object.assign(feature.properties, stopToStopCsv(sp, stopBufferGeographies?.get(sp.id)))
-    forExport.push(feature)
   }
 
   return forExport

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -195,30 +195,37 @@
         <div class="container is-max-tablet">
           <!-- Data to Load Section -->
           <cat-field label="Data to Load">
-            <div class="is-flex">
-              <cat-checkbox
-                v-model="includeFixedRoute"
-                class="mr-5"
-              >
-                Include Fixed-Route Transit
-              </cat-checkbox>
-              <cat-checkbox
-                v-model="includeFlexAreas"
-              >
-                Include Flex Service Areas
-              </cat-checkbox>
-            </div>
-            <div class="cal-query-departures">
-              <cat-checkbox
-                v-model="includeDepartures"
-                :disabled="!includeFixedRoute"
-              >
-                Include Departure Schedules
-              </cat-checkbox>
-              <cat-tooltip text="Departure schedules are the largest and slowest part of loading a query. Uncheck to quickly browse stop locations, routes, flex services, and census data; schedule-dependent features such as frequencies and visit counts will be unavailable.">
-                <cat-icon size="small" icon="information" />
-              </cat-tooltip>
-            </div>
+            <ul class="cal-query-data-toggles">
+              <li>
+                <cat-checkbox v-model="includeFixedRoute">
+                  Include Fixed-Route Transit
+                </cat-checkbox>
+              </li>
+              <li class="cal-query-data-toggles-nested">
+                <cat-checkbox
+                  v-model="includeDepartures"
+                  :disabled="!includeFixedRoute"
+                >
+                  Include Departure Schedules
+                </cat-checkbox>
+                <cat-tooltip text="Departure schedules are the largest and slowest part of loading a query. Uncheck to quickly browse stop locations, routes, flex services, and census data; schedule-dependent features such as frequencies and visit counts will be unavailable.">
+                  <cat-icon size="small" icon="information" />
+                </cat-tooltip>
+              </li>
+              <li>
+                <cat-checkbox v-model="includeFlexAreas">
+                  Include Flex Service Areas
+                </cat-checkbox>
+              </li>
+              <li>
+                <cat-checkbox v-model="includeCensus">
+                  Include Census Demographics
+                </cat-checkbox>
+                <cat-tooltip text="Census (ACS) demographic values for aggregation areas and stop statistical radius buffers. Uncheck to skip loading demographics; demographic columns and area details will be unavailable.">
+                  <cat-icon size="small" icon="information" />
+                </cat-tooltip>
+              </li>
+            </ul>
           </cat-field>
 
           <!-- Census Geography Dataset -->
@@ -345,6 +352,7 @@ const {
   includeFixedRoute,
   includeFlexAreas,
   includeDepartures,
+  includeCensus,
   fvids,
   applyDatesAndFvids,
 } = useScenarioInputs()
@@ -596,12 +604,21 @@ const validQueryParams = computed(() => {
     }
   }
 
+  // One toggle per line — the panel is too narrow for inline checkbox flow.
+  .cal-query-data-toggles {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    > li {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+  }
+
   // Indented under "Include Fixed-Route Transit" — departures are a subset
   // of fixed-route data (1.625rem = checkbox width + label gap).
-  .cal-query-departures {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
+  .cal-query-data-toggles-nested {
     margin-left: 1.625rem;
   }
 

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -208,6 +208,17 @@
                 Include Flex Service Areas
               </cat-checkbox>
             </div>
+            <div class="cal-query-departures">
+              <cat-checkbox
+                v-model="includeDepartures"
+                :disabled="!includeFixedRoute"
+              >
+                Include Departure Schedules
+              </cat-checkbox>
+              <cat-tooltip text="Departure schedules are the largest and slowest part of loading a query. Uncheck to quickly browse stop locations, routes, flex services, and census data; schedule-dependent features such as frequencies and visit counts will be unavailable.">
+                <cat-icon size="small" icon="information" />
+              </cat-tooltip>
+            </div>
           </cat-field>
 
           <!-- Census Geography Dataset -->
@@ -333,6 +344,7 @@ const {
   geoDatasetName,
   includeFixedRoute,
   includeFlexAreas,
+  includeDepartures,
   fvids,
   applyDatesAndFvids,
 } = useScenarioInputs()
@@ -582,6 +594,15 @@ const validQueryParams = computed(() => {
     :deep(.control) {
       flex-grow: 1;
     }
+  }
+
+  // Indented under "Include Fixed-Route Transit" — departures are a subset
+  // of fixed-route data (1.625rem = checkbox width + label gap).
+  .cal-query-departures {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: 1.625rem;
   }
 
   .cal-query-archive {

--- a/app/composables/useBufferRefetch.ts
+++ b/app/composables/useBufferRefetch.ts
@@ -49,6 +49,10 @@ export function useBufferRefetch (deps: UseBufferRefetchDeps): UseBufferRefetchR
     if (!receiver || !data) {
       return
     }
+    // Census demographics were excluded at query time; don't fetch them post-hoc.
+    if (deps.scenarioConfig.value.includeCensus === false) {
+      return
+    }
     abort?.abort()
     const localAbort = new AbortController()
     abort = localAbort

--- a/app/composables/useScenarioInputs.ts
+++ b/app/composables/useScenarioInputs.ts
@@ -25,6 +25,7 @@ interface ScenarioInputs {
   geoDatasetName: WritableComputedRef<string>
   includeFixedRoute: WritableComputedRef<boolean | undefined>
   includeFlexAreas: WritableComputedRef<boolean | undefined>
+  includeDepartures: WritableComputedRef<boolean | undefined>
   fixedRouteEnabled: WritableComputedRef<boolean | undefined>
   // fvids CSV — see parseFvids/serializeFvids for the encoding.
   fvids: WritableComputedRef<string>
@@ -96,6 +97,12 @@ export function useScenarioInputs (): ScenarioInputs {
     set: (v) => { setQuery({ includeFlexAreas: v ? undefined : 'false' }) }
   })
 
+  // Departure schedules dominate scenario loading time; off skips them.
+  const includeDepartures = computed<boolean | undefined>({
+    get: () => route.query.includeDepartures?.toString() !== 'false',
+    set: (v) => { setQuery({ includeDepartures: v ? undefined : 'false' }) }
+  })
+
   // Display toggle that filters fixed-route features out of the map; on by default.
   const fixedRouteEnabled = computed<boolean | undefined>({
     get: () => route.query.fixedRouteEnabled?.toString() !== 'false',
@@ -148,6 +155,7 @@ export function useScenarioInputs (): ScenarioInputs {
     geoDatasetName,
     includeFixedRoute,
     includeFlexAreas,
+    includeDepartures,
     fixedRouteEnabled,
     fvids,
     stopBufferRadius,

--- a/app/composables/useScenarioInputs.ts
+++ b/app/composables/useScenarioInputs.ts
@@ -26,6 +26,7 @@ interface ScenarioInputs {
   includeFixedRoute: WritableComputedRef<boolean | undefined>
   includeFlexAreas: WritableComputedRef<boolean | undefined>
   includeDepartures: WritableComputedRef<boolean | undefined>
+  includeCensus: WritableComputedRef<boolean | undefined>
   fixedRouteEnabled: WritableComputedRef<boolean | undefined>
   // fvids CSV — see parseFvids/serializeFvids for the encoding.
   fvids: WritableComputedRef<string>
@@ -103,6 +104,12 @@ export function useScenarioInputs (): ScenarioInputs {
     set: (v) => { setQuery({ includeDepartures: v ? undefined : 'false' }) }
   })
 
+  // Census demographics: aggregation-layer ACS values + stop-buffer passes.
+  const includeCensus = computed<boolean | undefined>({
+    get: () => route.query.includeCensus?.toString() !== 'false',
+    set: (v) => { setQuery({ includeCensus: v ? undefined : 'false' }) }
+  })
+
   // Display toggle that filters fixed-route features out of the map; on by default.
   const fixedRouteEnabled = computed<boolean | undefined>({
     get: () => route.query.fixedRouteEnabled?.toString() !== 'false',
@@ -156,6 +163,7 @@ export function useScenarioInputs (): ScenarioInputs {
     includeFixedRoute,
     includeFlexAreas,
     includeDepartures,
+    includeCensus,
     fixedRouteEnabled,
     fvids,
     stopBufferRadius,

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -331,6 +331,7 @@ const {
   includeFixedRoute,
   includeFlexAreas,
   includeDepartures,
+  includeCensus,
   fvids,
   stopBufferRadius,
   stopBufferLayer,
@@ -1004,6 +1005,7 @@ const scenarioConfig = computed((): ScenarioConfig => ({
   includeFixedRoute: includeFixedRoute.value,
   includeFlexAreas: includeFlexAreas.value,
   includeDepartures: includeDepartures.value,
+  includeCensus: includeCensus.value,
   // Feed version picks from the Query-tab picker modal (URL-backed).
   feedVersionOverrides: fvidsForConfig.value.feedVersionOverrides,
   excludedFeeds: fvidsForConfig.value.excludedFeeds,

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -330,6 +330,7 @@ const {
   geoDatasetName,
   includeFixedRoute,
   includeFlexAreas,
+  includeDepartures,
   fvids,
   stopBufferRadius,
   stopBufferLayer,
@@ -1002,6 +1003,7 @@ const scenarioConfig = computed((): ScenarioConfig => ({
   // Data loading toggles from Query tab > Advanced Settings
   includeFixedRoute: includeFixedRoute.value,
   includeFlexAreas: includeFlexAreas.value,
+  includeDepartures: includeDepartures.value,
   // Feed version picks from the Query-tab picker modal (URL-backed).
   feedVersionOverrides: fvidsForConfig.value.feedVersionOverrides,
   excludedFeeds: fvidsForConfig.value.excludedFeeds,

--- a/src/scenario/scenario.test.ts
+++ b/src/scenario/scenario.test.ts
@@ -48,6 +48,20 @@ describe('ScenarioFetcher', () => {
     }
   }
 
+  const stopsResponse = {
+    data: {
+      stops: [{
+        id: 1,
+        stop_id: 'stop_1',
+        stop_name: 'Test Stop',
+        location_type: 0,
+        geometry: { type: 'Point', coordinates: [-122.6, 45.5] },
+        census_geographies: [],
+        route_stops: []
+      }]
+    }
+  }
+
   it('should handle GraphQL errors', async () => {
     const mockError = new Error('GraphQL Error')
     mockClient.mockQuery.mockRejectedValue(mockError)
@@ -190,20 +204,6 @@ describe('ScenarioFetcher', () => {
   })
 
   describe('includeDepartures', () => {
-    const stopsResponse = {
-      data: {
-        stops: [{
-          id: 1,
-          stop_id: 'stop_1',
-          stop_name: 'Test Stop',
-          location_type: 0,
-          geometry: { type: 'Point', coordinates: [-122.6, 45.5] },
-          census_geographies: [],
-          route_stops: []
-        }]
-      }
-    }
-
     // Departure queries are the only ones with day-of-week include flags.
     function departureCalls (client: MockGraphQLClient) {
       return client.mockQuery.mock.calls.filter(([, vars]) => vars && 'include_monday' in vars)
@@ -234,6 +234,76 @@ describe('ScenarioFetcher', () => {
 
       expect(departureCalls(client)).toHaveLength(0)
       // Only the feed version and stop queries were issued
+      expect(client.mockQuery).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('includeCensus', () => {
+    // tableDatasetName + aggregateLayer enable the census-values stage.
+    const censusConfig: ScenarioConfig = {
+      ...config,
+      includeFixedRoute: false,
+      includeFlexAreas: false,
+      tableDatasetName: 'acsdt5y2021',
+      aggregateLayer: 'tract',
+    }
+
+    // stopBufferRadius + tableDatasetName (no aggregateLayer) enable only
+    // the buffer passes.
+    const bufferConfig: ScenarioConfig = {
+      ...config,
+      includeDepartures: false,
+      includeFlexAreas: false,
+      tableDatasetName: 'acsdt5y2021',
+      stopBufferRadius: 400,
+    }
+
+    it('fetches census values by default', async () => {
+      const client = new MockGraphQLClient()
+      client.mockQuery
+        .mockResolvedValueOnce({ data: { feeds: [makeFeedGql('1')] } })
+        .mockResolvedValue({ data: {} })
+
+      const fetcher = new ScenarioFetcher(censusConfig, client)
+      await fetcher.fetch()
+
+      expect(client.mockQuery).toHaveBeenCalledTimes(2)
+      expect(client.mockQuery.mock.calls[1][1]).toMatchObject({ tableNames: expect.any(Array) })
+    })
+
+    it('skips census values when includeCensus is false', async () => {
+      const client = new MockGraphQLClient()
+      client.mockQuery.mockResolvedValueOnce({ data: { feeds: [makeFeedGql('1')] } })
+
+      const fetcher = new ScenarioFetcher({ ...censusConfig, includeCensus: false }, client)
+      await fetcher.fetch()
+
+      expect(client.mockQuery).toHaveBeenCalledTimes(1)
+    })
+
+    it('runs buffer passes by default', async () => {
+      const client = new MockGraphQLClient()
+      client.mockQuery
+        .mockResolvedValueOnce({ data: { feeds: [makeFeedGql('1')] } })
+        .mockResolvedValueOnce(stopsResponse)
+        .mockResolvedValue({ data: {} })
+
+      const fetcher = new ScenarioFetcher(bufferConfig, client)
+      await fetcher.fetch()
+
+      // feeds + stops + per-stop buffer chunk + aggregation union
+      expect(client.mockQuery).toHaveBeenCalledTimes(4)
+    })
+
+    it('skips buffer passes when includeCensus is false', async () => {
+      const client = new MockGraphQLClient()
+      client.mockQuery
+        .mockResolvedValueOnce({ data: { feeds: [makeFeedGql('1')] } })
+        .mockResolvedValueOnce(stopsResponse)
+
+      const fetcher = new ScenarioFetcher({ ...bufferConfig, includeCensus: false }, client)
+      await fetcher.fetch()
+
       expect(client.mockQuery).toHaveBeenCalledTimes(2)
     })
   })

--- a/src/scenario/scenario.test.ts
+++ b/src/scenario/scenario.test.ts
@@ -189,6 +189,55 @@ describe('ScenarioFetcher', () => {
     })
   })
 
+  describe('includeDepartures', () => {
+    const stopsResponse = {
+      data: {
+        stops: [{
+          id: 1,
+          stop_id: 'stop_1',
+          stop_name: 'Test Stop',
+          location_type: 0,
+          geometry: { type: 'Point', coordinates: [-122.6, 45.5] },
+          census_geographies: [],
+          route_stops: []
+        }]
+      }
+    }
+
+    // Departure queries are the only ones with day-of-week include flags.
+    function departureCalls (client: MockGraphQLClient) {
+      return client.mockQuery.mock.calls.filter(([, vars]) => vars && 'include_monday' in vars)
+    }
+
+    it('fetches departures by default', async () => {
+      const client = new MockGraphQLClient()
+      client.mockQuery
+        .mockResolvedValueOnce({ data: { feeds: [makeFeedGql('1')] } })
+        .mockResolvedValueOnce(stopsResponse)
+        .mockResolvedValue({ data: { stops: [] } }) // departure queries
+
+      const fetcher = new ScenarioFetcher({ ...config, includeFlexAreas: false }, client)
+      await fetcher.fetch()
+
+      // The 8-day range chunks into two 7-day departure windows
+      expect(departureCalls(client)).toHaveLength(2)
+    })
+
+    it('skips departure queries when includeDepartures is false', async () => {
+      const client = new MockGraphQLClient()
+      client.mockQuery
+        .mockResolvedValueOnce({ data: { feeds: [makeFeedGql('1')] } })
+        .mockResolvedValueOnce(stopsResponse)
+
+      const fetcher = new ScenarioFetcher({ ...config, includeFlexAreas: false, includeDepartures: false }, client)
+      await fetcher.fetch()
+
+      expect(departureCalls(client)).toHaveLength(0)
+      // Only the feed version and stop queries were issued
+      expect(client.mockQuery).toHaveBeenCalledTimes(2)
+    })
+  })
+
   it('should call progress callback during fetch', async () => {
     // Mock first call returns one stop, second call returns empty to end recursion
     mockClient.mockQuery

--- a/src/scenario/scenario.ts
+++ b/src/scenario/scenario.ts
@@ -86,6 +86,13 @@ export interface ScenarioConfig {
    */
   includeFixedRoute?: boolean
   /**
+   * Whether to fetch stop departures (schedule data). Departures dominate
+   * scenario loading time and size; disabling them allows quickly browsing
+   * stops, routes, flex, and census data. Only meaningful when
+   * includeFixedRoute is enabled. Defaults to true.
+   */
+  includeDepartures?: boolean
+  /**
    * Whether to fetch flex service areas
    * Defaults to true
    */
@@ -624,6 +631,7 @@ export class ScenarioFetcher {
     // Fetch fixed-route transit data if enabled (default: true)
     const includeFixedRoute = this.config.includeFixedRoute !== false
     console.log(`[Scenario] includeFixedRoute = ${includeFixedRoute}`)
+    console.log(`[Scenario] includeDepartures = ${this.config.includeDepartures !== false}`)
     if (includeFixedRoute) {
       for (const fv of this.feedVersions) {
         this.stopFetchQueue.enqueueOne({
@@ -995,17 +1003,19 @@ export class ScenarioFetcher {
 
     // Enqueue stop departure fetching
     const stopIds = stopData.map(s => s.id)
-    const dates = getSelectedDateRange(this.config)
-    const weekSize = 7
-    // Build all tasks first
-    for (let sid = 0; sid < stopIds.length; sid += this.stopTimeBatchSize) {
-      for (let i = 0; i < dates.length; i += weekSize) {
-        const w = new StopDepartureQueryVars()
-        w.ids = stopIds.slice(sid, sid + this.stopTimeBatchSize)
-        for (const d of dates.slice(i, i + weekSize)) {
-          w.setDay(d)
+    if (this.config.includeDepartures !== false) {
+      const dates = getSelectedDateRange(this.config)
+      const weekSize = 7
+      // Build all tasks first
+      for (let sid = 0; sid < stopIds.length; sid += this.stopTimeBatchSize) {
+        for (let i = 0; i < dates.length; i += weekSize) {
+          const w = new StopDepartureQueryVars()
+          w.ids = stopIds.slice(sid, sid + this.stopTimeBatchSize)
+          for (const d of dates.slice(i, i + weekSize)) {
+            w.setDay(d)
+          }
+          this.stopDepartureQueue.enqueueOne(w)
         }
-        this.stopDepartureQueue.enqueueOne(w)
       }
     }
 

--- a/src/scenario/scenario.ts
+++ b/src/scenario/scenario.ts
@@ -97,6 +97,12 @@ export interface ScenarioConfig {
    * Defaults to true
    */
   includeFlexAreas?: boolean
+  /**
+   * Whether to fetch census demographics: ACS values for the aggregation
+   * layer (census-values stage) and the stop-buffer demographic passes.
+   * Defaults to true.
+   */
+  includeCensus?: boolean
   // Picker overrides: onestop_id → fv_id. Record (not Map) for BFF JSON.
   feedVersionOverrides?: Record<string, number>
   // Picker-excluded onestop_ids. Dropped before any stop/route fetch.
@@ -632,6 +638,7 @@ export class ScenarioFetcher {
     const includeFixedRoute = this.config.includeFixedRoute !== false
     console.log(`[Scenario] includeFixedRoute = ${includeFixedRoute}`)
     console.log(`[Scenario] includeDepartures = ${this.config.includeDepartures !== false}`)
+    console.log(`[Scenario] includeCensus = ${this.config.includeCensus !== false}`)
     if (includeFixedRoute) {
       for (const fv of this.feedVersions) {
         this.stopFetchQueue.enqueueOne({
@@ -763,6 +770,10 @@ export class ScenarioFetcher {
   // Skipped without `tableDatasetName` + `aggregateLayer`. Bbox is padded by
   // the radius so edge-crossing buffers can apportion against the right tracts.
   private async fetchCensusValues (): Promise<void> {
+    if (this.config.includeCensus === false) {
+      console.log('[CensusValues] Skipping (includeCensus = false)')
+      return
+    }
     const { tableDatasetName, aggregateLayer, geoDatasetName } = this.config
     if (!tableDatasetName || !aggregateLayer) {
       console.log('[CensusValues] Skipping (tableDatasetName or aggregateLayer not set)')
@@ -808,7 +819,7 @@ export class ScenarioFetcher {
   private async fetchBufferData (): Promise<void> {
     const { tableDatasetName, geoDatasetName } = this.config
     const radius = this.config.stopBufferRadius ?? 0
-    if (radius <= 0 || !tableDatasetName) {
+    if (this.config.includeCensus === false || radius <= 0 || !tableDatasetName) {
       return
     }
     await runBufferPasses(


### PR DESCRIPTION
## Summary

Adds opt-out toggles for the two heaviest parts of a browse query — departure schedules and census demographics — so users can quickly load and explore stop locations, routes, flex services, and census areas without waiting on (or running out of memory from) the departure fetch, which dominates scenario loading time and size. The toggles join the existing fixed-route and flex toggles in a reorganized "Data to Load" section under Advanced Settings, and all four are persisted in the URL so shared links reproduce the configuration. The PR also repairs the Share panel's "Download as GeoJSON" button, which has silently produced an empty FeatureCollection since the scenario streaming refactor (#161), and redefines the export to match what is currently displayed on the map — which adds flex areas to the GeoJSON download for the first time.

## User-facing changes

### Data to Load toggles (Query tab, Advanced Settings)

- The "Data to Load" checkboxes are now a vertical list instead of an inline row.
- New "Include Departure Schedules" checkbox, indented under "Include Fixed-Route Transit" and disabled when fixed-route is off. Unchecking skips all stop-departure queries; stops, routes, flex, and census data still load and render.
- New "Include Census Demographics" checkbox. Unchecking skips ACS census values for aggregation areas and all stop-buffer demographic passes; demographic columns and the choropleth will be empty.
- Both toggles are on by default and stored in the URL only when off, so existing shared links are unaffected.
- When census demographics were excluded at query time, changing the stop statistical radius or buffer layer no longer triggers a buffer-only refetch.
- Known limitation (follow-up planned): with departures skipped, schedule-dependent filters (days of week, "All" weekday mode, frequency thresholds) will filter out all stops and routes, and visit/frequency columns show zeros rather than a "not loaded" indicator.

### GeoJSON download

- The Share panel's "Download as GeoJSON" button works again (it previously always downloaded an empty FeatureCollection).
- The export now contains the marked features from the layers currently displayed on the map: routes and stops only when fixed-route display is enabled, and flex service areas only when flex display is enabled.
- Flex areas appear in the download for the first time, carrying their full attributes (agency, area type, advance notice, booking contact and URL, time windows) plus map styling.

## Implementation details

### Scenario fetcher (src/scenario/scenario.ts)

- New `ScenarioConfig.includeDepartures` gates the departure-batch enqueue loop in `fetchStops`. Departures are a terminal node in the pipeline, so no downstream stage needed changes; route fetching, buffer-id collection, and stop pagination are unaffected.
- New `ScenarioConfig.includeCensus` gates `fetchCensusValues` (census-values stage) and `fetchBufferData` (all four buffer passes: per-stop, per-route, per-agency, aggregation union).
- Both flags default to true via the same `!== false` idiom as `includeFixedRoute`/`includeFlexAreas`.

### UI wiring

- `useScenarioInputs` adds URL-backed `includeDepartures` and `includeCensus` computeds, omitted from the URL at their default.
- `query.vue` restructures the checkbox group as a `ul` (`cal-query-data-toggles`) with one toggle per line and info tooltips on the two new entries.
- `useBufferRefetch` returns early when the loaded config has `includeCensus: false`, so radius/layer changes cannot fetch ACS data the user opted out of.

### GeoJSON export

- `map.vue` passes its `exportFeatures` computed to `cal-map-share` as a prop, restoring the wiring removed in #161 (the component had a never-assigned local ref).
- `exportFeatures` wraps the route/stop gathering in a `fixedRouteEnabled` check and appends marked features from `flexDisplayFeatures` when `flexServicesEnabled` is set; flex display features already carry CSV-equivalent fields via `buildFlexAreaProperties`.

### Tests

- Six new `ScenarioFetcher` tests cover both directions of each gate: departures fetched by default / skipped when disabled, census values fetched by default / skipped when disabled, and buffer passes run by default / skipped when disabled.

## User test plan

1. Run a browse query with default settings — behavior should be unchanged (departures, census demographics, and buffers all load).
2. Uncheck "Include Departure Schedules" and run the same query — loading should be much faster; stops, routes, flex areas, and census boundaries render on the map. Frequency and visit-count columns show zeros (known limitation); leave weekday and frequency filters untouched.
3. Uncheck "Include Census Demographics" and run a query — demographic columns and choropleth are empty; dragging the stop statistical radius slider afterward should not trigger a "Recomputing buffer demographics" refetch.
4. Uncheck "Include Fixed-Route Transit" — the departures checkbox becomes disabled.
5. With a loaded scenario showing both fixed-route and flex layers, open Share and download the GeoJSON — it should contain marked routes, stops, and flex areas with attributes. Toggle flex display off and download again — no flex features. Toggle fixed-route display off — only flex features.
6. Copy the URL with toggles unchecked and open it in a new tab — the checkboxes should reproduce their state.
