### PR TITLE
Collapse map setSourceData

### DIFF
--- a/app/components/cal/map-viewer-ts.vue
+++ b/app/components/cal/map-viewer-ts.vue
@@ -791,128 +791,54 @@ function createLayers () {
   })
 }
 
-function updateChoroplethFeatures (features: Feature[]) {
+const isPoint = (f: Feature) => f.geometry?.type === 'Point'
+const isLine = (f: Feature) => f.geometry?.type === 'LineString' || f.geometry?.type === 'MultiLineString'
+const isPolygon = (f: Feature) => f.geometry?.type === 'Polygon' || f.geometry?.type === 'MultiPolygon'
+
+// Push features into a GeoJSON source, optionally filtering by geometry type.
+// No-ops if the map or the source isn't ready yet (sources are added together
+// in initMap, so a missing source means none are ready).
+function setSourceData (sourceId: string, features: Feature[], filter?: (f: Feature) => boolean) {
   if (!map) { return }
-  const source = map.getSource('choropleth') as maplibre.GeoJSONSource
+  const source = map.getSource(sourceId) as maplibre.GeoJSONSource
   if (!source) { return }
-  const polygons = features.filter(s => s.geometry?.type === 'Polygon' || s.geometry?.type === 'MultiPolygon')
-  source.setData({ type: 'FeatureCollection', features: polygons as any })
+  const data = filter ? features.filter(filter) : features
+  source.setData({ type: 'FeatureCollection', features: data as any })
+}
+
+function updateChoroplethFeatures (features: Feature[]) {
+  setSourceData('choropleth', features, isPolygon)
 }
 
 function updateOverlayFeatures (features: Feature[]) {
-  if (!map) {
-    return
-  }
-  // Check source exists
-  const p = map.getSource('overlayPolygons')
-  if (!p) {
-    return
-  }
-  if (!map) {
-    return
-  }
-  // Update sources
-  const polygonSource = map.getSource('overlayPolygons') as maplibre.GeoJSONSource
-  if (polygonSource) {
-    const polygons = features.filter((s) => { return s.geometry?.type === 'MultiPolygon' || s.geometry?.type === 'Polygon' })
-    polygonSource.setData({ type: 'FeatureCollection', features: polygons as any })
-  }
+  setSourceData('overlayPolygons', features, isPolygon)
 }
 
 function updateSelectableGeographies (features: Feature[]) {
-  if (!map) {
-    return
-  }
-  const source = map.getSource('selectableGeographies') as maplibre.GeoJSONSource
-  if (!source) {
-    return
-  }
-  const polygons = features.filter((s) => {
-    return s.geometry?.type === 'MultiPolygon' || s.geometry?.type === 'Polygon'
-  })
-  source.setData({ type: 'FeatureCollection', features: polygons as any })
+  setSourceData('selectableGeographies', features, isPolygon)
 }
 
 function updateFeatures (features: Feature[]) {
-  if (!map) {
-    return
-  }
-  // Check source exists
-  const p = map.getSource('lines')
-  if (!p) {
-    return
-  }
-  if (!map) {
-    return
-  }
-  // Update sources
-  const points = features.filter((s) => { return s.geometry?.type === 'Point' })
-  const lines = features.filter((s) => { return s.geometry?.type === 'LineString' || s.geometry?.type === 'MultiLineString' })
-  const polygons = features.filter((s) => { return s.geometry?.type === 'Polygon' || s.geometry?.type === 'MultiPolygon' })
-  const lineSource = map.getSource('lines') as maplibre.GeoJSONSource
-  const pointSource = map.getSource('points') as maplibre.GeoJSONSource
-  const polygonSource = map.getSource('polygons') as maplibre.GeoJSONSource
-  if (lineSource) {
-    lineSource.setData({ type: 'FeatureCollection', features: lines as any })
-  }
-  if (pointSource) {
-    pointSource.setData({ type: 'FeatureCollection', features: points as any })
-  }
-  if (polygonSource) {
-    polygonSource.setData({ type: 'FeatureCollection', features: polygons as any })
-  }
+  setSourceData('points', features, isPoint)
+  setSourceData('lines', features, isLine)
+  setSourceData('polygons', features, isPolygon)
 }
 
-/**
- * Update flex service area polygons on the map
- */
 function updateFlexFeatures (features: Feature[]) {
-  if (!map) {
-    return
-  }
-  const flexSource = map.getSource('flexPolygons') as maplibre.GeoJSONSource
-  if (!flexSource) {
-    return
-  }
-  // Filter to only polygon/multipolygon geometries (flex areas are polygons)
-  const polygons = features.filter((s) => {
-    return s.geometry?.type === 'Polygon' || s.geometry?.type === 'MultiPolygon'
-  })
-  flexSource.setData({ type: 'FeatureCollection', features: polygons as any })
+  setSourceData('flexPolygons', features, isPolygon)
 }
 
 // update the cluster marker + radius-circle sources.
 function updateClusterFeatures (features: Feature[]) {
-  if (!map) {
-    return
-  }
-  const source = map.getSource('clusters') as maplibre.GeoJSONSource
-  if (!source) {
-    return
-  }
-  source.setData({ type: 'FeatureCollection', features: features as any })
+  setSourceData('clusters', features)
 }
 
 function updateClusterCircle (features: Feature[]) {
-  if (!map) {
-    return
-  }
-  const source = map.getSource('clusterCircle') as maplibre.GeoJSONSource
-  if (!source) {
-    return
-  }
-  source.setData({ type: 'FeatureCollection', features: features as any })
+  setSourceData('clusterCircle', features)
 }
 
 function updateClusterLines (features: Feature[]) {
-  if (!map) {
-    return
-  }
-  const source = map.getSource('clusterLines') as maplibre.GeoJSONSource
-  if (!source) {
-    return
-  }
-  source.setData({ type: 'FeatureCollection', features: features as any })
+  setSourceData('clusterLines', features)
 }
 
 function fitFeatures (features: Feature[]) {

--- a/app/components/cal/map-viewer-ts.vue
+++ b/app/components/cal/map-viewer-ts.vue
@@ -800,7 +800,7 @@ const isPolygon = (f: Feature) => f.geometry?.type === 'Polygon' || f.geometry?.
 // in initMap, so a missing source means none are ready).
 function setSourceData (sourceId: string, features: Feature[], filter?: (f: Feature) => boolean) {
   if (!map) { return }
-  const source = map.getSource(sourceId) as maplibre.GeoJSONSource
+  const source = map.getSource<maplibre.GeoJSONSource>(sourceId)
   if (!source) { return }
   const data = filter ? features.filter(filter) : features
   source.setData({ type: 'FeatureCollection', features: data as any })


### PR DESCRIPTION
## Summary

Collapses eight near-identical `update*` functions in the map viewer into thin wrappers over a single `setSourceData` helper. Each function previously repeated the same shape — guard on the map, look up a GeoJSON source, optionally filter features by geometry type, then call `setData` — with some carrying redundant double `if (!map)` checks and a redundant pre-lookup of the source. This is a behavior-preserving refactor (net −74 lines); no watcher, call site, or rendered output changes. It is part of the component-cleanup epic (#406).

## User-facing changes

None. The map renders the same overlay polygons, choropleth, selectable geographies, lines/points/polygons, flex areas, and stop clusters exactly as before; only the internal implementation of how feature collections are pushed into their sources changed.

## Implementation details

- Added a `setSourceData(sourceId, features, filter?)` helper that no-ops when the map or the named source isn't ready, optionally filters by a geometry-type predicate, and pushes the resulting `FeatureCollection` to the source.
- Added three shared geometry-type predicates (`isPoint`, `isLine`, `isPolygon`) replacing the per-function inline `s.geometry?.type === …` filters.
- Rewrote the eight `update*` functions as one-line wrappers: `updateChoroplethFeatures`, `updateOverlayFeatures`, `updateSelectableGeographies`, and `updateFlexFeatures` delegate to `setSourceData(name, features, isPolygon)`; the three cluster updaters (`updateClusterFeatures`, `updateClusterCircle`, `updateClusterLines`) delegate with no filter; `updateFeatures` becomes three `setSourceData` calls for the `points`, `lines`, and `polygons` sources.
- The named functions are retained so the existing ~12 watchers and the `loadingStage` re-render handler keep their current call sites — the change is contained to the function bodies.
- The old `updateFeatures` bailed out entirely if the `lines` source was missing; because all sources are added together in `initMap`, "lines missing" implies "all missing," so the per-source guards inside `setSourceData` are equivalent.

## Out of scope

The `center`/`zoom` watchers in this file have a latent bug (they watch the ref object rather than its value, the callback's `oldVal`/`newVal` are swapped, and the dedup guard compares `{lon,lat}` objects via `.toString()` so it always early-returns). Fixing it is a cross-consumer behavior change — `map.vue` passes a non-reactive center, but `wsdot-viewer.vue` passes a reactive computed — so it is intentionally left for a separate change where the intended recenter semantics can be decided.

## User test plan

- Run a scenario and confirm the map still draws route lines, stop points, agency/route polygons, flex service areas, choropleth fill, selectable geographies, and stop-cluster markers/circles/lines.
- Toggle the layers and aggregation options that drive these sources (e.g. show/hide flex areas, switch aggregation layer, enable stop clusters) and confirm each source updates as before.
- Load a heavy scenario and confirm the loading-stage gating still suppresses feature updates during schedule loading and then renders everything once the stage completes.
- Open the WSDOT analysis viewer and confirm its map still renders its features (this file is shared between the main map and the WSDOT viewer).
