### PR TITLE
useScenarioRun

### DIFF
--- a/app/composables/useAggregateRefetch.ts
+++ b/app/composables/useAggregateRefetch.ts
@@ -10,7 +10,7 @@ import { useScenarioInputs } from './useScenarioInputs'
 import { useStreamingRefetch, type StreamingRefetchDeps } from './useStreamingRefetch'
 import type { CensusValuesPhaseConfig } from '~~/src/scenario'
 
-// scenarioReceiver is created by useBufferRefetch and shared so refetched
+// scenarioReceiver is created by useScenarioRun and shared so refetched
 // census values land in the same accumulator.
 export type UseAggregateRefetchDeps = StreamingRefetchDeps
 

--- a/app/composables/useBufferRefetch.ts
+++ b/app/composables/useBufferRefetch.ts
@@ -3,79 +3,46 @@
 // routes, departures, …) stays untouched.
 //
 // The streaming/abort/debounce machinery lives in useStreamingRefetch; this only
-// supplies the buffer-specific bits (what to watch, the body, how to clear) and
-// owns the shared ScenarioDataReceiver that the main fetch path reuses.
+// supplies the buffer-specific bits (what to watch, the body, how to clear). The
+// shared ScenarioDataReceiver is owned by useScenarioRun and passed in via deps.
 
-import { shallowRef, type Ref, type ShallowRef } from 'vue'
 import { useScenarioInputs } from './useScenarioInputs'
-import { useStreamingRefetch } from './useStreamingRefetch'
+import { useStreamingRefetch, type StreamingRefetchDeps } from './useStreamingRefetch'
 import { SCENARIO_DEFAULTS } from '~~/src/core'
-import type {
-  BufferFetchConfig,
-  ScenarioConfig,
-  ScenarioData,
-  ScenarioDataReceiver,
-  ScenarioPhaseName,
-  ScenarioProgress,
-} from '~~/src/scenario'
+import type { BufferFetchConfig } from '~~/src/scenario'
 
-interface UseBufferRefetchDeps {
-  scenarioData: Ref<ScenarioData | undefined>
-  // ComputedRef satisfies Ref for read access; the refetch only reads.
-  scenarioConfig: Ref<ScenarioConfig>
-  loadingProgress: Ref<ScenarioProgress | undefined>
-  showLoadingModal: Ref<boolean>
-  error: Ref<any>
-  // Weighted progress-bar state shared with the loading modal; the refetch
-  // installs a single-phase plan so the bar tracks the buffer passes.
-  phasePlan: Ref<ScenarioPhaseName[] | undefined>
-  phaseFractions: Ref<Partial<Record<ScenarioPhaseName, number>>>
-  refetchInFlight: Ref<number>
-}
+// scenarioReceiver is created by useScenarioRun and shared so refetched buffer
+// geographies land in the same accumulator as the main scenario fetch.
+export type UseBufferRefetchDeps = StreamingRefetchDeps
 
