### PR TITLE
Upgrade catenary to 0.6.0; typeable dates, Tab-select boundaries, Run Query reason, audible toasts (#390)

### DIFF
--- a/app/components/cal/end-date-field.vue
+++ b/app/components/cal/end-date-field.vue
@@ -5,24 +5,28 @@
         End date
       </slot>
     </template>
-    <div v-if="!singleDay" class="cal-end-date-field-range">
-      <cat-datepicker
-        ref="endPickerRef"
-        v-model="endModel"
-        :min-date="minDate"
-        :max-date="maxDate"
-        :years-range="yearsRange"
-        :variant="invalid ? 'danger' : undefined"
-      />
-      <!-- camelCase keys in a v-bind object: matches the ariaLabel/title props
-           (catenary 0.4.0) and avoids vue/attribute-hyphenation rewriting a
-           camelCase attribute back to kebab (which vue-tsc won't map to the prop). -->
-      <cat-button
-        icon="close"
-        v-bind="{ ariaLabel: 'Remove end date', title: singleDayTitle }"
-        @click="emit('update:singleDay', true)"
-      />
-    </div>
+    <cat-datepicker
+      v-if="!singleDay"
+      ref="endPickerRef"
+      v-model="endModel"
+      :min-date="minDate"
+      :max-date="maxDate"
+      :years-range="yearsRange"
+      :variant="invalid ? 'danger' : undefined"
+    >
+      <!-- The remove button joins the picker's addon group (catenary 0.6.0)
+           instead of floating beside it. camelCase keys in the v-bind object:
+           matches the ariaLabel/title props and avoids vue/attribute-hyphenation
+           rewriting a camelCase attribute back to kebab (which vue-tsc won't
+           map to the prop). -->
+      <template #addon>
+        <cat-button
+          icon="close"
+          v-bind="{ ariaLabel: 'Remove end date', title: singleDayTitle }"
+          @click="emit('update:singleDay', true)"
+        />
+      </template>
+    </cat-datepicker>
     <cat-button v-else ref="setEndButtonRef" @click="emit('update:singleDay', false)">
       Set an end date
     </cat-button>
@@ -86,11 +90,3 @@ watch(() => props.singleDay, async (single) => {
   }
 })
 </script>
-
-<style scoped>
-.cal-end-date-field-range {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-</style>

--- a/app/components/cal/end-date-field.vue
+++ b/app/components/cal/end-date-field.vue
@@ -13,7 +13,6 @@
         :max-date="maxDate"
         :years-range="yearsRange"
         :variant="invalid ? 'danger' : undefined"
-        readonly
       />
       <!-- camelCase keys in a v-bind object: matches the ariaLabel/title props
            (catenary 0.4.0) and avoids vue/attribute-hyphenation rewriting a

--- a/app/components/cal/feed-version-picker-modal.vue
+++ b/app/components/cal/feed-version-picker-modal.vue
@@ -17,7 +17,6 @@
           :min-date="wideMinDate"
           :max-date="wideMaxDate"
           :years-range="wideYearsRange"
-          readonly
         />
       </cat-field>
       <cal-end-date-field

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -14,7 +14,16 @@
       <p>Start by specifying your desired date range and geographic bounds. To explore stops, routes, and frequencies on the map and in tabular view click <em>Run Browse Query</em>. Or for more specialized analysis, click <em>Run Advanced Analysis</em>.</p>
     </cat-msg>
 
-    <div class="cal-body" :class="{ 'is-locked': props.scenarioLoaded }">
+    <!-- A named form makes the query controls a landmark screen reader
+         users can jump to. All buttons inside are type=button and the
+         widgets consume their own Enter keys, so there is no implicit
+         submission; submit.prevent guards the residual cases. -->
+    <form
+      class="cal-body"
+      :class="{ 'is-locked': props.scenarioLoaded }"
+      aria-label="Transit network query parameters"
+      @submit.prevent
+    >
       <cat-msg title="Date range">
         <cat-field>
           <template #label>
@@ -291,7 +300,7 @@
       >
         {{ queryBlockedReason }}
       </p>
-    </div>
+    </form>
 
     <cal-feed-version-picker-modal
       v-model:open="showFvPicker"

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -144,15 +144,18 @@
             Results limited to {{ props.viewportGeographiesLimit ?? 1000 }} boundaries. Zoom in to see all boundaries in the viewport.
           </p>
 
-          <cat-field>
-            <template #label>
-              Selected administrative boundaries
-              <span v-if="geographyIds.length > 0" class="ml-2">
-                <a role="button" class="is-size-7" @click="emit('fitToGeographies')">Show on map</a>
-                <span class="mx-1">|</span>
-                <a role="button" class="is-size-7" @click="emit('clearGeographies')">Clear all</a>
-              </span>
-            </template>
+          <cat-field label="Selected administrative boundaries">
+            <!-- Real buttons outside the label element: the previous href-less
+                 anchors inside the label slot were keyboard-unreachable and
+                 their text polluted the taginput's accessible name. -->
+            <div v-if="geographyIds.length > 0" class="cal-boundary-actions">
+              <cat-button variant="ghost" size="small" @click="emit('fitToGeographies')">
+                Show on map
+              </cat-button>
+              <cat-button variant="ghost" size="small" @click="emit('clearGeographies')">
+                Clear all
+              </cat-button>
+            </div>
             <cat-taginput
               v-model="geographyIds"
               v-model:input="geomSearch"
@@ -625,6 +628,13 @@ const validQueryParams = computed(() => {
 </script>
 
 <style scoped lang="scss">
+  .cal-boundary-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.25rem;
+    margin-bottom: 0.25rem;
+  }
+
   .cal-query {
     max-width: v-bind(panelWidthPx);
     display:flex;

--- a/app/components/cal/query.vue
+++ b/app/components/cal/query.vue
@@ -29,7 +29,6 @@
             :max-date="pickerMaxDate"
             :years-range="datePickerYearsRange"
             :variant="isStartDateInRange ? undefined : 'danger'"
-            readonly
           />
         </cat-field>
         <cal-end-date-field
@@ -273,13 +272,25 @@
       </cat-msg>
 
       <div class="field has-addons cal-query-actions">
-        <cat-button variant="primary" :disabled="!validQueryParams" class="is-fullwidth is-large" @click="emit('explore')">
+        <cat-button variant="primary" :disabled="!validQueryParams" v-bind="runButtonA11y" class="is-fullwidth is-large" @click="emit('explore')">
           Run Browse Query
         </cat-button>
-        <cat-button variant="primary" outlined :disabled="!validQueryParams" class="is-fullwidth is-large" @click="emit('switchToAnalysisTab')">
+        <cat-button variant="primary" outlined :disabled="!validQueryParams" v-bind="runButtonA11y" class="is-fullwidth is-large" @click="emit('switchToAnalysisTab')">
           Run Advanced Analysis
         </cat-button>
       </div>
+      <!-- Explains why the run buttons are disabled (#390: a screen reader
+           user could not tell). Referenced by both buttons via
+           aria-describedby, and always rendered so the polite live region
+           reliably announces when the blocker appears or clears. -->
+      <p
+        id="cal-query-blocked-reason"
+        class="help cal-query-blocked-reason"
+        :class="{ 'is-danger': queryBlockedReason }"
+        aria-live="polite"
+      >
+        {{ queryBlockedReason }}
+      </p>
     </div>
 
     <cal-feed-version-picker-modal
@@ -548,6 +559,36 @@ const selectedGeographyTagOptions = computed((): { value: number, label: string 
     results.push({ value: geo.id, label })
   }
   return results
+})
+
+// Spread as a v-bind object typed as a plain record: strictTemplates rejects
+// undeclared attributes written directly on a component, but aria-describedby
+// is a legitimate fallthrough attr that cat-button forwards to its native
+// button element.
+const runButtonA11y: Record<string, string> = { 'aria-describedby': 'cal-query-blocked-reason' }
+
+// Human-readable reason the run buttons are disabled, shown below them and
+// referenced via aria-describedby (#390). Empty when the query is runnable.
+const queryBlockedReason = computed(() => {
+  if (validQueryParams.value) {
+    return ''
+  }
+  if (!startDate.value) {
+    return 'Cannot run query yet: select a start date.'
+  }
+  if (!isStartDateInRange.value || !isEndDateInRange.value) {
+    return 'Cannot run query: dates are outside the Feed Archive range.'
+  }
+  if (!isEndDateValid.value) {
+    return 'Cannot run query: the end date is before the start date.'
+  }
+  if (geomSource.value === 'adminBoundary' && (geographyIds.value?.length ?? 0) === 0) {
+    return 'Cannot run query: select at least one administrative boundary.'
+  }
+  if (!bbox?.value?.valid) {
+    return 'Cannot run query: set the geographic bounds first.'
+  }
+  return 'Cannot run query: required parameters are missing.'
 })
 
 const validQueryParams = computed(() => {

--- a/app/composables/useToastNotification.ts
+++ b/app/composables/useToastNotification.ts
@@ -10,11 +10,15 @@ export const useToastNotification = () => {
     }
   }
 
-  const showToast = (message: string, variant: ToastVariant = 'primary', duration: number = 3000) => {
+  // The container is a persistent polite live region: screen readers only
+  // announce additions to a live region that already exists, so it is created
+  // once (ideally before the first toast) and never removed.
+  const ensureContainer = (): HTMLElement => {
     let container = document.getElementById('toast-container')
     if (!container) {
       container = document.createElement('div')
       container.id = 'toast-container'
+      container.setAttribute('aria-live', 'polite')
       // z-index must exceed `.cat-modal { z-index: 99999 !important }` in
       // app/assets/main.scss so toasts surface above an open modal.
       container.style.cssText = `
@@ -32,6 +36,12 @@ export const useToastNotification = () => {
       `
       document.body.appendChild(container)
     }
+    return container
+  }
+  ensureContainer()
+
+  const showToast = (message: string, variant: ToastVariant = 'primary', duration: number = 3000) => {
+    const container = ensureContainer()
 
     const toast = document.createElement('div')
     toast.className = `notification toast is-${variant}`
@@ -55,10 +65,10 @@ export const useToastNotification = () => {
       toast.style.opacity = '0'
       toast.style.transform = 'translateY(-20px)'
       setTimeout(() => {
+        // The container deliberately stays in the DOM: removing an empty live
+        // region and recreating it with the next toast makes screen readers
+        // miss the announcement.
         toast.remove()
-        if (container && container.children.length === 0) {
-          container.remove()
-        }
       }, 300)
     }, duration)
   }

--- a/app/composables/useToastNotification.ts
+++ b/app/composables/useToastNotification.ts
@@ -54,6 +54,12 @@ export const useToastNotification = () => {
       transition: all 0.3s ease;
     `
     toast.textContent = message
+    if (variant === 'danger') {
+      // Errors must interrupt: role=alert announces reliably on insertion.
+      // The polite container may re-announce it in some screen readers; an
+      // extra announcement is preferable to a missed error.
+      toast.setAttribute('role', 'alert')
+    }
     container.appendChild(toast)
 
     requestAnimationFrame(() => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@aitodotai/json-stringify-pretty-compact": "1.3.0",
-    "@interline-io/catenary": "0.4.0",
+    "@interline-io/catenary": "0.5.0",
     "@mdi/font": "7.4.47",
     "@interline-io/tlv2-auth": "0.1.0-sha.ad5c03e",
     "@apollo/client": "3.13.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@aitodotai/json-stringify-pretty-compact": "1.3.0",
-    "@interline-io/catenary": "0.5.0",
+    "@interline-io/catenary": "0.6.0",
     "@mdi/font": "7.4.47",
     "@interline-io/tlv2-auth": "0.1.0-sha.ad5c03e",
     "@apollo/client": "3.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 3.13.4
         version: 3.13.4(graphql@16.10.0)
       '@interline-io/catenary':
-        specifier: 0.4.0
-        version: 0.4.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
+        specifier: 0.5.0
+        version: 0.5.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       '@interline-io/tlv2-auth':
         specifier: 0.1.0-sha.ad5c03e
         version: 0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
@@ -735,8 +735,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@interline-io/catenary@0.4.0':
-    resolution: {integrity: sha512-mIvvqgQKAFrAPFvVk9huVmnCCtR05OW5PU82FEN9VO0cR1qxS66JnOtNeZpHAzYn4jA1OOYZT8VP8zmOlSoB4g==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.4.0/6d1eb95f9338b518eef058ab60114851f25c3927}
+  '@interline-io/catenary@0.5.0':
+    resolution: {integrity: sha512-6GBICpGs5VjRTGi1lME2Vo/Y2R60DQUWGvUk1OLmzbX5z3+PLY8FC5weT3GCXafQ5Li2YsbHzNSpu9kntX8n+g==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.5.0/dd8a0c8f2add352a2d06cd4f490adf294eeea8d5}
     peerDependencies:
       '@mdi/font': ^7.4.0
       bulma: ^1.0.0
@@ -5699,7 +5699,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@interline-io/catenary@0.4.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/catenary@0.5.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@mdi/font': 7.4.47
       bulma: 1.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,17 +15,17 @@ importers:
         specifier: 3.13.4
         version: 3.13.4(graphql@16.10.0)
       '@interline-io/catenary':
-        specifier: 0.5.0
-        version: 0.5.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
+        specifier: 0.6.0
+        version: 0.6.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       '@interline-io/tlv2-auth':
         specifier: 0.1.0-sha.ad5c03e
-        version: 0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
+        version: 0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
       '@mdi/font':
         specifier: 7.4.47
         version: 7.4.47
       '@nuxt/eslint':
         specifier: 1.10.0
-        version: 1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(magicast@0.3.5)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))
+        version: 1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))
       '@nuxt/eslint-config':
         specifier: 1.10.0
         version: 1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
@@ -79,7 +79,7 @@ importers:
         version: 5.2.0
       nuxt:
         specifier: 4.2.0
-        version: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
       protomaps-themes-base:
         specifier: 1.3.1
         version: 1.3.1
@@ -735,8 +735,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@interline-io/catenary@0.5.0':
-    resolution: {integrity: sha512-6GBICpGs5VjRTGi1lME2Vo/Y2R60DQUWGvUk1OLmzbX5z3+PLY8FC5weT3GCXafQ5Li2YsbHzNSpu9kntX8n+g==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.5.0/dd8a0c8f2add352a2d06cd4f490adf294eeea8d5}
+  '@interline-io/catenary@0.6.0':
+    resolution: {integrity: sha512-A9UEIcLXFWk/JqbZzcJr366VVaRV5Qae0ode0JzL1NrD9EyEKdT8xB1vVG5bdeYlT5Np20a3JdDk3LlMdrLsOA==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.6.0/2f470d4342e1a826996a11e8509463560748e266}
     peerDependencies:
       '@mdi/font': ^7.4.0
       bulma: ^1.0.0
@@ -5417,10 +5417,10 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
-  '@dxup/nuxt@0.2.2(magicast@0.3.5)':
+  '@dxup/nuxt@0.2.2(magicast@0.5.2)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       chokidar: 4.0.3
       pathe: 2.0.3
       tinyglobby: 0.2.15
@@ -5699,7 +5699,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@interline-io/catenary@0.5.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/catenary@0.6.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@mdi/font': 7.4.47
       bulma: 1.0.4
@@ -5708,12 +5708,12 @@ snapshots:
       vue: 3.5.22(typescript@5.9.3)
       vue-router: 4.6.4(vue@3.5.22(typescript@5.9.3))
 
-  '@interline-io/tlv2-auth@0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/tlv2-auth@0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@auth0/auth0-nuxt': 1.0.1
       defu: 6.1.4
       h3: 1.15.8
-      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
       vue: 3.5.22(typescript@5.9.3)
 
   '@ioredis/commands@1.5.1': {}
@@ -5835,11 +5835,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.2.0)(cac@6.7.14)(magicast@0.3.5)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.2.0)(cac@6.7.14)(magicast@0.5.2)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -5883,9 +5883,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@3.2.4(magicast@0.3.5)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       execa: 8.0.1
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -5983,13 +5983,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(magicast@0.3.5)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))':
+  '@nuxt/eslint@1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))':
     dependencies:
       '@eslint/config-inspector': 1.5.0(eslint@9.39.1(jiti@2.6.1))
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.3.5)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))
       '@nuxt/eslint-config': 1.10.0(@typescript-eslint/utils@8.57.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/eslint-plugin': 1.10.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       chokidar: 4.0.3
       eslint: 9.39.1(jiti@2.6.1)
       eslint-flat-config-utils: 2.1.4
@@ -6037,9 +6037,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.2.0(magicast@0.3.5)':
+  '@nuxt/kit@4.2.0(magicast@0.5.2)':
     dependencies:
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -6062,9 +6062,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.4.2(magicast@0.3.5)':
+  '@nuxt/kit@4.4.2(magicast@0.5.2)':
     dependencies:
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -6087,10 +6087,10 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.2.0(db0@0.3.4)(ioredis@5.10.0)(magicast@0.3.5)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.2.0(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.2.0(magicast@0.3.5)
+      '@nuxt/kit': 4.2.0(magicast@0.5.2)
       '@unhead/vue': 2.1.12(vue@3.5.22(typescript@5.9.3))
       '@vue/shared': 3.5.30
       consola: 3.4.2
@@ -6105,7 +6105,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.1
-      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
       pathe: 2.0.3
       pkg-types: 2.3.0
       radix3: 1.1.2
@@ -6160,18 +6160,18 @@ snapshots:
       pkg-types: 2.3.0
       std-env: 3.10.0
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.2.0(magicast@0.3.5))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.2.0(magicast@0.5.2))':
     dependencies:
-      '@nuxt/kit': 4.2.0(magicast@0.3.5)
+      '@nuxt/kit': 4.2.0(magicast@0.5.2)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/vite-builder@4.2.0(@types/node@25.5.0)(eslint@9.39.1(jiti@2.6.1))(magicast@0.3.5)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.2.0(@types/node@25.5.0)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
-      '@nuxt/kit': 4.2.0(magicast@0.3.5)
+      '@nuxt/kit': 4.2.0(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
@@ -6189,7 +6189,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.8
@@ -8966,19 +8966,19 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2):
+  nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
-      '@dxup/nuxt': 0.2.2(magicast@0.3.5)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.2.0)(cac@6.7.14)(magicast@0.3.5)
+      '@dxup/nuxt': 0.2.2(magicast@0.5.2)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.2.0)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 2.7.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
-      '@nuxt/kit': 4.2.0(magicast@0.3.5)
-      '@nuxt/nitro-server': 4.2.0(db0@0.3.4)(ioredis@5.10.0)(magicast@0.3.5)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)
+      '@nuxt/kit': 4.2.0(magicast@0.5.2)
+      '@nuxt/nitro-server': 4.2.0(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)
       '@nuxt/schema': 4.2.0
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.2.0(magicast@0.3.5))
-      '@nuxt/vite-builder': 4.2.0(@types/node@25.5.0)(eslint@9.39.1(jiti@2.6.1))(magicast@0.3.5)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.2.0(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.2.0(@types/node@25.5.0)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.2)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.12(vue@3.5.22(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2

--- a/test/browser/query.test.ts
+++ b/test/browser/query.test.ts
@@ -58,3 +58,32 @@ test.describe('Browse query results', () => {
     await expect(page.getByText('Display')).toBeVisible({ timeout: 5000 })
   })
 })
+
+// The disabled run buttons must expose why they are disabled (#390): a visible
+// reason below them, wired to both buttons via aria-describedby. This exercises
+// only client-side state (no query run, no boundary data needed).
+test.describe('Run query disabled-state explanation', () => {
+  test('explains the blocker and clears it once resolved', async ({ page }) => {
+    await page.goto('/tne?bbox=-122.69075,45.51358,-122.66809,45.53306')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('Transit Network Explorer')).toBeVisible({ timeout: 15000 })
+
+    const runButton = page.getByRole('button', { name: 'Run Browse Query' })
+    const reason = page.locator('#cal-query-blocked-reason')
+
+    // A valid bbox makes the query runnable: no reason shown.
+    await expect(runButton).toBeEnabled()
+    await expect(reason).toHaveText('')
+
+    // Administrative boundaries with nothing selected blocks the query.
+    await page.getByLabel(/Select geography by/).selectOption('adminBoundary')
+    await expect(runButton).toBeDisabled()
+    await expect(reason).toContainText('select at least one administrative boundary')
+    await expect(runButton).toHaveAttribute('aria-describedby', 'cal-query-blocked-reason')
+
+    // Switching back to the bounding box clears the blocker.
+    await page.getByLabel(/Select geography by/).selectOption('bbox')
+    await expect(runButton).toBeEnabled()
+    await expect(reason).toHaveText('')
+  })
+})


### PR DESCRIPTION
Addresses the accessibility barriers in #390.

## Summary

Upgrades @interline-io/catenary from 0.4.0 to 0.6.0 and completes the CALACT side of the accessibility barriers reported in #390. The catenary release carries the rebuilt datepicker (typeable input plus a calendar dialog button, replacing the screen-reader-inaccessible popup) and the rebuilt administrative boundary picker (ARIA 1.2 combobox where Tab selects the highlighted option), along with announced validation messages and live-region support for notifications. This PR removes the CALACT-side blockers that remained: the readonly props that made manual date entry impossible, the unexplained disabled state of the Run Query buttons, and toast notifications that screen readers never announced.

## User-facing changes

### Date entry (#390: "not possible to type in a date manually")
- Dates can now be typed directly into the start/end date fields in the query panel and the Feed Archive modal (committed on Enter or when leaving the field; invalid text reverts and is announced).
- The calendar opens from a dedicated, labeled button next to each date field; the button's name includes the currently selected date.
- The end date's remove button is now visually attached to the date field as part of its addon group (catenary 0.6.0 addon slot) instead of floating beside it.

### Administrative boundary selection (#390: "allow user to select an option using Tab or Enter key")
- Tab now selects the highlighted boundary before moving on (Enter continues to work).
- Selections and removals are announced ("Added ...", "Removed ..."), as are empty search results.

### Run Query buttons (#390: "error message for why the Run Query button can't be pressed")
- When the run buttons are disabled, the specific reason now appears below them (e.g. "Cannot run query: select at least one administrative boundary."), is announced when it appears or clears, and is attached to both buttons via aria-describedby so screen readers read it when focusing the disabled button.

### Toast notifications
- Toasts (query errors, confirmations) are now announced by screen readers; error toasts interrupt via role="alert". Previously all toasts were silent.

### Boundary actions
- "Show on map" and "Clear all" are now reachable and operable by keyboard (previously click-only). They moved out of the field label into a row above the picker; a tidier layout for the whole Geographic Bounds section is deferred to a follow-up PR.

## Implementation details

### Catenary 0.6.0 upgrade
- package.json bump; no API changes required in CALACT beyond the removals below. The datepicker's left calendar icon moved onto the new toggle button.
- end-date-field.vue moves the remove button into cat-datepicker's #addon slot and drops the cal-end-date-field-range flex wrapper, covering the query panel and Feed Archive modal via the shared component.
- Removed `readonly` from the three cat-datepicker usages (query.vue, end-date-field.vue, feed-version-picker-modal.vue); it existed to force calendar-only entry, which is exactly what #390 reported as a barrier.

### Run button reason
- New `queryBlockedReason` computed mirrors the `validQueryParams` checks in priority order and renders into an always-present `<p aria-live="polite">` below the buttons; both buttons reference it via a v-bind'd record (strictTemplates rejects undeclared attributes written directly on components).

### Toast live region
- useToastNotification's container is now created when the composable is first used (a live region must exist before content is inserted for announcements to fire) and is never removed; previously it was deleted when empty and recreated with its first toast, which screen readers miss. The container carries aria-live="polite"; danger toasts additionally carry role="alert" (an occasional double announcement in some screen readers is preferable to a missed error).
- A proper cat-toast component in catenary (named dismiss button, pause-on-hover, per-variant roles) and migration of this composable are queued as a follow-up pair; the composable's existing TODO already points there.

### Boundary actions and query form
- The "Show on map" / "Clear all" boundary actions are now real (ghost-styled) cat-buttons in an actions row above the picker. The previous href-less anchors were keyboard-unreachable, and because they sat inside the field's label element, their text polluted the taginput's accessible name and clicks also triggered label activation.
- The query controls are wrapped in a named form element (aria-label "Transit network query parameters"), giving screen reader users a landmark to jump to. All buttons inside are type=button and the widgets consume their own Enter keys, so there is no implicit submission; submit.prevent guards the rest.

### Tests
- New Playwright browser test (test/browser/query.test.ts) covering the disabled-state explanation: reason appears and is referenced via aria-describedby in administrative-boundary mode with no selection, and clears when resolved. Note the browser suite runs locally against the test database, not in CI.

## User test plan
- In the query panel, type a date (e.g. 2026-07-04) into Start date and press Enter; with VoiceOver, confirm "Date set to ..." is announced. Type invalid text and Tab away; confirm it reverts with an announcement.
- Open the calendar with the button next to the date field; arrow around; press Escape; confirm focus returns to the button.
- In Administrative boundaries, search, ArrowDown to highlight a boundary, press Tab; confirm it is selected and announced.
- Clear the boundary selection while in adminBoundary mode; confirm "Cannot run query: select at least one administrative boundary." appears below the run buttons and is read when focusing the disabled Run Browse Query button.
- Tab to "Show on map" / "Clear all" above the boundary picker and activate them with Enter.
- Trigger a toast (e.g. a failed query) with VoiceOver running; confirm it is announced.
- Check the Feed Archive modal dates work the same as the query panel.

Generated with [Claude Code](https://claude.com/claude-code)


