### PR TITLE
Extract flex display features into a composable

### DIFF
--- a/app/composables/useFlexDisplayFeatures.ts
+++ b/app/composables/useFlexDisplayFeatures.ts
@@ -1,0 +1,123 @@
+// Derives the GeoJSON feature collections for flex (demand-responsive) service
+// areas — both the map-display set (styled, respects the map toggles) and the
+// Reports-tab set (always available when data exists). All inputs are plain
+// data: the raw/filtered scenario results are passed in by the container, and
+// the URL-backed filter/display state is read from the useScenario* composables
+// (callable anywhere). No fetching or Apollo access happens here.
+
+import { computed, type Ref, type ComputedRef } from 'vue'
+import { useScenarioFilters } from './useScenarioFilters'
+import { useScenarioDisplay } from './useScenarioDisplay'
+import { useFlexAreaFormatting } from './useFlexAreaFormatting'
+import { getFlexAdvanceNotice, getFlexAgencyName, flexAreaMatchesFilters } from '~~/src/tl'
+import { type Feature, createCategoryColorScale, flexColors, dateToSeconds } from '~~/src/core'
+import type { ScenarioData, ScenarioFilterResult } from '~~/src/scenario'
+
+interface UseFlexDisplayFeaturesDeps {
+  // Raw stream data (all agencies, unfiltered) — drives the agency color scale.
+  scenarioData: Ref<ScenarioData | undefined>
+  // Agency-filtered results — the source for the per-area marked status.
+  scenarioFilterResult: Ref<ScenarioFilterResult | undefined>
+}
+
+export interface UseFlexDisplayFeaturesReturn {
+  // Styled features for the map; empty when flex display is toggled off.
+  flexDisplayFeatures: ComputedRef<Feature[]>
+  // Features for the Reports tab; available whenever flex data exists.
+  flexFeaturesForReport: ComputedRef<Feature[]>
+}
+
+export function useFlexDisplayFeatures (deps: UseFlexDisplayFeaturesDeps): UseFlexDisplayFeaturesReturn {
+  const {
+    startTime,
+    endTime,
+    flexServicesEnabled,
+    flexAdvanceNotice,
+    flexAreaTypesSelected,
+    flexColorBy,
+  } = useScenarioFilters()
+  const { hideUnmarked } = useScenarioDisplay()
+  const { buildFlexAreaProperties } = useFlexAreaFormatting()
+
+  // Color scale spans every agency in the raw stream (not the filtered set), so
+  // an agency's color stays stable as filters change.
+  const flexAgencyNames = computed(() => {
+    const names = new Set<string>()
+    for (const feature of deps.scenarioData.value?.flexAreas || []) {
+      const name = getFlexAgencyName(feature)
+      if (name) { names.add(name) }
+    }
+    return Array.from(names).sort()
+  })
+
+  const flexAgencyColorScale = computed(() => {
+    return createCategoryColorScale(flexAgencyNames.value, flexColors.agency)
+  })
+
+  // Every flex area with its marked status, independent of the map toggle.
+  // Combines agency marking from the scenario filter with the advance-notice,
+  // area-type, and time-of-day filters.
+  const flexAreasWithMarked = computed(() => {
+    const criteria = {
+      advanceNotice: flexAdvanceNotice.value,
+      areaTypes: flexAreaTypesSelected.value,
+      startSeconds: dateToSeconds(startTime.value),
+      endSeconds: dateToSeconds(endTime.value),
+    }
+    return (deps.scenarioFilterResult.value?.flexAreas || []).map(feature => ({
+      feature,
+      marked: (feature.properties.marked !== false) && flexAreaMatchesFilters(feature, criteria),
+    }))
+  })
+
+  const flexDisplayFeatures = computed((): Feature[] => {
+    if (!flexServicesEnabled.value) { return [] }
+    const colorBy = flexColorBy.value
+    return flexAreasWithMarked.value
+      .filter(({ marked }) => !hideUnmarked.value || marked) // Hide unmarked if toggle is on
+      .map(({ feature, marked }) => {
+        // Color by advance notice, else by agency.
+        let color: string
+        if (colorBy === 'Advance notice') {
+          const advanceNotice = getFlexAdvanceNotice(feature)
+          color = flexColors.advanceNotice[advanceNotice] || flexColors.default
+        } else {
+          const agencyName = getFlexAgencyName(feature)
+          color = flexAgencyColorScale.value(agencyName)
+        }
+
+        // Marked: filled with solid outline. Unmarked: no fill, dashed, faded.
+        const fillOpacity = marked ? 0.3 : 0
+        const strokeOpacity = marked ? 0.8 : 0.4
+        const properties: Record<string, any> = {
+          ...buildFlexAreaProperties(feature, marked),
+          'fill': color,
+          'fill-opacity': fillOpacity,
+          'stroke': color,
+          'stroke-width': 2,
+          'stroke-opacity': strokeOpacity,
+        }
+        if (!marked) {
+          properties['stroke-dasharray'] = true
+        }
+
+        return {
+          type: 'Feature',
+          id: feature.id,
+          geometry: feature.geometry,
+          properties,
+        } as Feature
+      })
+  })
+
+  const flexFeaturesForReport = computed((): Feature[] => {
+    return flexAreasWithMarked.value.map(({ feature, marked }) => ({
+      type: 'Feature',
+      id: feature.id,
+      geometry: feature.geometry,
+      properties: buildFlexAreaProperties(feature, marked),
+    } as Feature))
+  })
+
+  return { flexDisplayFeatures, flexFeaturesForReport }
+}

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -195,22 +195,16 @@
 <script lang="ts" setup>
 import { computed, shallowRef, watch } from 'vue'
 import { useQuery, useLazyQuery } from '@vue/apollo-composable'
