### PR TITLE
Use aggregateLayer for default stopBufferLayer

### DIFF
--- a/app/composables/useScenarioInputs.ts
+++ b/app/composables/useScenarioInputs.ts
@@ -136,10 +136,17 @@ export function useScenarioInputs (): ScenarioInputs {
     }
   })
 
+  // Defaults to the aggregation layer (set on the Query page) when not explicitly
+  // chosen, so the Filter selector's buffer layer starts out matching it. The setter
+  // elides against that same effective default so picking the default keeps tracking
+  // aggregateLayer rather than pinning a stale value into the URL.
   const stopBufferLayer = computed<string>({
-    get: () => route.query.stopBufferLayer?.toString() || STOP_BUFFER_DEFAULT_LAYER,
+    get: () => route.query.stopBufferLayer?.toString()
+      || route.query.aggregateLayer?.toString()
+      || STOP_BUFFER_DEFAULT_LAYER,
     set: (v) => {
-      setQuery({ stopBufferLayer: v === STOP_BUFFER_DEFAULT_LAYER ? undefined : v })
+      const fallback = route.query.aggregateLayer?.toString() || STOP_BUFFER_DEFAULT_LAYER
+      setQuery({ stopBufferLayer: v === fallback ? undefined : v })
     }
   })
 


### PR DESCRIPTION
## Summary
Seeds the stop-buffer layer from the aggregation layer. The stop statistical-radius apportionment layer (`stopBufferLayer`, chosen in the Filter selector) now defaults to whatever census geography layer was selected for aggregation (`aggregateLayer`, set on the Query page) when the user hasn't explicitly picked a buffer layer. Previously it always defaulted to `tract` independently. Since both still fall back to `tract`, nothing changes for users who never touch either control.

### Behavior
- `stopBufferLayer` resolution order is now explicit `?stopBufferLayer` query param, then `?aggregateLayer`, then `STOP_BUFFER_DEFAULT_LAYER` (`tract`).
- Setting the aggregation layer to e.g. County on the Query page makes the Filter's buffer-layer selector default to County instead of Tract.
- While `stopBufferLayer` is unset it tracks `aggregateLayer` — changing the aggregation layer later moves the buffer-layer default with it, until the user explicitly picks a different buffer layer, which pins it.

### Setter elision
- The default-elision in the setter now compares against the current effective default (`aggregateLayer` if present, else `tract`) rather than always against `tract`. Without this, picking the finer `tract` while `aggregateLayer=county` would drop the param from the URL and the getter would resolve back to `county`, silently overriding the user's choice. Now picking the effective default keeps tracking `aggregateLayer`, and any other pick is persisted to the URL.

## Test plan
- Load a scenario without setting either layer; confirm the buffer layer defaults to Tract as before.
- On the Query page set the aggregation layer to County; open the Filter selector and confirm the buffer layer now defaults to County.
- With `aggregateLayer=county`, explicitly select Tract as the buffer layer; confirm it sticks (URL gets `stopBufferLayer=tract`) and does not snap back to County.
- With the buffer layer left at the default, change the aggregation layer and confirm the buffer-layer default follows; then explicitly pick a buffer layer and confirm it no longer tracks.
