### PR TITLE
Update census data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@ tmp**
 **/tmp**
 .output
 testdata/gtfs/data/*.zip
-# Census raw downloads (fetched by rebuild-census.sh; the filtered data
-# lands in the committed calact_tlserver.dump).
+# Census raw downloads, fetched by rebuild-census.sh.
 testdata/gtfs/census-data/
+
+# DB dumps — regenerated locally (rebuild.sh / rebuild-census.sh), not committed for now
+# (LFS bloat). Drop this once dump-based fixtures are wired into CI.
+*.dump
 
 # Created by .ignore support plugin (hsz.mobi)
 ### Node template

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -49,7 +49,7 @@
       </cat-tooltip>
     </div>
 
-    <!-- Buffer apportionment is only rolled up for state/county/tract — for
+    <!-- Buffer apportionment is only rolled up for state/county/tract/bg — for
          place/cbsa/csa/uac20 we'd need server-side geographic containment
          that doesn't exist yet. Surface this honestly rather than silently
          showing un-apportioned values. -->
@@ -61,7 +61,7 @@
     >
       <p>
         Stop statistical radius apportionment is only supported when aggregating
-        by State, County, or Census Tract. Demographic columns below show the
+        by State, County, Census Tract, or Block Group. Demographic columns below show the
         full geography's values (no buffer apportionment). Switch to a supported
         layer above, or set the stop statistical radius to 0 to acknowledge.
       </p>

--- a/src/cli/scenario-cli.ts
+++ b/src/cli/scenario-cli.ts
@@ -13,7 +13,7 @@ export function scenarioOptionsAdd (program: Command): Command {
     .option('--end-time <time>', 'End time (HH:MM)', '22:00')
     .option('--output <format>', 'Output format (json|csv|summary)', 'summary')
     .option('--save-scenario-data <filename>', 'Save scenario data and config to file')
-    .option('--aggregate-layer <layer>', 'Census geography layer for aggregation (e.g., tract, blockgroup)', 'tract')
+    .option('--aggregate-layer <layer>', 'Census geography layer for aggregation (e.g., tract, bg)', 'tract')
     .option('--bbox-name <name>', 'Use canned bounding box', 'portland')
     .option('--no-schedule', 'Disable schedule fetching')
 }

--- a/src/core/census-buffer.test.ts
+++ b/src/core/census-buffer.test.ts
@@ -176,4 +176,28 @@ describe('geographiesForAggregationRow', () => {
   it('no match returns empty', () => {
     expect(geographiesForAggregationRow('0500000US99999', tracts)).toEqual([])
   })
+
+  it('rolls a block group up under its tract, county, and state', () => {
+    // A block-group geoid is its tract geoid (11 FIPS digits) plus one digit, so it
+    // prefix-nests under tract -> county -> state exactly like a tract does. This pins
+    // the bg membership added to HIERARCHICAL_TIGER_LAYERS.
+    const bgs = [
+      geography({ geoid: '1500000US410510101001', layer: 'bg' }), // tract 41051010100
+      geography({ geoid: '1500000US410510101002', layer: 'bg' }), // tract 41051010100
+      geography({ geoid: '1500000US410670301001', layer: 'bg' }), // Washington County
+    ]
+    expect(geographiesForAggregationRow('1400000US41051010100', bgs).map(g => g.geoid)).toEqual([
+      '1500000US410510101001',
+      '1500000US410510101002',
+    ])
+    expect(geographiesForAggregationRow('0500000US41051', bgs).map(g => g.geoid)).toEqual([
+      '1500000US410510101001',
+      '1500000US410510101002',
+    ])
+    expect(geographiesForAggregationRow('0400000US41', bgs).map(g => g.geoid)).toEqual([
+      '1500000US410510101001',
+      '1500000US410510101002',
+      '1500000US410670301001',
+    ])
+  })
 })

--- a/src/core/census-buffer.ts
+++ b/src/core/census-buffer.ts
@@ -2,9 +2,11 @@ import type { CensusValues } from './census-columns'
 import { CENSUS_COLUMNS, NON_ADDITIVE_CENSUS_COLUMNS } from './census-columns'
 import type { CensusGeographyData } from './census-intersection'
 
-// FIPS-prefix-rollup-safe layers. Place/cbsa/csa/uac/fta-uac20-nonurban need
-// server-side geometric containment (see #370).
-export const HIERARCHICAL_TIGER_LAYERS = new Set(['state', 'county', 'tract'])
+// FIPS-prefix-rollup-safe layers, coarse→fine: a finer geoid's FIPS digits start with
+// its parent's (block group nests in tract, tract in county, county in state), so
+// geoidFips prefix-matching rolls them up safely. Place/cbsa/csa/uac/fta-uac20-nonurban
+// don't nest by FIPS and need server-side geometric containment (see #370).
+export const HIERARCHICAL_TIGER_LAYERS = new Set(['state', 'county', 'tract', 'bg'])
 
 // Shared shape for `CensusGeographyData` (scenario pipeline) and
 // `BufferGeographyIntersection` (per-entity buffer fetch) — both pass

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -256,13 +256,15 @@ export const FILTER_EXPANDED_WIDTH = FILTER_MAIN_WIDTH + FILTER_SUB_WIDTH + PANE
 // #315 default: 402 m ≈ 1/4 mile (Tom). 0 disables the feature.
 export const STOP_BUFFER_DEFAULT_RADIUS = 402
 
-// Tract until transitland-server loads block-group (per #315 spec).
+// Tract is the default buffer layer (per #315 spec). Block group ('bg') is also
+// available wherever it's loaded; tract is kept as the default for stability.
 export const STOP_BUFFER_DEFAULT_LAYER = 'tract'
 
 export const censusLayerLabels: Record<string, { singular: string, plural: string }> = {
   'state': { singular: 'State', plural: 'states' },
   'county': { singular: 'County', plural: 'counties' },
   'tract': { singular: 'Census Tract', plural: 'census tracts' },
+  'bg': { singular: 'Block Group', plural: 'block groups' },
   'place': { singular: 'City/Place', plural: 'cities/places' },
   'cbsa': { singular: 'Metropolitan Area', plural: 'metropolitan areas' },
   'csa': { singular: 'Combined Statistical Area', plural: 'combined statistical areas' },

--- a/src/scenario/scenario-census.test.ts
+++ b/src/scenario/scenario-census.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, type Mock } from 'vitest'
+import {
+  type GraphQLClient,
+  type Bbox,
+  parseBbox,
+  apportionBuffer,
+  censusGeographyMapToEntries,
+  apiFetch,
+  BasicGraphQLClient,
+} from '~~/src/core'
+import {
+  runScenarioFetcher,
+  applyScenarioResultFilter,
+  type ScenarioConfig,
+} from '~~/src/scenario'
+import { stopGeoAggregateCsv } from '~~/src/tl'
+
+// End-to-end tests of the census branch of the scenario pipeline. Both suites drive
+// runScenarioFetcher and assert the same census numbers (tract and block group) — the
+// hermetic suite from a MockGraphQLClient (always runs), the integration suite from a
+// live transitland-server backed by the rebuild-census.sh test DB (opt-in). They share
+// the config, the known geoids, and the pinned values, so the mock and the server are
+// checked against the same expectations from opposite ends.
+
+const GEO_DATASET = 'tiger2021'
+const TABLE_DATASET = 'acsdt5y2021'
+// Downtown Portland, OR — inside the WA/OR/CA fixture and known to intersect the
+// geographies below. (The hermetic mock ignores query variables, but feed-versions
+// throws without a bbox.)
+const BBOX: Bbox = parseBbox('-122.69075,45.51358,-122.66809,45.53306')
+
+// Known geographies in the bbox with total population (b01003_001) pinned to the
+// committed census-data .dat. Block group 1500000US410510051012 nests under tract
+// 1400000US41051005101.
+const CASES = [
+  { layer: 'tract', geoid: '1400000US41051005101', name: 'Census Tract 51.01', pop: 3353 },
+  { layer: 'bg', geoid: '1500000US410510051012', name: 'Block Group 2', pop: 1843 },
+]
+
+// Census-only config: includeFixedRoute:false drops stops/routes/departures/buffers and
+// includeFlexAreas:false drops flex, so the plan is exactly [feed-versions, census-values].
+function censusConfig (aggregateLayer: string): ScenarioConfig {
+  return {
+    reportName: 'census-test',
+    bbox: BBOX,
+    geoDatasetName: GEO_DATASET,
+    tableDatasetName: TABLE_DATASET,
+    aggregateLayer,
+    includeFixedRoute: false,
+    includeFlexAreas: false,
+    includeDepartures: false,
+  }
+}
+
+// runScenarioFetcher streams progress to this controller while also accumulating
+// ScenarioData internally; the accumulation path doesn't depend on the controller, so
+// a no-op sink is sufficient for assertions.
+function noopController (): ReadableStreamDefaultController {
+  return {
+    enqueue () {},
+    close () {},
+    error () {},
+    get desiredSize () { return 1 },
+  } as unknown as ReadableStreamDefaultController
+}
+
+// --- Hermetic suite -------------------------------------------------------------
+
+// A GraphQLClient whose responses are scripted per call, in pipeline order.
+class MockGraphQLClient implements GraphQLClient {
+  public mockQuery: Mock
+  constructor () {
+    this.mockQuery = vi.fn()
+  }
+
+  async query<T = any> (query: any, variables?: any): Promise<{ data?: T }> {
+    return this.mockQuery(query, variables)
+  }
+}
+
+// Build the census_datasets response fetchCensusIntersection expects. geometryArea >
+// intersectionArea so the apportionment ratio is a clean 0.5.
+function censusResponse (geoid: string, layer: string, name: string, pop: number) {
+  return {
+    data: {
+      census_datasets: [{
+        id: 1,
+        name: GEO_DATASET,
+        url: '',
+        geographies: [{
+          id: 100,
+          name,
+          aland: 0,
+          awater: 0,
+          geoid,
+          layer_name: layer,
+          adm0_name: 'United States',
+          adm0_iso: 'US',
+          adm1_name: 'Oregon',
+          adm1_iso: 'US-OR',
+          geometry_area: 1000,
+          intersection_area: 500,
+          intersection_geometry: null,
+          values: [
+            { dataset_name: TABLE_DATASET, geoid, values: { b01003_001: pop } },
+          ],
+        }],
+      }],
+    },
+  }
+}
+
+describe('scenario census pipeline (hermetic)', () => {
+  for (const c of CASES) {
+    it(`runs the full pipeline and surfaces ${c.layer} census values end to end`, async () => {
+      const client = new MockGraphQLClient()
+      client.mockQuery
+        .mockResolvedValueOnce({ data: { feeds: [] } }) // feed-versions phase
+        .mockResolvedValueOnce(censusResponse(c.geoid, c.layer, c.name, c.pop)) // census-values phase
+        .mockResolvedValue({ data: {} })
+
+      const config = censusConfig(c.layer)
+      const data = await runScenarioFetcher(noopController(), config, client)
+
+      // Exactly two GraphQL calls: feed-versions then census-values.
+      expect(client.mockQuery).toHaveBeenCalledTimes(2)
+
+      // 1) Raw pipeline output: the geography + ACS value landed in ScenarioData, tagged
+      //    with the requested layer and the area-derived intersection ratio (500/1000).
+      const geo = data.censusGeographies.get(c.geoid)
+      expect(geo).toBeDefined()
+      expect(geo!.values['b01003_001']).toBe(c.pop)
+      expect(geo!.layer).toBe(c.layer)
+      expect(geo!.intersectionRatio).toBeCloseTo(0.5, 6)
+
+      // 2) scenarioFilter (applyScenarioResultFilter) passes the census map through
+      //    unchanged — this is the object the report components consume.
+      const filtered = applyScenarioResultFilter(data, config, {})
+      expect(filtered.censusGeographies?.get(c.geoid)?.values['b01003_001']).toBe(c.pop)
+
+      // 3) The aggregation table the report renders: a stop-less row is seeded per
+      //    geography and carries the full (un-apportioned) demographic value.
+      const rows = stopGeoAggregateCsv([], c.layer, filtered.censusGeographies)
+      const row = rows.find(r => r.geoid === c.geoid)
+      expect(row).toBeDefined()
+      expect(row!.layer_name).toBe(c.layer)
+      expect((row as Record<string, unknown>).total_population).toBe(c.pop)
+
+      // 4) Buffer apportionment (the stopBufferRadius>0 report path): the additive value
+      //    scales by the intersection ratio, while median income is non-additive => null.
+      const apportioned = apportionBuffer(censusGeographyMapToEntries(data.censusGeographies))
+      expect(apportioned.values.total_population).toBeCloseTo(c.pop * 0.5, 6)
+      expect(apportioned.pctCoverage).toBeCloseTo(0.5, 6)
+      expect(apportioned.values.median_household_income).toBeNull()
+    })
+  }
+})
+
+// --- Integration suite ----------------------------------------------------------
+//
+// Hits a live transitland-server backed by the rebuild-census.sh test DB (states
+// WA/OR/CA, datasets acsdt5y2021 + tiger2021). Opt-in so an environment without a
+// server doesn't fail; enable with:
+//   TEST_CENSUS=true TRANSITLAND_API_BASE=http://localhost:8080 pnpm test
+//
+// The raw b01003_001 total population is bbox-clip-invariant (the server returns the
+// full-geography ACS value and reports clipping separately), so the pinned values are
+// deterministic against the committed dump.
+describe.skipIf(process.env.TEST_CENSUS !== 'true')('scenario census pipeline (integration)', () => {
+  const client = new BasicGraphQLClient(
+    (process.env.TRANSITLAND_API_BASE || '') + '/query',
+    apiFetch(process.env.TRANSITLAND_API_KEY || ''),
+  )
+
+  for (const c of CASES) {
+    it(`fetches real ${c.layer} census values from the server`, async () => {
+      const data = await runScenarioFetcher(noopController(), censusConfig(c.layer), client)
+
+      // The census-values query returned geographies for the requested layer.
+      expect(data.censusGeographies.size).toBeGreaterThan(0)
+      for (const geo of data.censusGeographies.values()) {
+        expect(geo.layer).toBe(c.layer)
+      }
+
+      // The specific known geography carries its pinned ACS total population.
+      const known = data.censusGeographies.get(c.geoid)
+      expect(known, `expected ${c.geoid} in the downtown-Portland ${c.layer} results`).toBeDefined()
+      expect(known!.values['b01003_001']).toBe(c.pop)
+    }, 120000)
+  }
+})

--- a/src/scenario/scenario-census.test.ts
+++ b/src/scenario/scenario-census.test.ts
@@ -30,8 +30,8 @@ const TABLE_DATASET = 'acsdt5y2021'
 const BBOX: Bbox = parseBbox('-122.69075,45.51358,-122.66809,45.53306')
 
 // Known geographies in the bbox with total population (b01003_001) pinned to the
-// committed census-data .dat. Block group 1500000US410510051012 nests under tract
-// 1400000US41051005101.
+// rebuild-census.sh test DB (acsdt5y2021). Block group 1500000US410510051012 nests
+// under tract 1400000US41051005101.
 const CASES = [
   { layer: 'tract', geoid: '1400000US41051005101', name: 'Census Tract 51.01', pop: 3353 },
   { layer: 'bg', geoid: '1500000US410510051012', name: 'Block Group 2', pop: 1843 },
@@ -165,7 +165,7 @@ describe('scenario census pipeline (hermetic)', () => {
 //
 // The raw b01003_001 total population is bbox-clip-invariant (the server returns the
 // full-geography ACS value and reports clipping separately), so the pinned values are
-// deterministic against the committed dump.
+// deterministic against the rebuild-census.sh test DB.
 describe.skipIf(process.env.TEST_CENSUS !== 'true')('scenario census pipeline (integration)', () => {
   const client = new BasicGraphQLClient(
     (process.env.TRANSITLAND_API_BASE || '') + '/query',

--- a/src/tl/stop.test.ts
+++ b/src/tl/stop.test.ts
@@ -183,7 +183,7 @@ describe('stopGeoAggregateCsv', () => {
       route_stops: [makeRouteStop({ routeInternalId: 10, agencyId: 1 })],
       census_geographies: [
         { id: 1, geoid: '100', layer_name: 'tract', name: 'Tract 100' },
-        { id: 2, geoid: '100-1', layer_name: 'blockgroup', name: 'BG 100-1' },
+        { id: 2, geoid: '100-1', layer_name: 'bg', name: 'BG 100-1' },
       ] as unknown as Stop['census_geographies'],
       visits: makeVisitSummary({ total: counts(5, 1) }),
     })
@@ -193,10 +193,10 @@ describe('stopGeoAggregateCsv', () => {
     expect(byTract[0]?.geoid).toBe('100')
     expect(byTract[0]?.layer_name).toBe('tract')
 
-    const byBg = stopGeoAggregateCsv([stop], 'blockgroup')
+    const byBg = stopGeoAggregateCsv([stop], 'bg')
     expect(byBg).toHaveLength(1)
     expect(byBg[0]?.geoid).toBe('100-1')
-    expect(byBg[0]?.layer_name).toBe('blockgroup')
+    expect(byBg[0]?.layer_name).toBe('bg')
 
     // Unknown layer: no match
     expect(stopGeoAggregateCsv([stop], 'county')).toHaveLength(0)

--- a/testdata/gtfs/calact_tlserver.dump
+++ b/testdata/gtfs/calact_tlserver.dump
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d26c33ed3db7b7bf9b4dbc129ac68a9e56838f42950e78cf593a72ee2b22ecf3
-size 464536266

--- a/testdata/gtfs/calact_tlserver.dump
+++ b/testdata/gtfs/calact_tlserver.dump
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2adc6c2c9913967eb33356837d0ee5f5d038766bcdaac0a0a6415d072dcb47cd
-size 361296101
+oid sha256:d26c33ed3db7b7bf9b4dbc129ac68a9e56838f42950e78cf593a72ee2b22ecf3
+size 464536266

--- a/testdata/gtfs/rebuild-census.sh
+++ b/testdata/gtfs/rebuild-census.sh
@@ -21,10 +21,12 @@ SKIP_FETCH=${SKIP_FETCH:-false}
 # field titles/order coming from the dataset's Table Shells file.
 ACS_TABLES=(b01001 b01003 b02001 b08301 b19013 b23024 b25002 b25003 b25044 c17002)
 
-# TIGER layers to load. bg omitted: the tool doesn't use block-group geometry (and the
-# table-based SF doesn't publish bg values for every table we need). uac20 omitted: the
-# loader pins it to the 2020 urban areas (TIGER2023) and the tool doesn't use it.
-TIGER_LAYERS=(state county place cbsa csa tract)
+# TIGER layers to load. bg (block group) is included so it can be selected alongside
+# tract for aggregation and buffer apportionment; the ACS .dat files already carry
+# whatever block-group values each table publishes (some tables only go down to tract,
+# which the UI renders as insufficient data). uac20 omitted: the loader pins it to the
+# 2020 urban areas (TIGER2023) and the tool doesn't use it.
+TIGER_LAYERS=(state county place cbsa csa tract bg)
 
 # refdata-load --fetch downloads missing files into the input dir and skips ones already
 # present; SKIP_FETCH=true loads straight from that cache without touching the network.

--- a/testdata/gtfs/rebuild-census.sh
+++ b/testdata/gtfs/rebuild-census.sh
@@ -1,74 +1,59 @@
 #!/bin/bash
-# Loads ACS + TIGER data into calact_tlserver for the test snapshot.
-# Filtered to WA/OR/CA. Assumes `tlv2` is on PATH.
+# Loads ACS + TIGER reference data into the calact test database via the tlv2 refdata
+# loader, then filters to WA/OR/CA for the test snapshot.
+#
+# Requires `tlv2` on PATH (from interline-io/tlv2: `cd cmd/tlv2 && go install .`) and
+# TL_DATABASE_URL pointing at the target DB — it WILL be truncated and rewritten. The
+# DB must already have the tl_census_* schema (`tlv2 dbmigrate up`).
 #
 # Env:
-#   CENSUS_YEAR  — vintage (default 2021)
-#   SKIP_FETCH   — "true" to reuse existing ./census-data instead of wget
+#   CENSUS_YEAR  — ACS/TIGER vintage (default 2021); any year resolves on demand
+#   SKIP_FETCH   — "true" to load from previously fetched files instead of downloading
 set -ex -o pipefail
 
+: "${TL_DATABASE_URL:?set TL_DATABASE_URL to the target database (it will be truncated)}"
 CENSUS_YEAR=${CENSUS_YEAR:-2021}
 SKIP_FETCH=${SKIP_FETCH:-false}
 
-# bg omitted: table-based SF doesn't publish block-group values for every
-# table we need. uac20 omitted: not published in TIGER before 2023.
-CENSUS_LAYERS="state county place cbsa csa tract"
-
-# ACS tables consumed by src/core/census-columns.ts. Keep in sync with
-# `REQUIRED_ACS_TABLES` (derived from the per-column `requiredTables`).
+# ACS detail tables consumed by src/core/census-columns.ts. Keep in sync with
+# REQUIRED_ACS_TABLES (derived from the per-column requiredTables). The loader's table
+# set is open: --table names any detail table id, synthesized from one template, with
+# field titles/order coming from the dataset's Table Shells file.
 ACS_TABLES=(b01001 b01003 b02001 b08301 b19013 b23024 b25002 b25003 b25044 c17002)
 
-CENSUS_BASE="ftp://ftp.census.gov/programs-surveys/acs/summary_file/${CENSUS_YEAR}/table-based-SF"
-TIGER_BASE="ftp://ftp.census.gov/geo/tiger/TIGER${CENSUS_YEAR}"
+# TIGER layers to load. bg omitted: the tool doesn't use block-group geometry (and the
+# table-based SF doesn't publish bg values for every table we need). uac20 omitted: the
+# loader pins it to the 2020 urban areas (TIGER2023) and the tool doesn't use it.
+TIGER_LAYERS=(state county place cbsa csa tract)
 
-mkdir -p census-data
-cd census-data
+# refdata-load --fetch downloads missing files into the input dir and skips ones already
+# present; SKIP_FETCH=true loads straight from that cache without touching the network.
+# Files are kept under census-data/<dataset> so they persist between runs.
+FETCH=(--fetch)
+[ "$SKIP_FETCH" = "true" ] && FETCH=()
 
-# -------- 1. Fetch --------
-if [ "$SKIP_FETCH" != "true" ]; then
-  wget -cr "${CENSUS_BASE}/documentation/Geos${CENSUS_YEAR}5YR.txt"
-  wget -cr "${CENSUS_BASE}/documentation/ACS${CENSUS_YEAR}1YR_Table_Shells.txt"
-  # Exact filename (no `*`) skips race/ethnicity sub-tables we don't use.
-  for tbl in "${ACS_TABLES[@]}"; do
-    wget -cr -A "acsdt5y${CENSUS_YEAR}-${tbl}.dat" "${CENSUS_BASE}/data/5YRData/"
-  done
-  for layer in $CENSUS_LAYERS; do
-    wget -cr "${TIGER_BASE}/$(echo "$layer" | tr a-z A-Z)/"
-  done
-else
-  echo "SKIP_FETCH=true — using existing files under census-data/"
-fi
+# -------- 1. Reset --------
+psql "$TL_DATABASE_URL" -c "TRUNCATE TABLE tl_census_datasets RESTART IDENTITY CASCADE;"
 
-# -------- 2. Reset --------
-psql -c "TRUNCATE TABLE tl_census_datasets RESTART IDENTITY CASCADE;"
+# -------- 2. Load ACS values --------
+ACS_ARGS=()
+for tbl in "${ACS_TABLES[@]}"; do ACS_ARGS+=(--table "$tbl"); done
+tlv2 refdata-load \
+  --dataset "acsdt5y${CENSUS_YEAR}" \
+  --input-dir "census-data/acsdt5y${CENSUS_YEAR}" \
+  "${FETCH[@]}" "${ACS_ARGS[@]}"
 
-# -------- 3. Load ACS values --------
-# Single invocation across all layers — per-layer invocations are
-# incompatible with --truncate-source (it would wipe the prior layer).
-TABLE_ARGS=()
-for tbl in "${ACS_TABLES[@]}"; do
-  TABLE_ARGS+=(--table="$(echo "$tbl" | tr a-z A-Z)")
-done
-tlv2 geodata-us-census-acs-table-load \
-  --truncate-source \
-  --dataset-name="acsdt5y${CENSUS_YEAR}" \
-  "${TABLE_ARGS[@]}" \
-  "ftp.census.gov/programs-surveys/acs/summary_file/${CENSUS_YEAR}/table-based-SF/documentation/ACS${CENSUS_YEAR}1YR_Table_Shells.txt" \
-  "ftp.census.gov/programs-surveys/acs/summary_file/${CENSUS_YEAR}/table-based-SF/data"
+# -------- 3. Load TIGER geometries --------
+TIGER_ARGS=()
+for layer in "${TIGER_LAYERS[@]}"; do TIGER_ARGS+=(--table "$layer"); done
+tlv2 refdata-load \
+  --dataset "tiger${CENSUS_YEAR}" \
+  --input-dir "census-data/tiger${CENSUS_YEAR}" \
+  "${FETCH[@]}" "${TIGER_ARGS[@]}"
 
-# -------- 4. Load TIGER geometries --------
-for layer in $CENSUS_LAYERS; do
-  layerup=$(echo "$layer" | tr a-z A-Z)
-  tlv2 geodata-us-census-tiger-load \
-    --dataset-name="tiger${CENSUS_YEAR}" \
-    --layer-name "$layer" \
-    --layer-level "$layer" \
-    --layer-desc "Layer: ${layer}" \
-    --dir "./ftp.census.gov/geo/tiger/TIGER${CENSUS_YEAR}/${layerup}/"
-done
-
-# -------- 5. Filter to WA (53), OR (41), CA (06) --------
-psql -c "delete from tl_census_values    where geoid !~ '.*US(06|41|53).*';"
-psql -c "delete from tl_census_geographies where geoid !~ '.*US(06|41|53).*';"
+# -------- 4. Filter to WA (53), OR (41), CA (06) --------
+# ACS/TIGER geoids carry the state FIPS as US<ff>; keep only these three states.
+psql "$TL_DATABASE_URL" -c "DELETE FROM tl_census_values      WHERE geoid !~ '.*US(06|41|53).*';"
+psql "$TL_DATABASE_URL" -c "DELETE FROM tl_census_geographies WHERE geoid !~ '.*US(06|41|53).*';"
 
 echo "Census data loaded into $TL_DATABASE_URL"

--- a/testdata/gtfs/rebuild-census.sh
+++ b/testdata/gtfs/rebuild-census.sh
@@ -1,61 +1,59 @@
 #!/bin/bash
-# Loads ACS + TIGER reference data into the calact test database via the tlv2 refdata
-# loader, then filters to WA/OR/CA for the test snapshot.
+# (Re)loads, scopes, and dumps the census/NTD tables (calact_tlserver-census.dump) via the
+# tlv2 refdata loader — self-contained, independent of rebuild.sh (the base GTFS dump).
+# Scoped to WA/OR/CA for the test fixture; FULL_NATIONAL=true loads every state.
 #
-# Requires `tlv2` on PATH (from interline-io/tlv2: `cd cmd/tlv2 && go install .`) and
-# TL_DATABASE_URL pointing at the target DB — it WILL be truncated and rewritten. The
-# DB must already have the tl_census_* schema (`tlv2 dbmigrate up`).
+# Needs `tlv2` on PATH and TL_DATABASE_URL (externally-created DB; schema applied below).
+# Loading is incremental (per-source SHA1 skip); truncate first for a clean reload:
+#   psql "$TL_DATABASE_URL" -c "TRUNCATE TABLE tl_census_datasets RESTART IDENTITY CASCADE;"
 #
-# Env:
-#   CENSUS_YEAR  — ACS/TIGER vintage (default 2021); any year resolves on demand
-#   SKIP_FETCH   — "true" to load from previously fetched files instead of downloading
+# Env: CENSUS_YEAR (default 2021), NTD_YEAR (default 2024), FULL_NATIONAL (skip scoping).
 set -ex -o pipefail
 
-: "${TL_DATABASE_URL:?set TL_DATABASE_URL to the target database (it will be truncated)}"
+: "${TL_DATABASE_URL:?set TL_DATABASE_URL to the target database}"
 CENSUS_YEAR=${CENSUS_YEAR:-2021}
-SKIP_FETCH=${SKIP_FETCH:-false}
+NTD_YEAR=${NTD_YEAR:-2024}
 
-# ACS detail tables consumed by src/core/census-columns.ts. Keep in sync with
-# REQUIRED_ACS_TABLES (derived from the per-column requiredTables). The loader's table
-# set is open: --table names any detail table id, synthesized from one template, with
-# field titles/order coming from the dataset's Table Shells file.
+# Schema (idempotent; natural-earth is base GTFS data, not census).
+transitland dbmigrate up
+transitland dbmigrate-natural-earth
+
+# ACS detail tables; keep in sync with REQUIRED_ACS_TABLES in src/core/census-columns.ts.
 ACS_TABLES=(b01001 b01003 b02001 b08301 b19013 b23024 b25002 b25003 b25044 c17002)
 
-# TIGER layers to load. bg (block group) is included so it can be selected alongside
-# tract for aggregation and buffer apportionment; the ACS .dat files already carry
-# whatever block-group values each table publishes (some tables only go down to tract,
-# which the UI renders as insufficient data). uac20 omitted: the loader pins it to the
-# 2020 urban areas (TIGER2023) and the tool doesn't use it.
+# TIGER layers. bg (block group) included for aggregation; uac20 omitted (tool doesn't use it).
 TIGER_LAYERS=(state county place cbsa csa tract bg)
 
-# refdata-load --fetch downloads missing files into the input dir and skips ones already
-# present; SKIP_FETCH=true loads straight from that cache without touching the network.
-# Files are kept under census-data/<dataset> so they persist between runs.
-FETCH=(--fetch)
-[ "$SKIP_FETCH" = "true" ] && FETCH=()
-
-# -------- 1. Reset --------
-psql "$TL_DATABASE_URL" -c "TRUNCATE TABLE tl_census_datasets RESTART IDENTITY CASCADE;"
-
-# -------- 2. Load ACS values --------
+# -------- 1. Load ACS values --------
 ACS_ARGS=()
 for tbl in "${ACS_TABLES[@]}"; do ACS_ARGS+=(--table "$tbl"); done
 tlv2 refdata-load \
   --dataset "acsdt5y${CENSUS_YEAR}" \
   --input-dir "census-data/acsdt5y${CENSUS_YEAR}" \
-  "${FETCH[@]}" "${ACS_ARGS[@]}"
+  --fetch "${ACS_ARGS[@]}"
 
-# -------- 3. Load TIGER geometries --------
+# -------- 2. Load TIGER geometries --------
 TIGER_ARGS=()
 for layer in "${TIGER_LAYERS[@]}"; do TIGER_ARGS+=(--table "$layer"); done
 tlv2 refdata-load \
   --dataset "tiger${CENSUS_YEAR}" \
   --input-dir "census-data/tiger${CENSUS_YEAR}" \
-  "${FETCH[@]}" "${TIGER_ARGS[@]}"
+  --fetch "${TIGER_ARGS[@]}"
 
-# -------- 4. Filter to WA (53), OR (41), CA (06) --------
-# ACS/TIGER geoids carry the state FIPS as US<ff>; keep only these three states.
-psql "$TL_DATABASE_URL" -c "DELETE FROM tl_census_values      WHERE geoid !~ '.*US(06|41|53).*';"
-psql "$TL_DATABASE_URL" -c "DELETE FROM tl_census_geographies WHERE geoid !~ '.*US(06|41|53).*';"
+# -------- 3. Load NTD annual data (all tables) --------
+tlv2 refdata-load \
+  --dataset "ntd-annual-${NTD_YEAR}" \
+  --input-dir "census-data/ntd-annual-${NTD_YEAR}" \
+  --fetch
 
-echo "Census data loaded into $TL_DATABASE_URL"
+# -------- 4. Scope to WA (53), OR (41), CA (06) --------
+# Census geoids carry the state FIPS as US<ff>; NTD (ntd:%) is national and kept whole.
+# CBSA/CSA geoids have no state FIPS and are dropped. Skipped when FULL_NATIONAL=true.
+if [ "${FULL_NATIONAL:-false}" != "true" ]; then
+  psql "$TL_DATABASE_URL" -c "DELETE FROM tl_census_values      WHERE geoid NOT LIKE 'ntd:%' AND geoid !~ '.*US(06|41|53).*';"
+  psql "$TL_DATABASE_URL" -c "DELETE FROM tl_census_geographies WHERE geoid !~ '.*US(06|41|53).*';"
+fi
+
+# -------- 5. Dump --------
+pg_dump -Fc -f calact_tlserver-census.dump -t 'tl_census_*' "$TL_DATABASE_URL"
+echo "Census + NTD dumped to calact_tlserver-census.dump"

--- a/testdata/gtfs/rebuild.sh
+++ b/testdata/gtfs/rebuild.sh
@@ -2,11 +2,9 @@
 set -ex -o pipefail
 rm -rf data tmp || true; mkdir -p data tmp
 
-# Migrate
-export PGDATABASE="calact_tlserver"
-export PGHOST="localhost"
-export TL_DATABASE_URL="postgres://localhost/calact_tlserver"
-dropdb --if-exists calact_tlserver; createdb calact_tlserver
+# Migrate. The target DB is created externally; everything here connects via
+# $TL_DATABASE_URL (defaulting to a local calact_tlserver).
+: "${TL_DATABASE_URL:=postgres://localhost/calact_tlserver}"; export TL_DATABASE_URL
 transitland dbmigrate up
 transitland dbmigrate-natural-earth
 
@@ -18,11 +16,12 @@ find ./data -name "*.zip" | parallel --lb transitland fetch --allow-local-fetch 
 transitland import --activate --storage="tmp" --activate --workers=8
 
 # Set feeds to public
-psql -c "update feed_states set public = true"
+psql "$TL_DATABASE_URL" -c "update feed_states set public = true"
 
-# Load US Census ACS + TIGER data (for the #302 aggregation demographic
-# columns). Idempotent; see rebuild-census.sh for details.
-./rebuild-census.sh
-
-# Dump
-pg_dump -Fc -f calact_tlserver.dump calact_tlserver
+# Dump the base (GTFS/etc.) tables by allowlist. -T 'tl_census_*' still excludes the
+# census/NTD tables and their sequences (which the 'tl_*' pattern would otherwise match),
+# keeping the base and census dumps disjoint. Census/NTD: run ./rebuild-census.sh.
+pg_dump -Fc -f calact_tlserver.dump \
+  -t 'gtfs_*' -t 'tl_*' -t 'feed_*' -t 'ne_*' -t 'schema_migrations' -t 'current_*' \
+  -T 'tl_census_*' \
+  "$TL_DATABASE_URL"

--- a/testdata/gtfs/rebuild.sh
+++ b/testdata/gtfs/rebuild.sh
@@ -8,7 +8,7 @@ export PGHOST="localhost"
 export TL_DATABASE_URL="postgres://localhost/calact_tlserver"
 dropdb --if-exists calact_tlserver; createdb calact_tlserver
 transitland dbmigrate up
-transitland dbmigrate natural-earth
+transitland dbmigrate-natural-earth
 
 # Fetch
 cat fvs.txt | parallel --colsep ' ' 'curl -H "apikey:$TRANSITLAND_API_KEY" -SLo data/{1}.zip https://api.transit.land/api/v2/rest/feed_versions/{2}/download'

--- a/testdata/gtfs/restore.sh
+++ b/testdata/gtfs/restore.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 set -ex -o pipefail
 
-# Drop and recreate database
-dropdb --if-exists calact_tlserver
-createdb calact_tlserver
+# Restore both snapshots into the $TL_DATABASE_URL database (defaulting to a local
+# calact_tlserver). No dropdb/createdb: pg_restore --clean --if-exists drops and recreates
+# each object in place, so this refreshes an existing DB and works against a managed one
+# you can't drop. Base tables first, then the census/NTD reference tables (disjoint sets
+# with no cross-FK, so order is not load-bearing).
+: "${TL_DATABASE_URL:=postgres://localhost/calact_tlserver}"
+export TL_DATABASE_URL
 
-# Restore snapshot
-pg_restore -d calact_tlserver calact_tlserver.dump || true
+pg_restore --clean --if-exists --no-owner -d "$TL_DATABASE_URL" calact_tlserver.dump || true
+pg_restore --clean --if-exists --no-owner -d "$TL_DATABASE_URL" calact_tlserver-census.dump || true
 
 # Run server
-export TL_DATABASE_URL=postgres://localhost/calact_tlserver
 TL_LOG=trace transitland server --max-radius=100_000_000  --loader-stop-time-batch-size=1000 --long-query=0

--- a/testdata/gtfs/restore.sh
+++ b/testdata/gtfs/restore.sh
@@ -9,8 +9,8 @@ set -ex -o pipefail
 : "${TL_DATABASE_URL:=postgres://localhost/calact_tlserver}"
 export TL_DATABASE_URL
 
-pg_restore --clean --if-exists --no-owner -d "$TL_DATABASE_URL" calact_tlserver.dump || true
-pg_restore --clean --if-exists --no-owner -d "$TL_DATABASE_URL" calact_tlserver-census.dump || true
+pg_restore --clean --if-exists --no-owner -d "$TL_DATABASE_URL" calact_tlserver.dump
+pg_restore --clean --if-exists --no-owner -d "$TL_DATABASE_URL" calact_tlserver-census.dump
 
 # Run server
 TL_LOG=trace transitland server --max-radius=100_000_000  --loader-stop-time-batch-size=1000 --long-query=0


### PR DESCRIPTION
## Summary
Refreshes the committed census reference data and adds Census block group ('bg') as a first-class aggregation layer alongside state/county/tract. Along the way it reworks the test-database rebuild scripts to load census/NTD data through the new `tlv2 refdata-load` loader (replacing the retired `geodata-us-census-*` commands), splits the base GTFS snapshot from the census/NTD snapshot into two disjoint dumps, and adds end-to-end tests that drive the full scenario pipeline and pin known census values.

### Block group support
- Added `bg` to `HIERARCHICAL_TIGER_LAYERS` so block groups roll up by FIPS prefix the same way tracts do (a bg geoid is its tract geoid plus one digit, nesting bg → tract → county → state). Place/cbsa/csa/uac still require server-side containment (#370) and remain excluded.
- Added a `bg` entry to `censusLayerLabels` ("Block Group" / "block groups") and surfaced it in the report's apportionment-support copy and tooltip.
- Updated the scenario CLI `--aggregate-layer` help and the `STOP_BUFFER_DEFAULT_LAYER` comment; tract stays the default for stability.
- Renamed the layer key from `blockgroup` to `bg` in `stop.test.ts` to match the loader's output.

### End-to-end scenario census tests
- New `src/scenario/scenario-census.test.ts` drives `runScenarioFetcher` through the census branch and asserts the same pinned values (tract 1400000US41051005101 = 3353, bg 1500000US410510051012 = 1843) from both ends: a hermetic suite backed by a scripted `MockGraphQLClient` (always runs) and an opt-in integration suite against a live transitland-server (`TEST_CENSUS=true`).
- The hermetic suite checks the full chain — raw `ScenarioData`, `applyScenarioResultFilter`, `stopGeoAggregateCsv`, and `apportionBuffer` (additive value scales by intersection ratio, non-additive median income → null).
- Added a `census-buffer.test.ts` case pinning the bg-under-tract/county/state rollup added to `HIERARCHICAL_TIGER_LAYERS`.

### Test DB rebuild rework
- `rebuild-census.sh` now loads ACS, TIGER (including `bg`), and NTD via `tlv2 refdata-load --fetch`, scopes to WA/OR/CA (NTD kept whole; `FULL_NATIONAL=true` to skip scoping), and dumps `tl_census_*` to its own `calact_tlserver-census.dump`. Replaces the old FTP `wget` + `geodata-us-census-acs-table-load` / `geodata-us-census-tiger-load` flow.
- `rebuild.sh` and `rebuild-census.sh` are now independent: the base script dumps everything except `tl_census_*` by allowlist, the census script dumps only `tl_census_*`, keeping the two snapshots disjoint.
- All three scripts drop the hard-coded `dropdb`/`createdb` and `PG*` env vars and work purely off `$TL_DATABASE_URL` (defaulting to a local `calact_tlserver`); `restore.sh` uses `pg_restore --clean --if-exists --no-owner` to refresh in place, so it works against a managed DB it can't drop.
- Updated the `dbmigrate natural-earth` invocation to the current `dbmigrate-natural-earth` subcommand spelling.

### Dump handling
- Removed the committed `calact_tlserver.dump` LFS pointer and added `*.dump` to `.gitignore` — dumps are regenerated locally for now and not committed (LFS bloat). To be revisited once dump-based fixtures are wired into CI.

## Test plan
- Build the test DB locally: run `testdata/gtfs/rebuild.sh` then `testdata/gtfs/rebuild-census.sh` against a scratch `$TL_DATABASE_URL`; confirm two disjoint dumps are produced and the census dump contains only `tl_census_*` tables.
- `testdata/gtfs/restore.sh` into a fresh and into an already-populated DB; confirm both restore cleanly and the server starts.
- Run the hermetic scenario census suite (default `pnpm test`) and confirm the tract and bg cases pass.
- With a server on the rebuilt DB, run `TEST_CENSUS=true TRANSITLAND_API_BASE=http://localhost:8080 pnpm test` and confirm the integration suite fetches the pinned tract/bg values.
- In the UI, aggregate by Block Group and confirm the layer label, rollup values, and the apportionment-support warning copy all reflect bg.

closes https://github.com/interline-io/calact-network-analysis-tool/issues/374