-import { useFlexAreaFormatting } from '~/composables/useFlexAreaFormatting'
+import { useFlexDisplayFeatures } from '~/composables/useFlexDisplayFeatures'
 import { useBufferDetails } from '~/composables/useBufferDetails'
 import { useCensusGeographyLayers } from '~/composables/useCensusGeographyLayers'
 import {
-  getFlexAreaType,
-  getFlexAdvanceNotice,
-  getFlexAgencyName,
   geographyLayerQuery,
   geographyBboxQuery,
   stopGeoAggregateCsv,
   parseFvids,
 } from '~~/src/tl'
 import type {
-  FlexAdvanceNotice,
-  FlexAreaType,
-  FlexAreaFeature,
   CensusDataset,
   CensusGeography,
   Route,
@@ -220,17 +214,12 @@ import {
   type Point,
   type Feature,
   type AgencyFilterItem,
-  createCategoryColorScale,
-  flexColors,
   routeTypeNames,
   fmtDate,
   fmtTime,
-  dateToSeconds,
   convertBbox,
   SCENARIO_DEFAULTS,
   censusLayerLabels,
-  flexAdvanceNoticeTypes,
-  flexAreaTypes,
   formatAcsDatasetLabel,
   summarizeBbox,
   deriveApportionedRow,
@@ -245,13 +234,11 @@ import { useToastNotification, useRouter } from '#imports'
 import { ScenarioStreamReceiver, applyScenarioResultFilter, getSelectedDateRange, type ScenarioConfig, type ScenarioData, type ScenarioFilter, type ScenarioFilterResult, type ScenarioPhaseName, ScenarioDataReceiver, type ScenarioProgress } from '~~/src/scenario'
 
 // Initialize composables
-const { buildFlexAreaProperties } = useFlexAreaFormatting()
 const { setQuery } = useUrlQuery()
 const {
   showAggAreas,
   aggregateLayer,
   onlyWithStops,
-  hideUnmarked,
   showBbox,
 } = useScenarioDisplay()
 const {
@@ -281,10 +268,6 @@ const {
   selectedWeekdayMode,
   frequencyUnder,
   frequencyOver,
-  flexServicesEnabled,
-  flexAdvanceNotice,
-  flexAreaTypesSelected,
-  flexColorBy,
   clusterMaxTransferMinutes,
 } = useScenarioFilters()
 
@@ -404,139 +387,9 @@ const agencyFilterItems = computed((): AgencyFilterItem[] => {
   return Array.from(agencyMap.values()).sort((a, b) => a.name.localeCompare(b.name))
 })
 
-const flexAgencyNames = computed(() => {
-  const names = new Set<string>()
-  for (const feature of scenarioData.value?.flexAreas || []) {
-    const name = getFlexAgencyName(feature)
-    if (name) { names.add(name) }
-  }
-  return Array.from(names).sort()
-})
-
-const flexAgencyColorScale = computed(() => {
-  return createCategoryColorScale(flexAgencyNames.value, flexColors.agency)
-})
-
-// Check if a flex area matches the current filters
-// Returns true if it matches, false if it should be "downplayed"
-const flexAreaMatchesFilters = (feature: FlexAreaFeature): boolean => {
-  // Filter to only valid values to handle potential invalid URL query params
-  // undefined means "not set" = all values match (no filter applied)
-  const advanceNoticeFilter = flexAdvanceNotice.value?.filter(
-    (v): v is FlexAdvanceNotice => flexAdvanceNoticeTypes.includes(v as FlexAdvanceNotice)
-  )
-  const areaTypesFilter = flexAreaTypesSelected.value?.filter(
-    (v): v is FlexAreaType => flexAreaTypes.includes(v as FlexAreaType)
-  )
-
-  const featureAreaType = getFlexAreaType(feature)
-  // If filter is set (not undefined) and doesn't include this type, filter it out
-  if (areaTypesFilter !== undefined && !areaTypesFilter.includes(featureAreaType)) { return false }
-
-  const featureAdvanceNotice = getFlexAdvanceNotice(feature)
-  // If filter is set (not undefined) and doesn't include this notice type, filter it out
-  if (advanceNoticeFilter !== undefined && !advanceNoticeFilter.includes(featureAdvanceNotice)) { return false }
-
-  // Time-of-day filtering for flex areas
-  const applyTimeFilter = startTime.value != null || endTime.value != null
-  if (applyTimeFilter) {
-    const userStartSeconds = dateToSeconds(startTime.value)
-    const userEndSeconds = dateToSeconds(endTime.value)
-    const flexStart = feature.properties.time_window_start
-    const flexEnd = feature.properties.time_window_end
-
-    // If flex area has time windows defined and user has set time filters, check for overlap
-    if (flexStart !== undefined && flexEnd !== undefined
-      && userStartSeconds !== undefined && userEndSeconds !== undefined) {
-      const noOverlap = flexEnd < userStartSeconds || flexStart > userEndSeconds
-      if (noOverlap) { return false }
-    }
-  }
-
-  return true
-}
-
-// All flex areas with their "marked" status (matches filters)
-// Base computed that always calculates marked status (independent of map toggle)
-// Combines agency filtering from scenario-filter with advance notice, area type, and time filters
-const flexAreasWithMarkedBase = computed(() => {
-  return (scenarioFilterResult.value?.flexAreas || []).map(feature => ({
-    feature,
-    // Combine marked status from scenario-filter (agency) with local filters (advance notice, area type, time)
-    marked: (feature.properties.marked !== false) && flexAreaMatchesFilters(feature)
-  }))
-})
-
-// Flex areas for map display (respects flexServicesEnabled toggle)
-const flexAreasWithMarked = computed(() => {
-  if (!flexServicesEnabled.value) { return [] }
-  return flexAreasWithMarkedBase.value
-})
-
-// Flex areas for Reports tab (always available if data exists, independent of map toggle)
-const flexAreasWithMarkedForReport = computed(() => {
-  return flexAreasWithMarkedBase.value
-})
-
-const flexDisplayFeatures = computed((): Feature[] => {
-  if (!flexServicesEnabled.value) { return [] }
-
-  const colorBy = flexColorBy.value
-
-  return flexAreasWithMarked.value
-    .filter(({ marked }) => !hideUnmarked.value || marked) // Hide unmarked if toggle is on
-    .map(({ feature, marked }) => {
-      // Determine color based on colorBy mode
-      let color: string
-      if (colorBy === 'Advance notice') {
-        const advanceNotice = getFlexAdvanceNotice(feature)
-        color = flexColors.advanceNotice[advanceNotice] || flexColors.default
-      } else {
-        const agencyName = getFlexAgencyName(feature)
-        color = flexAgencyColorScale.value(agencyName)
-      }
-
-      // Style based on marked status
-      // Marked: filled polygon with solid outline
-      // Unmarked: no fill, dashed outline, reduced opacity
-      const fillOpacity = marked ? 0.3 : 0
-      const strokeOpacity = marked ? 0.8 : 0.4
-
-      const properties: Record<string, any> = {
-        ...buildFlexAreaProperties(feature, marked),
-        // Custom styling for marked/unmarked
-        'fill': color,
-        'fill-opacity': fillOpacity,
-        'stroke': color,
-        'stroke-width': 2,
-        'stroke-opacity': strokeOpacity,
-      }
-
-      // Only set stroke-dasharray for unmarked features (dashed outline)
-      if (!marked) {
-        properties['stroke-dasharray'] = true
-      }
-
-      return {
-        type: 'Feature',
-        id: feature.id,
-        geometry: feature.geometry,
-        properties
-      } as Feature
-    })
-})
-
-// Flex features for Reports tab (always available if data exists, independent of map toggle)
-const flexFeaturesForReport = computed((): Feature[] => {
-  return flexAreasWithMarkedForReport.value.map(({ feature, marked }) => {
-    return {
-      type: 'Feature',
-      id: feature.id,
-      geometry: feature.geometry,
-      properties: buildFlexAreaProperties(feature, marked)
-    } as Feature
-  })
-})
+// Flex (demand-responsive) display features for the map and Reports tab are
+// derived by useFlexDisplayFeatures — wired up below, once scenarioFilterResult
+// is defined (see flexDisplayFeatures / flexFeaturesForReport).
 
 /////////////////
 // Geography datasets
@@ -912,10 +765,13 @@ const scenarioFilter = computed((): ScenarioFilter => ({
   clusterMaxTransferMinutes: clusterMaxTransferMinutes.value,
 }))
 
-// Internal state for streaming scenario data
-// Note: scenarioData is defined earlier in the file (before useFlexAreas)
+// Internal state for streaming scenario data (scenarioData is defined earlier).
 const scenarioFilterResult = shallowRef<ScenarioFilterResult | undefined>(undefined)
 const exportFeatures = shallowRef<Feature[]>([])
+
+// Flex display features (map + Reports tab). Instantiated here because it
+// depends on scenarioFilterResult; consumed by the map and report components.
+const { flexDisplayFeatures, flexFeaturesForReport } = useFlexDisplayFeatures({ scenarioData, scenarioFilterResult })
 
 // Unique census geography IDs for the current aggregate layer across all marked stops.
 // Shared base for both the filter summary count and the choropleth geometry fetch.

--- a/src/tl/flex.test.ts
+++ b/src/tl/flex.test.ts
@@ -5,6 +5,7 @@ import {
   bookingTypeToAdvanceNotice,
   getFlexAgencyName,
   getFlexAgencyNames,
+  flexAreaMatchesFilters,
   isBookingAvailableOnDay,
   isBookingAvailableToday,
   formatBookingDays,
@@ -351,5 +352,58 @@ describe('formatBookingDays', () => {
       saturday: false,
     }
     expect(formatBookingDays(noDays)).toBe('No days')
+  })
+})
+
+describe('flexAreaMatchesFilters', () => {
+  // PU-only, On-demand area for filter targeting
+  const puOnDemand = createFlexFeature({
+    pickup_available: true,
+    drop_off_available: false,
+    pickup_booking_rules: [{ booking_rule_id: 'r1', booking_type: 0 }],
+  })
+
+  it('matches everything when no criteria are set', () => {
+    expect(flexAreaMatchesFilters(puOnDemand, {})).toBe(true)
+  })
+
+  it('matches when the area type is in the area-type filter', () => {
+    expect(flexAreaMatchesFilters(puOnDemand, { areaTypes: ['PU only'] })).toBe(true)
+  })
+
+  it('does not match when the area type is excluded by the area-type filter', () => {
+    expect(flexAreaMatchesFilters(puOnDemand, { areaTypes: ['DO only'] })).toBe(false)
+  })
+
+  it('matches when the advance notice is in the filter', () => {
+    expect(flexAreaMatchesFilters(puOnDemand, { advanceNotice: ['On-demand'] })).toBe(true)
+  })
+
+  it('does not match when the advance notice is excluded', () => {
+    expect(flexAreaMatchesFilters(puOnDemand, { advanceNotice: ['Same day'] })).toBe(false)
+  })
+
+  it('ignores invalid filter values (treated as no match against a real type)', () => {
+    // An all-invalid selection filters down to an empty list, which matches nothing.
+    expect(flexAreaMatchesFilters(puOnDemand, { areaTypes: ['not-a-type'] })).toBe(false)
+  })
+
+  it('does not match when the area time window is outside the user window', () => {
+    const area = createFlexFeature({ time_window_start: 100, time_window_end: 200 })
+    expect(flexAreaMatchesFilters(area, { startSeconds: 500, endSeconds: 600 })).toBe(false)
+  })
+
+  it('matches when the time windows overlap', () => {
+    const area = createFlexFeature({ time_window_start: 100, time_window_end: 200 })
+    expect(flexAreaMatchesFilters(area, { startSeconds: 150, endSeconds: 600 })).toBe(true)
+  })
+
+  it('does not apply the time filter unless both start and end are set', () => {
+    const area = createFlexFeature({ time_window_start: 100, time_window_end: 200 })
+    expect(flexAreaMatchesFilters(area, { startSeconds: 500 })).toBe(true)
+  })
+
+  it('matches when the area declares no time window even if the user set one', () => {
+    expect(flexAreaMatchesFilters(puOnDemand, { startSeconds: 500, endSeconds: 600 })).toBe(true)
   })
 })

--- a/src/tl/flex.test.ts
+++ b/src/tl/flex.test.ts
@@ -383,8 +383,8 @@ describe('flexAreaMatchesFilters', () => {
     expect(flexAreaMatchesFilters(puOnDemand, { advanceNotice: ['Same day'] })).toBe(false)
   })
 
-  it('ignores invalid filter values (treated as no match against a real type)', () => {
-    // An all-invalid selection filters down to an empty list, which matches nothing.
+  it('treats an all-invalid selection as matching nothing (like an empty selection)', () => {
+    // Invalid values are dropped, leaving an empty active filter that matches nothing.
     expect(flexAreaMatchesFilters(puOnDemand, { areaTypes: ['not-a-type'] })).toBe(false)
   })
 

--- a/src/tl/flex.ts
+++ b/src/tl/flex.ts
@@ -266,11 +266,15 @@ export function getFlexAgencyName (feature: FlexAreaFeature): string {
 }
 
 /**
- * Filter selections for {@link flexAreaMatchesFilters}. Each is optional;
+ * Filter selections for {@link flexAreaMatchesFilters}. Each field is optional;
  * `undefined` means "no filter applied" (everything matches that dimension).
- * `advanceNotice`/`areaTypes` accept raw URL values — invalid entries are
- * ignored. `startSeconds`/`endSeconds` are the user's time-of-day window in
- * seconds since midnight (both must be set for the time filter to apply).
+ *
+ * For `advanceNotice`/`areaTypes`, raw URL values are accepted but invalid
+ * entries are dropped, and the remaining (possibly empty) list becomes the
+ * active filter — so a selection of only invalid values matches nothing, the
+ * same as an empty selection (distinct from `undefined`, which disables the
+ * filter). `startSeconds`/`endSeconds` are the user's time-of-day window in
+ * seconds since midnight; both must be set for the time filter to apply.
  */
 export interface FlexAreaFilterCriteria {
   advanceNotice?: readonly string[]

--- a/src/tl/flex.ts
+++ b/src/tl/flex.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-tag'
-import { parseHMS } from '~~/src/core'
+import { parseHMS, flexAdvanceNoticeTypes, flexAreaTypes } from '~~/src/core'
 import turfArea from '@turf/area'
 
 //////////
@@ -263,6 +263,55 @@ export function getFlexAdvanceNotice (feature: FlexAreaFeature): FlexAdvanceNoti
  */
 export function getFlexAgencyName (feature: FlexAreaFeature): string {
   return feature.properties.agencies?.[0]?.agency_name || 'Unknown Agency'
+}
+
+/**
+ * Filter selections for {@link flexAreaMatchesFilters}. Each is optional;
+ * `undefined` means "no filter applied" (everything matches that dimension).
+ * `advanceNotice`/`areaTypes` accept raw URL values — invalid entries are
+ * ignored. `startSeconds`/`endSeconds` are the user's time-of-day window in
+ * seconds since midnight (both must be set for the time filter to apply).
+ */
+export interface FlexAreaFilterCriteria {
+  advanceNotice?: readonly string[]
+  areaTypes?: readonly string[]
+  startSeconds?: number
+  endSeconds?: number
+}
+
+/**
+ * Whether a flex area matches the current advance-notice, area-type, and
+ * time-of-day filters. Returns true when it matches (should be highlighted);
+ * false when it should be downplayed. Agency filtering is handled upstream by
+ * the scenario filter, not here.
+ */
+export function flexAreaMatchesFilters (feature: FlexAreaFeature, criteria: FlexAreaFilterCriteria): boolean {
+  // Drop invalid URL values; undefined stays undefined ("no filter").
+  const advanceNoticeFilter = criteria.advanceNotice?.filter(
+    (v): v is FlexAdvanceNotice => flexAdvanceNoticeTypes.includes(v as FlexAdvanceNotice)
+  )
+  const areaTypesFilter = criteria.areaTypes?.filter(
+    (v): v is FlexAreaType => flexAreaTypes.includes(v as FlexAreaType)
+  )
+
+  const featureAreaType = getFlexAreaType(feature)
+  if (areaTypesFilter !== undefined && !areaTypesFilter.includes(featureAreaType)) { return false }
+
+  const featureAdvanceNotice = getFlexAdvanceNotice(feature)
+  if (advanceNoticeFilter !== undefined && !advanceNoticeFilter.includes(featureAdvanceNotice)) { return false }
+
+  // Time-of-day overlap: only applies when the user set a window and the area
+  // declares one. Non-overlapping windows downplay the area.
+  if (criteria.startSeconds !== undefined && criteria.endSeconds !== undefined) {
+    const flexStart = feature.properties.time_window_start
+    const flexEnd = feature.properties.time_window_end
+    if (flexStart !== undefined && flexEnd !== undefined) {
+      const noOverlap = flexEnd < criteria.startSeconds || flexStart > criteria.endSeconds
+      if (noOverlap) { return false }
+    }
+  }
+
+  return true
 }
 
 /**


### PR DESCRIPTION
## Summary

Extracts the inline flex (demand-responsive) service-area display logic out of `tne.vue` into a focused composable, and lifts the flex-area filter predicate into a pure, tested function in `src/tl`. This is part of the component-cleanup epic (#406, Item 7) — slimming the `tne.vue` orchestrator by moving a cohesive block into a testable unit. It is behavior-preserving: the same map features, report features, and marked/color styling render as before; net −154 lines in `tne.vue`.

## User-facing changes

None. The flex service areas on the map and in the Reports tab render and filter identically — same colors, same marked/unmarked styling, same advance-notice/area-type/time-of-day filtering.

## Implementation details

### Pure filter predicate → `src/tl/flex.ts`

- Added `flexAreaMatchesFilters(feature, criteria)` and a `FlexAreaFilterCriteria` interface. The predicate decides whether a flex area matches the current advance-notice, area-type, and time-of-day filters (agency filtering is handled upstream by the scenario filter).
- It takes a plain criteria object (`advanceNotice`/`areaTypes` selections plus a time-of-day window in seconds) instead of reading reactive refs, so it has no Vue/URL coupling and is unit-testable.
- Invalid URL filter values are dropped internally (validated against `flexAdvanceNoticeTypes`/`flexAreaTypes`), preserving the previous inline behavior. The time filter only applies when both a start and end are set and the area declares a window.
- Added 11 tests in `src/tl/flex.test.ts` covering the area-type/advance-notice filters, invalid-value handling, and time-window overlap edge cases.

### New composable `useFlexDisplayFeatures`

- Takes `{ scenarioData, scenarioFilterResult }` (the container's data, passed in as plain refs) and returns `{ flexDisplayFeatures, flexFeaturesForReport }`.
- Reads the URL-backed flex/time/display state (`useScenarioFilters`/`useScenarioDisplay`) internally, which the state-ownership convention permits; it performs no data fetching and no Apollo-cache access.
- Builds the agency color scale from the raw (unfiltered) stream so an agency's color stays stable as filters change, computes per-area marked status via the new predicate, and produces the styled map feature collection (fill/stroke/dash by marked status and color-by mode) and the Reports-tab feature collection.

### tne.vue

- Removed the inline flex block (~133 lines) and instantiated the composable immediately after `scenarioFilterResult` is defined (it depends on that ref). Consumers in the template are unchanged.
- Removed the now-unused flex imports and destructured filter/display refs.
- Collapsed three near-redundant intermediate computeds (`…Base`, the toggle-gated `…WithMarked`, and `…ForReport`) into a single base: `flexDisplayFeatures` applies the display toggle via its existing early return, and `flexFeaturesForReport` is always available when data exists — behavior-identical.

## User test plan

- Load a scenario that includes flex service areas. Enable flex display and confirm the areas render on the map with the same fill/outline styling; toggle "hide unmarked" and confirm unmarked areas drop out.
- Switch the flex "color by" between Agency and Advance notice and confirm colors update and stay stable per agency as other filters change.
- Apply advance-notice and area-type filters and a time-of-day window, and confirm areas are marked/downplayed exactly as before (including areas with no declared time window staying matched).
- Open the Reports tab "Flex Areas" view and confirm the flex rows appear regardless of the map display toggle.
