### PR TITLE
Dedupe loop terminal departures in headway calculation (#368)

### DIFF
--- a/app/components/cal/route-timetable.vue
+++ b/app/components/cal/route-timetable.vue
@@ -529,6 +529,12 @@
                 >
                   <cat-icon icon="check" size="small" class="has-text-primary ml-1" />
                 </cat-tooltip>
+                <cat-tooltip
+                  v-if="row.departureCount > row.tripCount"
+                  :text="`${row.departureCount} departures here come from ${row.tripCount} trips, so some trips serve this stop more than once (for example a loop revisiting a point). These repeat visits can be useful to riders, but they are excluded from the route frequency calculation, where they would otherwise look like very short headways.`"
+                >
+                  <cat-icon icon="repeat" size="small" class="has-text-grey ml-1" />
+                </cat-tooltip>
               </td>
             </tr>
           </tbody>
@@ -942,6 +948,9 @@ interface StopDetailRow {
   stopId: number
   directionId: number
   departureCount: number
+  // Distinct trips serving the stop. When departureCount exceeds this, some
+  // trips visit the stop more than once (e.g. a loop revisiting a point).
+  tripCount: number
   isRepresentativeStop: boolean
 }
 
@@ -965,6 +974,7 @@ const stopDetailDateGroups = computed<StopDetailDateGroup[]>(() => {
           stopId: sid,
           directionId: dir,
           departureCount: deps.length,
+          tripCount: oneDeparturePerTrip(deps).length,
           isRepresentativeStop: sid === rep.stopId && dir === dominant,
         })
       }
@@ -990,6 +1000,7 @@ const stopDetailsCsvData = computed(() => {
       stop_id: stopIdStr(row.stopId),
       stop_name: stopName(row.stopId),
       departure_count: row.departureCount,
+      trip_count: row.tripCount,
       is_representative_stop: row.isRepresentativeStop,
     })),
   )

--- a/app/components/cal/route-timetable.vue
+++ b/app/components/cal/route-timetable.vue
@@ -240,6 +240,16 @@
       </p>
 
       <div v-else>
+        <cat-msg
+          v-if="repeatRepStopVisits > 0"
+          variant="warning"
+          title="Repeat visits excluded"
+          class="mb-4"
+        >
+          <p>
+            {{ repeatRepStopVisits }} departures at the representative stop are repeat visits by the same trip, which happens when the stop is both the first and last stop of a loop. Only each trip's first departure is counted toward frequency, so the loop turnaround is not mistaken for a short headway (issue #368).
+          </p>
+        </cat-msg>
         <cat-msg variant="info" title="Summary" class="mb-4">
           <p class="mb-2">
             Frequency is calculated from gaps between consecutive departures at the representative stop, using only the dominant direction. Only service dates matching the selected weekdays contribute to the statistics; out-of-scope dates are still listed below but flagged and excluded. Gaps under {{ MIN_HEADWAY_SECONDS }} seconds are considered noise and excluded (shown struck through below).