-export interface UseBufferRefetchReturn {
-  // Shared with the main fetch path so refetched buffer state lands in the
-  // same accumulator. Parent assigns into this after each main scenario fetch.
-  scenarioReceiver: ShallowRef<ScenarioDataReceiver | undefined>
-}
-
-export function useBufferRefetch (deps: UseBufferRefetchDeps): UseBufferRefetchReturn {
-  // Shared with the main fetch path so refetched buffer state lands in the
-  // same accumulator.
-  const scenarioReceiver = shallowRef<ScenarioDataReceiver>()
-
+export function useBufferRefetch (deps: UseBufferRefetchDeps): void {
   const { stopBufferRadius, stopBufferLayer, geoDatasetName } = useScenarioInputs()
 
-  useStreamingRefetch(
-    { ...deps, scenarioReceiver },
-    {
-      watchSources: [stopBufferRadius, stopBufferLayer],
-      endpoint: '/api/buffer-geographies',
-      phase: 'buffers',
-      loadingMessage: 'Recomputing buffer demographics...',
-      clearBeforeFetch: true,
-      clearStale: receiver => receiver.clearBufferGeographies(),
-      plan: (data, config) => {
-        // Census demographics were excluded at query time; don't fetch them post-hoc.
-        if (config.includeCensus === false) {
-          return 'skip'
-        }
-        const agencyIds = [...new Set(
-          data.routes.map(r => r.agency?.id).filter((id): id is number => id != null),
-        )]
-        const body: BufferFetchConfig = {
-          radius: stopBufferRadius.value,
-          layer: stopBufferLayer.value,
-          geoDatasetName: geoDatasetName.value,
-          tableDatasetName: config.tableDatasetName ?? SCENARIO_DEFAULTS.tableDatasetName,
-          stopIds: data.stops.map(s => s.id),
-          routeIds: data.routes.map(r => r.id),
-          agencyIds,
-        }
-        return body
-      },
+  useStreamingRefetch(deps, {
+    watchSources: [stopBufferRadius, stopBufferLayer],
+    endpoint: '/api/buffer-geographies',
+    phase: 'buffers',
+    loadingMessage: 'Recomputing buffer demographics...',
+    clearBeforeFetch: true,
+    clearStale: receiver => receiver.clearBufferGeographies(),
+    plan: (data, config) => {
+      // Census demographics were excluded at query time; don't fetch them post-hoc.
+      if (config.includeCensus === false) {
+        return 'skip'
+      }
+      const agencyIds = [...new Set(
+        data.routes.map(r => r.agency?.id).filter((id): id is number => id != null),
+      )]
+      const body: BufferFetchConfig = {
+        radius: stopBufferRadius.value,
+        layer: stopBufferLayer.value,
+        geoDatasetName: geoDatasetName.value,
+        tableDatasetName: config.tableDatasetName ?? SCENARIO_DEFAULTS.tableDatasetName,
+        stopIds: data.stops.map(s => s.id),
+        routeIds: data.routes.map(r => r.id),
+        agencyIds,
+      }
+      return body
     },
-  )
-
-  return { scenarioReceiver }
+  })
 }

--- a/app/composables/useClusterRefetch.ts
+++ b/app/composables/useClusterRefetch.ts
@@ -7,7 +7,7 @@ import { useScenarioInputs } from './useScenarioInputs'
 import { useStreamingRefetch, type StreamingRefetchDeps } from './useStreamingRefetch'
 import type { FeedVersionRef, StopClusterFetchConfig } from '~~/src/scenario'
 
-// scenarioReceiver is created by useBufferRefetch and shared so refetched
+// scenarioReceiver is created by useScenarioRun and shared so refetched
 // clusters land in the same accumulator.
 export type UseClusterRefetchDeps = StreamingRefetchDeps
 

--- a/app/composables/useScenarioRun.ts
+++ b/app/composables/useScenarioRun.ts
@@ -1,0 +1,173 @@
+// The main scenario run lifecycle: streams a scenario from /api/scenario (or a
+// canned example JSON) into a ScenarioDataReceiver, tracks loading/progress
+// state for the modal, and derives the filtered result whenever the raw data or
+// filters change. Owns the run/loading state (and the shared receiver that the
+// buffer/cluster/aggregate refetch composables reuse); receives the data and
+// config refs from the container, which owns the scenario data graph.
+
+import { ref, shallowRef, watch, markRaw, type Ref, type ShallowRef } from 'vue'
+import { useToastNotification } from './useToastNotification'
+import {
+  ScenarioStreamReceiver,
+  ScenarioDataReceiver,
+  applyScenarioResultFilter,
+  type ScenarioConfig,
+  type ScenarioData,
+  type ScenarioFilter,
+  type ScenarioFilterResult,
+  type ScenarioPhaseName,
+  type ScenarioProgress,
+} from '~~/src/scenario'
+
+interface UseScenarioRunDeps {
+  // Owned by the container (the central data graph); written here as the stream
+  // accumulates and as filters change.
+  scenarioData: Ref<ScenarioData | undefined>
+  scenarioFilterResult: Ref<ScenarioFilterResult | undefined>
+  // Read-only inputs to the request body and the result filter.
+  scenarioConfig: Ref<ScenarioConfig>
+  scenarioFilter: Ref<ScenarioFilter>
+}
+
+export interface UseScenarioRunReturn {
+  // Live accumulator, shared with the refetch composables so incremental
+  // recomputes land in the same data. Reassigned on each fetch.
+  scenarioReceiver: ShallowRef<ScenarioDataReceiver | undefined>
+  loadingProgress: Ref<ScenarioProgress | undefined>
+  showLoadingModal: Ref<boolean>
+  error: Ref<Error | string | undefined>
+  // Weighted progress-bar state shared with the loading modal and refetches.
+  scenarioPhasePlan: Ref<ScenarioPhaseName[] | undefined>
+  scenarioPhaseFractions: Ref<Partial<Record<ScenarioPhaseName, number>>>
+  // Ref-counts concurrent refetches so the modal closes only when the last settles.
+  refetchInFlight: Ref<number>
+  stopDepartureCount: Ref<number>
+  // Streams a scenario; pass an example name to load canned JSON, '' for a live query.
+  fetchScenario: (loadExample: string) => Promise<void>
+}
+
+export function useScenarioRun (deps: UseScenarioRunDeps): UseScenarioRunReturn {
+  const loadingProgress = ref<ScenarioProgress>()
+  const stopDepartureCount = ref<number>(0)
+  // Weighted progress-bar state, accumulated inside the receiver callback so no
+  // events are missed (template-level watchers only sample the latest).
+  const scenarioPhasePlan = ref<ScenarioPhaseName[] | undefined>()
+  const scenarioPhaseFractions = ref<Partial<Record<ScenarioPhaseName, number>>>({})
+  const showLoadingModal = ref(false)
+  const refetchInFlight = ref(0)
+  const error = ref(undefined as Error | string | undefined)
+  const scenarioReceiver = shallowRef<ScenarioDataReceiver>()
+
+  const fetchScenario = async (loadExample: string): Promise<void> => {
+    const config = deps.scenarioConfig.value
+    if (!loadExample && !config.bbox && (!config.geographyIds || config.geographyIds.length === 0)) {
+      return // Need either bbox or geography IDs, unless loading example
+    }
+    loadingProgress.value = undefined
+    stopDepartureCount.value = 0
+    scenarioPhasePlan.value = undefined
+    scenarioPhaseFractions.value = {}
+
+    // Create receiver to accumulate scenario data
+    const receiver = new ScenarioDataReceiver({
+      onProgress: (progress: ScenarioProgress) => {
+        // Update progress for modal
+        loadingProgress.value = progress
+        stopDepartureCount.value += progress.partialData?.stopDepartures?.length || 0
+
+        // Weighted progress bar: plan announcement + per-phase fractions
+        // (clamped max-so-far; stop pagination grows its denominator mid-phase)
+        if (progress.phasePlan) {
+          scenarioPhasePlan.value = progress.phasePlan
+          scenarioPhaseFractions.value = {}
+        }
+        const pp = progress.phaseProgress
+        if (pp) {
+          const fraction = pp.total > 0 ? Math.min(pp.completed / pp.total, 1) : 0
+          if (fraction > (scenarioPhaseFractions.value[pp.phase] ?? 0)) {
+            scenarioPhaseFractions.value = { ...scenarioPhaseFractions.value, [pp.phase]: fraction }
+          }
+        }
+
+        if (progress.warnings && progress.warnings.length > 0) {
+          for (const msg of progress.warnings) {
+            useToastNotification().showToast(msg)
+          }
+        }
+
+        // Apply filters to partial data and emit (without schedule-dependent features)
+        // Skip if no route/stop/flex data in this progress update
+        const hasRoutes = (progress.partialData?.routes?.length || 0) > 0
+        const hasStops = (progress.partialData?.stops?.length || 0) > 0
+        const hasFlexAreas = (progress.partialData?.flexAreas?.length || 0) > 0
+        if (!hasRoutes && !hasStops && !hasFlexAreas) {
+          return
+        }
+        deps.scenarioData.value = markRaw(receiver.getCurrentData())
+      },
+      onComplete: () => {
+        // Get final accumulated data and apply filters
+        loadingProgress.value = undefined
+        deps.scenarioData.value = markRaw(receiver.getCurrentData())
+      },
+      onError: (err: any) => {
+        error.value = err
+      }
+    })
+    scenarioReceiver.value = receiver
+
+    let response: Response
+
+    if (loadExample) {
+      // Load example data from public JSON file
+      response = await fetch(`/examples/${loadExample}.json`)
+    } else {
+      // Make request to streaming scenario endpoint
+      response = await fetch('/api/scenario', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(config),
+      })
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+
+    if (!response.body) {
+      throw new Error('No response body received')
+    }
+
+    // Process the streaming response
+    const streamer = new ScenarioStreamReceiver()
+    const { success } = await streamer.processStream(response.body, receiver)
+    if (!success) {
+      error.value = new Error('Stream ended unexpectedly. The server may have run out of memory. Try a smaller region.')
+    }
+  }
+
+  // Apply filters and emit results when data or filters change
+  watch(() => [
+    deps.scenarioData.value,
+    deps.scenarioFilter.value,
+  ], () => {
+    if (!deps.scenarioData.value) {
+      return
+    }
+    deps.scenarioFilterResult.value = markRaw(
+      applyScenarioResultFilter(deps.scenarioData.value, deps.scenarioConfig.value, deps.scenarioFilter.value),
+    )
+  })
+
+  return {
+    scenarioReceiver,
+    loadingProgress,
+    showLoadingModal,
+    error,
+    scenarioPhasePlan,
+    scenarioPhaseFractions,
+    refetchInFlight,
+    stopDepartureCount,
+    fetchScenario,
+  }
+}

--- a/app/composables/useScenarioRun.ts
+++ b/app/composables/useScenarioRun.ts
@@ -64,6 +64,9 @@ export function useScenarioRun (deps: UseScenarioRunDeps): UseScenarioRunReturn 
       return // Need either bbox or geography IDs, unless loading example
     }
     loadingProgress.value = undefined
+    // Clear any error left by a prior run/refetch so a fresh run starts clean —
+    // otherwise the success path (gated on !error) stays suppressed.
+    error.value = undefined
     stopDepartureCount.value = 0
     scenarioPhasePlan.value = undefined
     scenarioPhaseFractions.value = {}

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -231,7 +231,7 @@ import {
   FILTER_EXPANDED_WIDTH,
 } from '~~/src/core'
 import { useToastNotification, useRouter } from '#imports'
-import { ScenarioStreamReceiver, applyScenarioResultFilter, getSelectedDateRange, type ScenarioConfig, type ScenarioData, type ScenarioFilter, type ScenarioFilterResult, type ScenarioPhaseName, ScenarioDataReceiver, type ScenarioProgress } from '~~/src/scenario'
+import { getSelectedDateRange, type ScenarioConfig, type ScenarioData, type ScenarioFilter, type ScenarioFilterResult } from '~~/src/scenario'
 
 // Initialize composables
 const { setQuery } = useUrlQuery()
@@ -328,8 +328,6 @@ const querySubmitted = ref(false)
 // new bbox value takes effect rather than the stale explicit bbox.
 watch(cannedBbox, () => { querySubmitted.value = false })
 
-const error = ref(undefined as Error | string | undefined)
-
 // Runs on explore event from query (when user clicks "Run Query")
 const runQuery = async () => {
   querySubmitted.value = true
@@ -347,16 +345,13 @@ const runQuery = async () => {
   loadingProgress.value = undefined
 }
 
-// Scenario data ref - defined early so flex computed properties can reference it
-// This is populated when fetchScenario runs
+// Scenario data ref - the central scenario data graph, populated by fetchScenario.
+// Defined early so it can be passed into the run / flex / refetch composables below.
 // shallowRef + markRaw: scenario data is huge and updated only by whole-shell
 // replacement (getCurrentData returns a fresh object per batch), so deep
 // proxying would add tracking overhead on every stop/route/departure read
 // without enabling anything.
 const scenarioData = shallowRef<ScenarioData>()
-
-// Flex areas filtering and styling (inline, similar to how fixed-route uses applyScenarioResultFilter)
-// Raw data comes from scenario stream via scenarioData.flexAreas
 
 // Agency filter items with metadata about service types
 // Uses raw scenarioData (not filtered scenarioFilterResult) so ALL agencies appear
@@ -848,19 +843,24 @@ const { choroplethClassification, choroplethFeatures } = useChoroplethClassifica
   selectedAggregationGeoid,
 })
 
