### PR TITLE
Simplify templates

### DIFF
--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -88,102 +88,26 @@
           <span v-if="!row.info_url && !row.booking_url" class="has-text-grey-light">—</span>
         </span>
       </template>
-      <template #column-average_trips_per_day="{ value, row }">
+      <template
+        v-for="col of timetableDrillColumns"
+        :key="col.id"
+        #[`column-${col.id}`]="{ value, row }"
+      >
         <button
           v-if="value != null && row.id != null"
           type="button"
           class="cal-report-cell-button"
-          @click="handleOpenTimetable(row.id, 'trips')"
+          @click="handleOpenTimetable(row.id, col.tab)"
         >
-          {{ value }}
-        </button>
-      </template>
-      <template #column-average_trips_per_hour="{ value, row }">
-        <button
-          v-if="value != null && row.id != null"
-          type="button"
-          class="cal-report-cell-button"
-          @click="handleOpenTimetable(row.id, 'trips')"
-        >
-          {{ value }}
-        </button>
-      </template>
-      <template #column-average_frequency="{ value, row }">
-        <button
-          v-if="value != null && row.id != null"
-          type="button"
-          class="cal-report-cell-button"
-          @click="handleOpenTimetable(row.id, 'frequency')"
-        >
-          {{ formatDuration(value) }}
+          {{ col.format(value) }}
         </button>
         <cat-tooltip
-          v-if="row.frequency_irregular || row.frequency_directions_differ"
+          v-if="col.caveat && (row.frequency_irregular || row.frequency_directions_differ)"
           :text="frequencyCaveatText(row)"
           class="cal-report-frequency-caveat"
         >
           <cat-icon icon="alert" size="small" />
         </cat-tooltip>
-      </template>
-      <template #column-fastest_frequency="{ value, row }">
-        <button
-          v-if="value != null && row.id != null"
-          type="button"
-          class="cal-report-cell-button"
-          @click="handleOpenTimetable(row.id, 'frequency')"
-        >
-          {{ formatDuration(value) }}
-        </button>
-      </template>
-      <template #column-slowest_frequency="{ value, row }">
-        <button
-          v-if="value != null && row.id != null"
-          type="button"
-          class="cal-report-cell-button"
-          @click="handleOpenTimetable(row.id, 'frequency')"
-        >
-          {{ formatDuration(value) }}
-        </button>
-      </template>
-      <template #column-earliest_trip_start="{ value, row }">
-        <button
-          v-if="value != null && row.id != null"
-          type="button"
-          class="cal-report-cell-button"
-          @click="handleOpenTimetable(row.id, 'trips')"
-        >
-          {{ formatGtfsTime(value) }}
-        </button>
-      </template>
-      <template #column-earliest_trip_end="{ value, row }">
-        <button
-          v-if="value != null && row.id != null"
-          type="button"
-          class="cal-report-cell-button"
-          @click="handleOpenTimetable(row.id, 'trips')"
-        >
-          {{ formatGtfsTime(value) }}
-        </button>
-      </template>
-      <template #column-latest_trip_start="{ value, row }">
-        <button
-          v-if="value != null && row.id != null"
-          type="button"
-          class="cal-report-cell-button"
-          @click="handleOpenTimetable(row.id, 'trips')"
-        >
-          {{ formatGtfsTime(value) }}
-        </button>
-      </template>
-      <template #column-latest_trip_end="{ value, row }">
-        <button
-          v-if="value != null && row.id != null"
-          type="button"
-          class="cal-report-cell-button"
-          @click="handleOpenTimetable(row.id, 'trips')"
-        >
-          {{ formatGtfsTime(value) }}
-        </button>
       </template>
       <template
         v-for="col of CENSUS_COLUMNS"
@@ -237,6 +161,26 @@ function handleOpenTimetable (routeId: number, initialTab: RouteTimetableTab) {
     emit('openTimetable', { route, initialTab })
   }
 }