@@ -543,6 +553,7 @@ import {
   computeHeadwaysPerDay,
   calculateRouteTripStats,
   scopeDatesToWeekdays,
+  oneDeparturePerTrip,
   summarizeGaps,
   WEEKDAY_BY_GETDAY,
   MIN_HEADWAY_SECONDS,
@@ -760,7 +771,7 @@ const frequencyRows = computed<FrequencyRow[]>(() => {
     if (rep.stopId === undefined) {
       continue
     }
-    const inWindow = rep.departures
+    const inWindow = oneDeparturePerTrip(rep.departures)
       .filter(st => st.departureTime >= startTimeSec.value && st.departureTime <= endTimeSec.value)
       .sort((a, b) => a.departureTime - b.departureTime)
     // Shared helper returns one Headway<T> per consecutive pair; entry `i` is
@@ -782,6 +793,24 @@ const frequencyRows = computed<FrequencyRow[]>(() => {
     }
   }
   return out
+})
+
+// Count representative-stop departures that are repeat visits by the same trip
+// (e.g. a loop terminal that is both first and last stop). These are excluded
+// from the frequency calc by oneDeparturePerTrip; surfaced as a note so the
+// dedup is visible rather than silent (issue #368).
+const repeatRepStopVisits = computed(() => {
+  let removed = 0
+  const dir = dominantDirection.value
+  for (const d of scopedDateRange.value) {
+    const dateStr = format(d, 'yyyy-MM-dd')
+    const rep = pickRepresentativeStop(routeIndex.value, props.route.id, dir, dateStr)
+    const inWindow = rep.departures.filter(
+      st => st.departureTime >= startTimeSec.value && st.departureTime <= endTimeSec.value,
+    )
+    removed += inWindow.length - oneDeparturePerTrip(inWindow).length
+  }
+  return removed
 })
 
 interface FrequencyDateGroup {

--- a/app/components/cal/route-timetable.vue
+++ b/app/components/cal/route-timetable.vue
@@ -247,7 +247,7 @@
           class="mb-4"
         >
           <p>
-            {{ repeatRepStopVisits }} departures at the representative stop are repeat visits by the same trip, which happens when the stop is both the first and last stop of a loop. Only each trip's first departure is counted toward frequency, so the loop turnaround is not mistaken for a short headway (issue #368).
+            {{ repeatRepStopVisits }} departures at the representative stop are repeat visits by the same trip, which happens when the stop is both the first and last stop of a loop. Only each trip's first departure is counted toward frequency, so the loop turnaround is not mistaken for a short headway.
           </p>
         </cat-msg>
         <cat-msg variant="info" title="Summary" class="mb-4">

--- a/app/components/cal/route-timetable.vue
+++ b/app/components/cal/route-timetable.vue
@@ -560,11 +560,13 @@ import {
   calculateRouteTripStats,
   scopeDatesToWeekdays,
   oneDeparturePerTrip,
+  distinctTripCount,
   summarizeGaps,
   WEEKDAY_BY_GETDAY,
   MIN_HEADWAY_SECONDS,
 } from '~~/src/scenario/route-headway'
 import { RouteDepartureIndex } from '~~/src/tl/departure-cache'
+import type { StopTimeCacheItem } from '~~/src/tl/departure-cache'
 
 type Tab = 'frequency' | 'trips' | 'stops'
 
@@ -761,6 +763,48 @@ const hasAnyRows = computed(() => unrolledSections.value.length > 0)
 
 const activeTab = ref<Tab>(props.initialTab ?? 'trips')
 
+// Per-date frequency source: the dominant-direction representative stop and its
+// in-window departures, deduped to one boarding departure per trip (issue #368).
+// Both the Frequency view rows and the repeat-visit warning derive from this so
+// they share one dedup-then-filter pass and can never disagree.
+interface FrequencyDateData {
+  serviceDate: string
+  inScope: boolean
+  repStopId: number
+  // One boarding departure per trip, in the time window, sorted ascending —
+  // the exact departures that feed average/fastest/slowest frequency.
+  inWindow: StopTimeCacheItem[]
+  // All representative-stop departures in the same window, before dedup. The
+  // difference (rawInWindowCount - inWindow.length) is the repeat-visit count.
+  rawInWindowCount: number
+}
+
+const frequencyByDate = computed<FrequencyDateData[]>(() => {
+  const out: FrequencyDateData[] = []
+  const dir = dominantDirection.value
+  for (const d of props.selectedDateRange) {
+    const dateStr = format(d, 'yyyy-MM-dd')
+    const rep = pickRepresentativeStop(routeIndex.value, props.route.id, dir, dateStr)
+    if (rep.stopId === undefined) {
+      continue
+    }
+    const inWindow = oneDeparturePerTrip(rep.departures)
+      .filter(st => st.departureTime >= startTimeSec.value && st.departureTime <= endTimeSec.value)
+      .sort((a, b) => a.departureTime - b.departureTime)
+    const rawInWindowCount = rep.departures.filter(
+      st => st.departureTime >= startTimeSec.value && st.departureTime <= endTimeSec.value,
+    ).length
+    out.push({
+      serviceDate: dateStr,
+      inScope: isDateInScope(dateStr),
+      repStopId: rep.stopId,
+      inWindow,
+      rawInWindowCount,
+    })
+  }
+  return out
+})
+
 // Frequency Calculation view: every dominant-direction representative-stop
 // departure across all selected service days, in the time-of-day window.
 // These are the exact numbers that feed average/fastest/slowest frequency.
@@ -770,54 +814,39 @@ const activeTab = ref<Tab>(props.initialTab ?? 'trips')
 const frequencyRows = computed<FrequencyRow[]>(() => {
   const out: FrequencyRow[] = []
   const dir = dominantDirection.value
-  for (const d of props.selectedDateRange) {
-    const dateStr = format(d, 'yyyy-MM-dd')
-    const dateInScope = isDateInScope(dateStr)
-    const rep = pickRepresentativeStop(routeIndex.value, props.route.id, dir, dateStr)
-    if (rep.stopId === undefined) {
-      continue
-    }
-    const inWindow = oneDeparturePerTrip(rep.departures)
-      .filter(st => st.departureTime >= startTimeSec.value && st.departureTime <= endTimeSec.value)
-      .sort((a, b) => a.departureTime - b.departureTime)
+  for (const day of frequencyByDate.value) {
     // Shared helper returns one Headway<T> per consecutive pair; entry `i` is
     // the pair (inWindow[i], inWindow[i + 1]). Length is inWindow.length - 1.
-    const headways = computeHeadwaysPerDay([inWindow], st => st.departureTime)
-    for (let i = 0; i < inWindow.length; i++) {
-      const st = inWindow[i]!
+    const headways = computeHeadwaysPerDay([day.inWindow], st => st.departureTime)
+    for (let i = 0; i < day.inWindow.length; i++) {
+      const st = day.inWindow[i]!
       const h = headways[i]
       out.push({
-        serviceDate: dateStr,
+        serviceDate: day.serviceDate,
         tripId: st.tripId,
         directionId: dir,
-        stopId: rep.stopId,
+        stopId: day.repStopId,
         departureTime: st.departureTime,
         gapToNext: h?.gap,
         gapIsNoise: h?.isNoise ?? false,
-        inScope: dateInScope,
+        inScope: day.inScope,
       })
     }
   }
   return out
 })
 
-// Count representative-stop departures that are repeat visits by the same trip
-// (e.g. a loop terminal that is both first and last stop). These are excluded
-// from the frequency calc by oneDeparturePerTrip; surfaced as a note so the
-// dedup is visible rather than silent (issue #368).
-const repeatRepStopVisits = computed(() => {
-  let removed = 0
-  const dir = dominantDirection.value
-  for (const d of scopedDateRange.value) {
-    const dateStr = format(d, 'yyyy-MM-dd')
-    const rep = pickRepresentativeStop(routeIndex.value, props.route.id, dir, dateStr)
-    const inWindow = rep.departures.filter(
-      st => st.departureTime >= startTimeSec.value && st.departureTime <= endTimeSec.value,
-    )
-    removed += inWindow.length - oneDeparturePerTrip(inWindow).length
-  }
-  return removed
-})
+// Count representative-stop departures excluded as repeat visits by the same
+// trip (e.g. a loop terminal that is both first and last stop). Derived from
+// the same dedup-then-filter pass as frequencyRows so the warning count can
+// never disagree with the table (issue #368). Out-of-scope dates do not feed
+// the statistics, so their repeats are not counted.
+const repeatRepStopVisits = computed(() =>
+  frequencyByDate.value.reduce(
+    (sum, day) => sum + (day.inScope ? day.rawInWindowCount - day.inWindow.length : 0),
+    0,
+  ),
+)
 
 interface FrequencyDateGroup {
   serviceDate: string
@@ -974,7 +1003,7 @@ const stopDetailDateGroups = computed<StopDetailDateGroup[]>(() => {
           stopId: sid,
           directionId: dir,
           departureCount: deps.length,
-          tripCount: oneDeparturePerTrip(deps).length,
+          tripCount: distinctTripCount(deps),
           isRepresentativeStop: sid === rep.stopId && dir === dominant,
         })
       }

--- a/src/scenario/phases/departures.ts
+++ b/src/scenario/phases/departures.ts
@@ -23,7 +23,8 @@ export type StopDepartureTuple = readonly [
   departure_time: number, // seconds since midnight
   trip_id: number,
   trip_direction_id: number,
-  trip_route_id: number
+  trip_route_id: number,
+  pickup_type: number | null // GTFS pickup_type; null when the feed omits it
 ]
 
 // Helper functions for working with the tuple
@@ -35,7 +36,8 @@ export const StopDepartureTuple = {
     trip_id: number,
     trip_direction_id: number,
     trip_route_id: number,
-  ): StopDepartureTuple => [stop_id, departure_date, departure_time, trip_id, trip_direction_id, trip_route_id],
+    pickup_type: number | null,
+  ): StopDepartureTuple => [stop_id, departure_date, departure_time, trip_id, trip_direction_id, trip_route_id, pickup_type],
   fromStopTime: (stopId: number, departureDate: string, stopDeparture: StopTime) => StopDepartureTuple.create(
     stopId,
     departureDate,
@@ -43,6 +45,7 @@ export const StopDepartureTuple = {
     stopDeparture.trip.id,
     stopDeparture.trip.direction_id,
     stopDeparture.trip.route.id,
+    stopDeparture.pickup_type ?? null,
   ),
   stopId: (tuple: StopDepartureTuple) => tuple[0],
   departureDate: (tuple: StopDepartureTuple) => tuple[1],
@@ -50,6 +53,7 @@ export const StopDepartureTuple = {
   tripId: (tuple: StopDepartureTuple) => tuple[3],
   tripDirectionId: (tuple: StopDepartureTuple) => tuple[4],
   tripRouteId: (tuple: StopDepartureTuple) => tuple[5],
+  pickupType: (tuple: StopDepartureTuple) => tuple[6],
 }
 
 export class StopDepartureQueryVars {

--- a/src/scenario/route-headway.test.ts
+++ b/src/scenario/route-headway.test.ts
@@ -8,6 +8,7 @@ import {
   pickDominantDirection,
   scopeDatesToWeekdays,
   oneDeparturePerTrip,
+  distinctTripCount,
   summarizeGaps,
   MIN_HEADWAY_SECONDS,
   type RouteDepartures,
@@ -869,6 +870,22 @@ describe('oneDeparturePerTrip', () => {
 
   it('returns an empty array for empty input', () => {
     expect(oneDeparturePerTrip([])).toEqual([])
+  })
+})
+
+describe('distinctTripCount', () => {
+  const item = (departure: string, tripId: number) =>
+    new StopTimeCacheItem(hms(departure), tripId, 0, 100)
+
+  it('counts distinct trips, matching oneDeparturePerTrip length', () => {
+    // Trip 1 visits twice (loop terminal), trips 2 and 3 once: 3 distinct trips.
+    const deps = [item('08:00:00', 1), item('09:50:00', 1), item('10:00:00', 2), item('12:00:00', 3)]
+    expect(distinctTripCount(deps)).toBe(3)
+    expect(distinctTripCount(deps)).toBe(oneDeparturePerTrip(deps).length)
+  })
+
+  it('returns 0 for empty input', () => {
+    expect(distinctTripCount([])).toBe(0)
   })
 })
 

--- a/src/scenario/route-headway.test.ts
+++ b/src/scenario/route-headway.test.ts
@@ -7,11 +7,12 @@ import {
   computeHeadwaysPerDay,
   pickDominantDirection,
   scopeDatesToWeekdays,
+  oneDeparturePerTrip,
   summarizeGaps,
   MIN_HEADWAY_SECONDS,
   type RouteDepartures,
 } from './route-headway'
-import { StopDepartureCache, RouteDepartureIndex } from '../tl/departure-cache'
+import { StopDepartureCache, RouteDepartureIndex, StopTimeCacheItem } from '../tl/departure-cache'
 import type { Route } from '../tl/route'
 import type { StopTime } from '../tl/departure'
 import type { Weekday } from '../core'
@@ -830,5 +831,69 @@ describe('summarizeGaps', () => {
     const gaps = [40, 10, 30, 10]
     summarizeGaps(gaps)
     expect(gaps).toEqual([40, 10, 30, 10])
+  })
+})
+
+describe('oneDeparturePerTrip', () => {
+  const item = (departure: string, tripId: number) => new StopTimeCacheItem(hms(departure), tripId, 0, 100)
+
+  it('keeps each trip earliest departure and drops repeat visits', () => {
+    // Trip 1 visits twice (loop start 08:00 + return 09:50); trips 2 and 3 once.
+    const deps = [item('08:00:00', 1), item('09:50:00', 1), item('10:00:00', 2), item('12:00:00', 3)]
+    const result = oneDeparturePerTrip(deps).map(d => d.departureTime).sort((a, b) => a - b)
+    expect(result).toEqual([hms('08:00:00'), hms('10:00:00'), hms('12:00:00')])
+  })
+
+  it('is a no-op when every trip visits the stop once', () => {
+    const deps = [item('08:00:00', 1), item('09:00:00', 2)]
+    expect(oneDeparturePerTrip(deps)).toHaveLength(2)
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(oneDeparturePerTrip([])).toEqual([])
+  })
+})
+
+describe('routeHeadways — loop representative-stop dedup (#368)', () => {
+  // A loop whose representative stop (stop 1) is the terminal: every trip starts
+  // there (~08:00) and returns ~1h50m later. Without dedup, the sorted terminal
+  // departures interleave start/return and the gap between one trip's return and
+  // the next trip's start becomes a spurious ~10-minute "headway".
+  function buildLoopIndex (): RouteDepartureIndex {
+    const dateStr = '2024-01-15'
+    const sdCache = new StopDepartureCache()
+    const trips: Array<[string, string, string]> = [
+      // [start at terminal, mid stop, return to terminal]
+      ['08:00:00', '08:30:00', '09:50:00'],
+      ['10:00:00', '10:30:00', '11:50:00'],
+      ['12:00:00', '12:30:00', '13:50:00'],
+    ]
+    trips.forEach(([start, mid, ret], i) => {
+      addTripToCache(sdCache, dateStr, makeTrip(100, String(2000 + i), 0, [
+        { stopId: 1, departure: start }, // loop terminal (first visit)
+        { stopId: 2, departure: mid },
+        { stopId: 1, departure: ret }, // loop terminal (return visit)
+      ]))
+    })
+    return RouteDepartureIndex.fromCache(sdCache)
+  }
+
+  it('counts one departure per trip at the loop terminal, yielding the true headway', () => {
+    const route = makeRoute(100)
+    const date = makeLocalDate('2024-01-15')
+    const result = routeHeadways(route, [date], '00:00:00', '24:00:00', buildLoopIndex())
+    // Stop 1 is the rep stop (6 raw departures), deduped to each trip's start.
+    expect(result.dir0[0]).toEqual([hms('08:00:00'), hms('10:00:00'), hms('12:00:00')])
+  })
+
+  it('reports the true ~2h headway, not the spurious loop-turnaround gap', () => {
+    const route = makeRoute(100)
+    const date = makeLocalDate('2024-01-15')
+    const result = routeHeadways(route, [date], '00:00:00', '24:00:00', buildLoopIndex())
+    const stats = calculateHeadwayStats(result.dir0)
+    // Two 2-hour gaps; the ~10-minute turnaround gaps are gone.
+    expect(stats?.fastest).toBe(hms('02:00:00'))
+    expect(stats?.slowest).toBe(hms('02:00:00'))
+    expect(stats?.average).toBe(hms('02:00:00'))
   })
 })

--- a/src/scenario/route-headway.test.ts
+++ b/src/scenario/route-headway.test.ts
@@ -835,13 +835,31 @@ describe('summarizeGaps', () => {
 })
 
 describe('oneDeparturePerTrip', () => {
-  const item = (departure: string, tripId: number) => new StopTimeCacheItem(hms(departure), tripId, 0, 100)
+  const item = (departure: string, tripId: number, pickupType: number | null = null) =>
+    new StopTimeCacheItem(hms(departure), tripId, 0, 100, pickupType)
 
   it('keeps each trip earliest departure and drops repeat visits', () => {
     // Trip 1 visits twice (loop start 08:00 + return 09:50); trips 2 and 3 once.
     const deps = [item('08:00:00', 1), item('09:50:00', 1), item('10:00:00', 2), item('12:00:00', 3)]
     const result = oneDeparturePerTrip(deps).map(d => d.departureTime).sort((a, b) => a - b)
     expect(result).toEqual([hms('08:00:00'), hms('10:00:00'), hms('12:00:00')])
+  })
+
+  it('prefers a boardable visit over an earlier drop-off-only visit', () => {
+    // Trip arrives drop-off-only (pickup_type 1) at 08:00, then boards at 08:10.
+    // Earliest alone would pick 08:00; pickup_type picks the boardable 08:10.
+    const deps = [item('08:00:00', 1, 1), item('08:10:00', 1, 0)]
+    expect(oneDeparturePerTrip(deps).map(d => d.departureTime)).toEqual([hms('08:10:00')])
+  })
+
+  it('excludes a loop return (pickup_type 1) in favor of the boardable start', () => {
+    const deps = [item('08:00:00', 1, 0), item('09:50:00', 1, 1)]
+    expect(oneDeparturePerTrip(deps).map(d => d.departureTime)).toEqual([hms('08:00:00')])
+  })
+
+  it('falls back to the earliest visit when a trip has only drop-off visits', () => {
+    const deps = [item('09:50:00', 1, 1), item('08:00:00', 1, 1)]
+    expect(oneDeparturePerTrip(deps).map(d => d.departureTime)).toEqual([hms('08:00:00')])
   })
 
   it('is a no-op when every trip visits the stop once', () => {

--- a/src/scenario/route-headway.ts
+++ b/src/scenario/route-headway.ts
@@ -99,6 +99,12 @@ export function routeHeadways (
  * stop — the in-bbox stop with the most departures — and return both its stopId
  * and its stop_times. Returns stopId = undefined when the bucket is empty.
  *
+ * The returned `departures` are RAW: a loop terminal lists each trip twice
+ * (outbound start plus inbound return). Headway/frequency consumers must
+ * collapse them with `oneDeparturePerTrip` first (otherwise the loop turnaround
+ * looks like a short headway — issue #368); callers that genuinely want the
+ * raw per-visit count (e.g. Stop Details) use them as-is.
+ *
  * Tie-breaking: when two stops have the same departure count, the lower
  * numeric stop ID wins. Deterministic regardless of Map insertion order.
  */
@@ -158,6 +164,22 @@ export function oneDeparturePerTrip (departures: StopTimeCacheItem[]): StopTimeC
     chosenByTrip.set(st.tripId, cur === undefined ? st : preferDeparture(cur, st))
   }
   return [...chosenByTrip.values()]
+}
+
+/**
+ * Count the distinct trips among a stop's departures. Equivalent to
+ * `oneDeparturePerTrip(departures).length` but without building the deduped
+ * array or running the boardability tie-break — used where only the count is
+ * needed (e.g. flagging stops some trip visits more than once). When this is
+ * less than the raw departure count, a trip serves the stop more than once
+ * (e.g. a loop revisiting a point).
+ */
+export function distinctTripCount (departures: StopTimeCacheItem[]): number {
+  const trips = new Set<number>()
+  for (const st of departures) {
+    trips.add(st.tripId)
+  }
+  return trips.size
 }
 
 /**

--- a/src/scenario/route-headway.ts
+++ b/src/scenario/route-headway.ts
@@ -121,23 +121,43 @@ export function pickRepresentativeStop (
 }
 
 /**
- * Reduce a stop's departures to one per trip: the trip's earliest departure at
+ * Pick the visit that better represents a trip's boarding departure at a stop.
+ * A visit with `pickup_type === 1` ("no pickup available") is drop-off only,
+ * e.g. a loop's return to its terminal, so a boardable visit is always
+ * preferred. Among visits of equal boardability the earlier one wins. When
+ * `pickup_type` is null (the feed omits it) every visit is boardable, so this
+ * reduces to "earliest wins".
+ */
+function preferDeparture (a: StopTimeCacheItem, b: StopTimeCacheItem): StopTimeCacheItem {
+  const aBoardable = a.pickupType !== 1
+  const bBoardable = b.pickupType !== 1
+  if (aBoardable !== bBoardable) {
+    return aBoardable ? a : b
+  }
+  return b.departureTime < a.departureTime ? b : a
+}
+
+/**
+ * Reduce a stop's departures to one per trip: the trip's boarding departure at
  * that stop. A loop route whose representative stop is the start-and-end
  * terminal lists each trip twice (outbound start plus inbound return); counting
  * both inflates the departure list and injects spurious short gaps into the
- * headway calculation (issue #368). Keeping each trip's earliest visit yields
- * its actual scheduled departure, so consecutive-departure gaps reflect the true
- * headway. A no-op for normal routes, where each trip visits a stop once.
+ * headway calculation (issue #368). Keeping one departure per trip yields the
+ * true headway between consecutive trips.
+ *
+ * When `pickup_type` is available the boardable visit is chosen (so a drop-off
+ * return is excluded even if it sorts earlier); otherwise the earliest visit is
+ * used. A trip with only drop-off visits still contributes its earliest one, so
+ * no trip is dropped. A no-op for normal routes, where each trip visits a stop
+ * once.
  */
 export function oneDeparturePerTrip (departures: StopTimeCacheItem[]): StopTimeCacheItem[] {
-  const earliestByTrip = new Map<number, StopTimeCacheItem>()
+  const chosenByTrip = new Map<number, StopTimeCacheItem>()
   for (const st of departures) {
-    const cur = earliestByTrip.get(st.tripId)
-    if (cur === undefined || st.departureTime < cur.departureTime) {
-      earliestByTrip.set(st.tripId, st)
-    }
+    const cur = chosenByTrip.get(st.tripId)
+    chosenByTrip.set(st.tripId, cur === undefined ? st : preferDeparture(cur, st))
   }
-  return [...earliestByTrip.values()]
+  return [...chosenByTrip.values()]
 }
 
 /**

--- a/src/scenario/route-headway.ts
+++ b/src/scenario/route-headway.ts
@@ -78,8 +78,10 @@ export function routeHeadways (
       const formattedDate = format(d, 'yyyy-MM-dd')
       const rep = pickRepresentativeStop(routeIndex, route.id, dir, formattedDate)
 
-      // Filter by time window (departureTime is already in seconds) and sort.
-      const stSecs = rep.departures
+      // Collapse repeat visits by the same trip (loop terminals) to one
+      // departure per trip before measuring headways (issue #368), then filter
+      // by time window (departureTime is already in seconds) and sort.
+      const stSecs = oneDeparturePerTrip(rep.departures)
         .map(st => st.departureTime)
         .filter(depTime => depTime >= 0 && depTime >= startTime && depTime <= endTime)
       stSecs.sort((a, b) => a - b)
@@ -116,6 +118,26 @@ export function pickRepresentativeStop (
     }
   }
   return { stopId, departures }
+}
+
+/**
+ * Reduce a stop's departures to one per trip: the trip's earliest departure at
+ * that stop. A loop route whose representative stop is the start-and-end
+ * terminal lists each trip twice (outbound start plus inbound return); counting
+ * both inflates the departure list and injects spurious short gaps into the
+ * headway calculation (issue #368). Keeping each trip's earliest visit yields
+ * its actual scheduled departure, so consecutive-departure gaps reflect the true
+ * headway. A no-op for normal routes, where each trip visits a stop once.
+ */
+export function oneDeparturePerTrip (departures: StopTimeCacheItem[]): StopTimeCacheItem[] {
+  const earliestByTrip = new Map<number, StopTimeCacheItem>()
+  for (const st of departures) {
+    const cur = earliestByTrip.get(st.tripId)
+    if (cur === undefined || st.departureTime < cur.departureTime) {
+      earliestByTrip.set(st.tripId, st)
+    }
+  }
+  return [...earliestByTrip.values()]
 }
 
 /**

--- a/src/scenario/scenario.ts
+++ b/src/scenario/scenario.ts
@@ -574,6 +574,7 @@ export class ScenarioDataReceiver {
             StopDepartureTuple.tripId(event),
             StopDepartureTuple.tripDirectionId(event),
             StopDepartureTuple.tripRouteId(event),
+            StopDepartureTuple.pickupType(event),
           )
         }
       }

--- a/src/tl/departure-cache.ts
+++ b/src/tl/departure-cache.ts
@@ -8,13 +8,16 @@ import type { StopTime } from './departure'
  * - tripId: internal numeric trip ID (for deduplication)
  * - directionId: 0 or 1
  * - routeId: internal numeric route ID
+ * - pickupType: GTFS pickup_type; null when the feed omits it. 1 = no pickup
+ *   available (drop-off only), e.g. a loop's return to its terminal.
  */
 export class StopTimeCacheItem {
   constructor (
     public readonly departureTime: number,
     public readonly tripId: number,
     public readonly directionId: number,
-    public readonly routeId: number
+    public readonly routeId: number,
+    public readonly pickupType: number | null = null
   ) {}
 
   /**
@@ -25,7 +28,8 @@ export class StopTimeCacheItem {
       parseHMS(st.departure_time),
       st.trip.id,
       st.trip.direction_id,
-      st.trip.route.id
+      st.trip.route.id,
+      st.pickup_type ?? null
     )
   }
 }
@@ -62,10 +66,10 @@ export class StopDepartureCache {
    * Add a single stop time directly from wire format values (no intermediate object).
    * This is more efficient when receiving streaming data.
    */
-  addFromWire (stopId: number, date: string, departureTime: number, tripId: number, directionId: number, routeId: number) {
+  addFromWire (stopId: number, date: string, departureTime: number, tripId: number, directionId: number, routeId: number, pickupType: number | null = null) {
     const a = this.cache.get(stopId) || new Map()
     const b = a.get(date) || []
-    b.push(new StopTimeCacheItem(departureTime, tripId, directionId, routeId))
+    b.push(new StopTimeCacheItem(departureTime, tripId, directionId, routeId, pickupType))
     a.set(date, b)
     this.cache.set(stopId, a)
   }

--- a/src/tl/departure.ts
+++ b/src/tl/departure.ts
@@ -7,6 +7,7 @@ import { gql } from 'graphql-tag'
 export const stopDepartureQuery = gql`
 fragment departure on StopTime {
   departure_time
+  pickup_type
   trip {
     id
     direction_id
@@ -63,6 +64,7 @@ query (
 export const stopTimeQuery = gql`
 fragment departure on StopTime {
   departure_time
+  pickup_type
   trip {
     id
     direction_id
@@ -118,6 +120,9 @@ query (
 
 export interface StopTime {
   departure_time: string
+  // GTFS stop_times.pickup_type; null when the feed omits it. 1 = no pickup
+  // available (drop-off only), e.g. a loop's return to its terminal.
+  pickup_type?: number | null
   trip: {
     id: number
     direction_id: number


### PR DESCRIPTION
## Summary

Frequency for loop routes whose representative (busiest) stop is the start-and-end terminal was badly wrong. The City of Sandy "Clackamas Town Center 2.0" loop reported a fastest frequency of ~10 minutes and an average of ~1h12m, when the route actually runs roughly every 2 hours. This is the loop fastest-frequency case from #368.

## Root cause

The representative stop is chosen as the stop with the most departures. On a loop, every trip touches the terminal twice, once departing at the start and once returning at the end (for example, trip 1017304 at 10:20 and again at 12:10). So eight trips produced sixteen departures at the representative stop. Sorted, the start and return visits interleave, and the gap between one trip's return and the next trip's start becomes a spurious short headway (the 10-minute fastest). The true ~2-hour headway between consecutive departures was never measured.

This was confirmed in the Route Timetable debug modal, where the Frequency tab showed each `trip_id` appearing twice at the representative stop.

## Fix

Add `oneDeparturePerTrip`, which reduces a stop's departures to one per trip, and apply it in `routeHeadways` before measuring gaps. This is a no-op for normal routes, where each trip visits a stop once, so only loop and repeat-visit routes change. For the Sandy loop this yields eight departures per day at the terminal (05:45, 07:50, 10:20, and so on) with ~2-hour gaps, which matches the published schedule.

The same dedup is applied in the Route Timetable modal's Frequency view so the debug view stays consistent with the report, and the modal shows a warning naming the count of excluded repeat visits.

## pickup_type refinement

When `pickup_type` is available, the dedup picks each trip's **boardable** visit (`pickup_type != 1`) rather than relying on "the earliest visit is the departure". A `pickup_type` of 1 ("no pickup available") is a drop-off-only visit, such as a loop's return to its terminal. This is more robust than earliest-only: it excludes a drop-off return even when it does not sort first, and ignores deadhead or drop-off arrivals at the representative stop.

`pickup_type` is nullable, so this degrades gracefully: when a feed omits it, every visit is treated as boardable and the result is identical to the earliest-per-trip dedup. A trip with only drop-off visits still contributes its earliest one, so no trip is dropped. The field is threaded from the departures query through the streaming wire tuple and `StopTimeCacheItem`.

## Stop Details annotation

Stop Details now flags stops where a trip visits more than once: when the departure count exceeds the distinct-trip count, the Departures cell shows a repeat icon with a tooltip explaining that these repeat visits (for example a loop revisiting a point) can be useful to riders but are excluded from the route frequency calculation, where they would otherwise look like very short headways. This reconciles the raw departure count shown in Stop Details with the deduped count used for frequency. `trip_count` is added to the Stop Details CSV.

## Test plan

- New unit tests for `oneDeparturePerTrip`: drops repeat visits, prefers a boardable visit over an earlier drop-off-only one, excludes a loop return, falls back to earliest when a trip has only drop-off visits, no-op for single visits, empty input.
- New loop regression test in `route-headway.test.ts`: a route whose representative stop is visited twice per trip now reports the true 2-hour headway instead of the spurious ~10-minute gap.
- Full unit suite passes; ESLint and `nuxt typecheck` are clean.
- Manual: open the Route Timetable for the City of Sandy Clackamas Town Center loop (and the Shopper Shuttle), and confirm the Frequency tab reports the real headway, each trip appears once at the representative stop, the repeat-visits warning shows, and Stop Details shows the repeat icon on the double-visited stops.

Addresses the loop fastest-frequency case in #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
