### PR TITLE
Upgrade catenary to 0.6.1 for taginput selection announcements

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@aitodotai/json-stringify-pretty-compact": "1.3.0",
-    "@interline-io/catenary": "0.6.0",
+    "@interline-io/catenary": "0.6.1",
     "@mdi/font": "7.4.47",
     "@interline-io/tlv2-auth": "0.1.0-sha.ad5c03e",
     "@apollo/client": "3.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 3.13.4
         version: 3.13.4(graphql@16.10.0)
       '@interline-io/catenary':
-        specifier: 0.6.0
-        version: 0.6.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
+        specifier: 0.6.1
+        version: 0.6.1(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       '@interline-io/tlv2-auth':
         specifier: 0.1.0-sha.ad5c03e
         version: 0.1.0-sha.ad5c03e(h3@1.15.8)(nuxt@4.2.0(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.2))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.22(typescript@5.9.3))
@@ -735,8 +735,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@interline-io/catenary@0.6.0':
-    resolution: {integrity: sha512-A9UEIcLXFWk/JqbZzcJr366VVaRV5Qae0ode0JzL1NrD9EyEKdT8xB1vVG5bdeYlT5Np20a3JdDk3LlMdrLsOA==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.6.0/2f470d4342e1a826996a11e8509463560748e266}
+  '@interline-io/catenary@0.6.1':
+    resolution: {integrity: sha512-r0JdnsacPMJ+UyFFMHVOpVW0amAs3Bg2D8000E82J832447yPvb6isqSeDLit3UX0ceRrc2XaeYkN0mfouTR7Q==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.6.1/0e5397a66246a31f289e371d24f0b2aa3f8a4d59}
     peerDependencies:
       '@mdi/font': ^7.4.0
       bulma: ^1.0.0
@@ -5699,7 +5699,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@interline-io/catenary@0.6.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
+  '@interline-io/catenary@0.6.1(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@mdi/font': 7.4.47
       bulma: 1.0.4


### PR DESCRIPTION
Brings in catenary #44, the final #390 follow-up from accessibility review: boundary add/remove announcements now restate the resulting selection (the input clears after each pick, so the delta alone left screen reader users unsure what was held), and the input carries a visually hidden usage hint describing the type-to-search, arrow browsing, and Enter/Tab interaction.