+
+// The trips/frequency columns all render a drill button that opens the route
+// timetable; they vary only by which tab to open and how the value is formatted.
+// average_frequency additionally shows the #368 frequency caveat tooltip.
+const timetableDrillColumns: {
+  id: string
+  tab: RouteTimetableTab
+  format: (value: unknown) => unknown
+  caveat?: boolean
+}[] = [
+  { id: 'average_trips_per_day', tab: 'trips', format: value => value },
+  { id: 'average_trips_per_hour', tab: 'trips', format: value => value },
+  { id: 'average_frequency', tab: 'frequency', format: formatDuration, caveat: true },
+  { id: 'fastest_frequency', tab: 'frequency', format: formatDuration },
+  { id: 'slowest_frequency', tab: 'frequency', format: formatDuration },
+  { id: 'earliest_trip_start', tab: 'trips', format: formatGtfsTime },
+  { id: 'earliest_trip_end', tab: 'trips', format: formatGtfsTime },
+  { id: 'latest_trip_start', tab: 'trips', format: formatGtfsTime },
+  { id: 'latest_trip_end', tab: 'trips', format: formatGtfsTime },
+]
 
 // Issue #368: explain the frequency caveat flags in the routes table, where
 // analysts compare the derived frequency against agencies' own classifications.

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -4,91 +4,21 @@
     <template #footer />
     <template #menu-items>
       <ul class="menu-list">
-        <li>
+        <li v-for="item of menuRailItems" :key="item.tab">
           <button
             type="button"
             class="cal-icon-button"
-            :class="itemHelper('query')"
-            title="Query"
-            aria-label="Query"
-            @click="setTab({ tab: 'query', sub: '' })"
+            :class="[itemHelper(item.tab), { 'is-disabled': item.requiresScenario && !scenarioFilterResult }]"
+            :title="item.requiresScenario && !scenarioFilterResult ? `${item.label} (Run a query first)` : item.label"
+            :aria-label="item.requiresScenario && !scenarioFilterResult ? `${item.label} (Run a query first)` : item.label"
+            :aria-disabled="(item.requiresScenario && !scenarioFilterResult) || undefined"
+            @click="(!item.requiresScenario || scenarioFilterResult) && setTab({ tab: item.tab, sub: '' })"
           >
             <cat-icon
-              icon="magnify"
+              :icon="item.icon"
               class="is-fullwidth"
               size="large"
-              variant="white"
-            />
-          </button>
-        </li>
-        <li>
-          <button
-            type="button"
-            class="cal-icon-button"
-            :class="[itemHelper('filter'), { 'is-disabled': !scenarioFilterResult }]"
-            :title="scenarioFilterResult ? 'Filter' : 'Filter (Run a query first)'"
-            :aria-label="scenarioFilterResult ? 'Filter' : 'Filter (Run a query first)'"
-            :aria-disabled="!scenarioFilterResult || undefined"
-            @click="scenarioFilterResult && setTab({ tab: 'filter', sub: '' })"
-          >
-            <cat-icon
-              icon="filter"
-              class="is-fullwidth"
-              size="large"
-              :variant="scenarioFilterResult ? 'white' : 'dark'"
-            />
-          </button>
-        </li>
-        <li>
-          <button
-            type="button"
-            class="cal-icon-button"
-            :class="[itemHelper('map'), { 'is-disabled': !scenarioFilterResult }]"
-            :title="scenarioFilterResult ? 'Map' : 'Map (Run a query first)'"
-            :aria-label="scenarioFilterResult ? 'Map' : 'Map (Run a query first)'"
-            :aria-disabled="!scenarioFilterResult || undefined"
-            @click="scenarioFilterResult && setTab({ tab: 'map', sub: '' })"
-          >
-            <cat-icon
-              icon="map"
-              class="is-fullwidth"
-              size="large"
-              :variant="scenarioFilterResult ? 'white' : 'dark'"
-            />
-          </button>
-        </li>
-        <li>
-          <button
-            type="button"
-            class="cal-icon-button"
-            :class="[itemHelper('report'), { 'is-disabled': !scenarioFilterResult }]"
-            :title="scenarioFilterResult ? 'Report' : 'Report (Run a query first)'"
-            :aria-label="scenarioFilterResult ? 'Report' : 'Report (Run a query first)'"
-            :aria-disabled="!scenarioFilterResult || undefined"
-            @click="scenarioFilterResult && setTab({ tab: 'report', sub: '' })"
-          >
-            <cat-icon
-              icon="file-chart"
-              class="is-fullwidth"
-              size="large"
-              :variant="scenarioFilterResult ? 'white' : 'dark'"
-            />
-          </button>
-        </li>
-        <li>
-          <button
-            type="button"
-            class="cal-icon-button"
-            :class="itemHelper('analysis')"
-            title="Analysis"
-            aria-label="Analysis"
-            @click="setTab({ tab: 'analysis', sub: '' })"
-          >
-            <cat-icon
-              icon="chart-scatter-plot"
-              class="is-fullwidth"
-              size="large"
-              variant="white"
+              :variant="!item.requiresScenario || scenarioFilterResult ? 'white' : 'dark'"
             />
           </button>
         </li>