-// Loading progress tracking for modal
-const loadingProgress = ref<ScenarioProgress>()
-const stopDepartureCount = ref<number>(0)
-// Weighted progress-bar state, accumulated inside the receiver callback so
-// no events are missed (template-level watchers only sample the latest).
-const scenarioPhasePlan = ref<ScenarioPhaseName[] | undefined>()
-const scenarioPhaseFractions = ref<Partial<Record<ScenarioPhaseName, number>>>({})
-const showLoadingModal = ref(false)
-// Ref-counted across the buffer/cluster/aggregate refetches so the loading modal
-// stays open until the last in-flight refetch settles (see useStreamingRefetch).
-const refetchInFlight = ref(0)
+// The scenario run lifecycle owns the loading/progress state, the streaming
+// fetch, and the shared receiver that the refetch composables reuse.
+const {
+  scenarioReceiver,
+  loadingProgress,
+  showLoadingModal,
+  error,
+  scenarioPhasePlan,
+  scenarioPhaseFractions,
+  refetchInFlight,
+  stopDepartureCount,
+  fetchScenario,
+} = useScenarioRun({ scenarioData, scenarioFilterResult, scenarioConfig, scenarioFilter })
 
-const { scenarioReceiver } = useBufferRefetch({
+// Debounced standalone recomputes that stream into the same receiver without
+// re-running the whole scenario.
+useBufferRefetch({
+  scenarioReceiver,
   scenarioData,
   scenarioConfig,
   loadingProgress,
@@ -902,107 +902,6 @@ const loadExampleData = async (exampleName: string) => {
   activeTab.value = { tab: 'map', sub: '' }
   fetchScenario(exampleName)
 }
-
-// Scenario fetching logic
-const fetchScenario = async (loadExample: string) => {
-  // console.log('fetchScenario:', loadExample)
-  const config = scenarioConfig.value
-  if (!loadExample && !config.bbox && (!config.geographyIds || config.geographyIds.length === 0)) {
-    return // Need either bbox or geography IDs, unless loading example
-  }
-  loadingProgress.value = undefined
-  stopDepartureCount.value = 0
-  scenarioPhasePlan.value = undefined
-  scenarioPhaseFractions.value = {}
-
-  // Create receiver to accumulate scenario data
-  const receiver = new ScenarioDataReceiver({
-    onProgress: (progress: ScenarioProgress) => {
-      // Update progress for modal
-      loadingProgress.value = progress
-      stopDepartureCount.value += progress.partialData?.stopDepartures?.length || 0
-
-      // Weighted progress bar: plan announcement + per-phase fractions
-      // (clamped max-so-far; stop pagination grows its denominator mid-phase)
-      if (progress.phasePlan) {
-        scenarioPhasePlan.value = progress.phasePlan
-        scenarioPhaseFractions.value = {}
-      }
-      const pp = progress.phaseProgress
-      if (pp) {
-        const fraction = pp.total > 0 ? Math.min(pp.completed / pp.total, 1) : 0
-        if (fraction > (scenarioPhaseFractions.value[pp.phase] ?? 0)) {
-          scenarioPhaseFractions.value = { ...scenarioPhaseFractions.value, [pp.phase]: fraction }
-        }
-      }
-
-      if (progress.warnings && progress.warnings.length > 0) {
-        for (const msg of progress.warnings) {
-          useToastNotification().showToast(msg)
-        }
-      }
-
-      // Apply filters to partial data and emit (without schedule-dependent features)
-      // Skip if no route/stop/flex data in this progress update
-      const hasRoutes = (progress.partialData?.routes?.length || 0) > 0
-      const hasStops = (progress.partialData?.stops?.length || 0) > 0
-      const hasFlexAreas = (progress.partialData?.flexAreas?.length || 0) > 0
-      if (!hasRoutes && !hasStops && !hasFlexAreas) {
-        return
-      }
-      scenarioData.value = markRaw(receiver.getCurrentData())
-    },
-    onComplete: () => {
-      // Get final accumulated data and apply filters
-      loadingProgress.value = undefined
-      scenarioData.value = markRaw(receiver.getCurrentData())
-    },
-    onError: (err: any) => {
-      error.value = err
-    }
-  })
-  scenarioReceiver.value = receiver
-
-  let response: Response
-
-  if (loadExample) {
-    // Load example data from public JSON file
-    response = await fetch(`/examples/${loadExample}.json`)
-  } else {
-    // Make request to streaming scenario endpoint
-    response = await fetch('/api/scenario', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(config),
-    })
-  }
-
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`)
-  }
-
-  if (!response.body) {
-    throw new Error('No response body received')
-  }
-
-  // Process the streaming response
-  const streamer = new ScenarioStreamReceiver()
-  const { success } = await streamer.processStream(response.body, receiver)
-  if (!success) {
-    error.value = new Error('Stream ended unexpectedly. The server may have run out of memory. Try a smaller region.')
-  }
-}
-
-// Apply filters and emit results when data or filters change
-watch(() => [
-  scenarioData.value,
-  scenarioFilter.value,
-], () => {
-  if (!scenarioData.value) {
-    return
-  }
-  scenarioFilterResult.value = markRaw(applyScenarioResultFilter(scenarioData.value, scenarioConfig.value, scenarioFilter.value))
-})
 
 /////////////////
 // Filter tags


### PR DESCRIPTION
## Summary

Extracts the main scenario run lifecycle out of `tne.vue` into a dedicated `useScenarioRun` composable, and consolidates ownership of the shared streaming receiver. This is part of the component-cleanup epic (#406, Item 5) — the highest-touch tne extraction, since the run lifecycle owns the fetch/stream/abort/progress/error state and interlocks with the existing buffer/cluster/aggregate refetch composables. The extraction is otherwise behavior-preserving (net −143 lines in `tne.vue`); it also folds in one small, intentional fix — clearing `error` at the start of each run (see Implementation details).

## User-facing changes

Essentially none — running a query or loading an example streams, shows progress, surfaces warnings/errors, and filters results exactly as before; the buffer/cluster/aggregate refetches continue to work unchanged. One small fix: after a run errors, a subsequent successful run now shows its success toast and closes the loading modal, where previously a stale error could suppress that.

## Implementation details

### New `useScenarioRun` composable

- Owns the cohesive run/loading slice: the shared `ScenarioDataReceiver` (`scenarioReceiver`), the loading/progress state (`loadingProgress`, `showLoadingModal`, `error`, `scenarioPhasePlan`, `scenarioPhaseFractions`, `refetchInFlight`, `stopDepartureCount`), the `fetchScenario` streaming function, and the `applyScenarioResultFilter` watch that derives the filtered result.
- Receives the scenario data graph (`scenarioData`, `scenarioFilterResult`) and the request inputs (`scenarioConfig`, `scenarioFilter`) from the container and writes into the data refs — the same pattern the refetch composables already use. `tne.vue` remains the composition root that owns the data graph.
- `fetchScenario` is moved near-verbatim: the receiver `onProgress`/`onComplete`/`onError` callbacks, the weighted per-phase progress accumulation, toast warnings, and the example-JSON-vs-live-endpoint fetch are unchanged.
- Clears `error` at the start of each run (alongside the existing progress/phase resets), fixing a latent bug: `error` was never reset anywhere, so once any run or refetch failed, the next successful run's success/close path (gated on `!error`) stayed suppressed.

### Shared receiver ownership

- Ownership of `scenarioReceiver` moves from `useBufferRefetch` to `useScenarioRun` (it is run state). `useBufferRefetch` no longer creates it — it receives it, collapsing to the same `StreamingRefetchDeps` / `void` shape as `useClusterRefetch` and `useAggregateRefetch`. The three refetch composables are now structurally uniform.
- Updated the "created by useBufferRefetch" comments in the cluster/aggregate composables to point at `useScenarioRun`.

### tne.vue

- Replaced the inline `fetchScenario`, the filter-derivation watch, the loading-state ref declarations, and the standalone `error` ref with a single `useScenarioRun(...)` call, wired ahead of the (otherwise unchanged) refetch composable calls so they share its receiver and loading state.
- `runQuery`, `loadExampleData`, and `clearScenario` stay in the page as thin orchestration — they touch page UI state (`activeTab`, `querySubmitted`, `exportFeatures`) and drive the composable's `fetchScenario`/`error`/`showLoadingModal`.
- Removed the now-unused `src/scenario` imports and tidied two stale comments that referenced moved code.

## User test plan

- Run a query (bbox and geography-IDs cases) and confirm the loading modal shows progress, the phase bar advances, and stop/route/flex features appear during streaming and finalize on completion.
- Confirm a successful run shows the success toast and closes the modal, and that a server error (e.g. a too-large region) surfaces the error state.
- Trigger an error (e.g. a too-large region), then run a valid query, and confirm the second run recovers normally (success toast, modal closes) rather than staying stuck on the prior error.
- Load a canned example and confirm it renders the same as before.
- After a scenario loads, change the stop statistical radius, the aggregate-by layer, and the stop-cluster distance, and confirm each standalone refetch still streams into the existing results (the rest of the scenario stays intact) and the loading modal stays open until concurrent refetches settle.
- Use the nav guard / reset path and confirm leaving `/tne` or resetting clears the scenario as before.