@@ -1330,6 +1260,17 @@ async function resetFilters () {
     stopBufferLayer: undefined,
   })
 }
+
+// Left-rail navigation. Filter/Map/Report require a loaded scenario; Query and
+// Analysis are always available. The disabled styling/labels derive from
+// requiresScenario so the buttons render from one template.
+const menuRailItems: { tab: string, icon: string, label: string, requiresScenario: boolean }[] = [
+  { tab: 'query', icon: 'magnify', label: 'Query', requiresScenario: false },
+  { tab: 'filter', icon: 'filter', label: 'Filter', requiresScenario: true },
+  { tab: 'map', icon: 'map', label: 'Map', requiresScenario: true },
+  { tab: 'report', icon: 'file-chart', label: 'Report', requiresScenario: true },
+  { tab: 'analysis', icon: 'chart-scatter-plot', label: 'Analysis', requiresScenario: false },
+]
 
 function itemHelper (p: string): string {
   if (activeTab.value.tab === p) {


### PR DESCRIPTION
## Summary

Collapses two blocks of near-identical, hand-repeated template markup into single `v-for` loops over a config array. This is a behavior-preserving refactor — the rendered output and interactions are unchanged; only the source shrinks (net −115 lines). It is the first item from the component-cleanup epic (#406): replacing copy-pasted markup with config-driven rendering. The `report.vue` change mirrors a pattern (`CENSUS_COLUMNS` `v-for`) that already exists in that file.

## User-facing changes

None. The report drill buttons, the frequency caveat tooltip, and the left navigation rail render and behave exactly as before; this PR only changes how that markup is expressed in source.

## Implementation details

### report.vue — timetable drill columns

- Replaced the nine hand-written `#column-*` slot templates (trips/frequency/earliest/latest columns) with one `v-for` over a `timetableDrillColumns` config of `{ id, tab, format, caveat? }`.
- Each entry carries which timetable tab to open (`trips` or `frequency`) and how to format the value (identity, `formatDuration`, or `formatGtfsTime`); the lone `average_frequency` special case (the #368 frequency caveat tooltip) is expressed with a `caveat` flag rather than a bespoke slot.
- The dynamic slot binding (`#[`column-${col.id}`]`) follows the existing `CENSUS_COLUMNS` `v-for` in the same file.

### tne.vue — left navigation rail

- Replaced the five hand-written `<li>` nav buttons with one `v-for` over a `menuRailItems` config of `{ tab, icon, label, requiresScenario }`.
- The disabled styling, "(Run a query first)" title/aria-label, `aria-disabled`, click-gating, and icon variant all derive from `requiresScenario`, so the always-available items (Query, Analysis) and the scenario-gated items (Filter, Map, Report) render from one button template. Each binding reduces to the original per case.

### Out of scope

The three remaining #406 item-1 candidates were intentionally left out: the `query.vue` "Data to Load" checkboxes (four distinct settings, not a uniform list — a config `v-for` there would add a `v-model="…value"` indirection with no real savings), the `route-timetable.vue` date-nav blocks (debug-oriented component kept as-is), and the `map-viewer-ts.vue` `update*` functions (a different, imperative collapse in a shared component, better paired with the `center`-watcher fix in its own PR).

## User test plan

- Open a scenario and go to the Report tab. On Routes, confirm the trips/frequency cells still render as drill buttons and clicking them opens the route timetable on the correct tab (trips columns → Trips, frequency columns → Frequency). Confirm the frequency caveat (alert) tooltip still appears on `average_frequency` for routes flagged irregular or with differing directions.
- Confirm the census/demographic drill buttons in the report still open the buffer-details view when a stop statistical radius is set.
- In the left navigation rail, confirm all five icons appear in order (Query, Filter, Map, Report, Analysis). Before running a query, confirm Filter/Map/Report are disabled with the "(Run a query first)" tooltip and dimmed icon, while Query/Analysis are active. After running a query, confirm all five are enabled and the active tab shows its highlighted state.
