### PR TITLE
Display headways as durations, not clock times (#368)

### DIFF
--- a/app/components/cal/hourly-departures-chart.vue
+++ b/app/components/cal/hourly-departures-chart.vue
@@ -58,11 +58,11 @@
       </div>
       <div v-if="totals.medianHeadway != null">
         <dt>Median headway:</dt>
-        <dd>{{ formatGtfsTimeFull(totals.medianHeadway) }}</dd>
+        <dd>{{ formatDuration(totals.medianHeadway) }}</dd>
       </div>
       <div v-if="totals.avgHeadway != null">
         <dt>Average headway:</dt>
-        <dd>{{ formatGtfsTimeFull(Math.round(totals.avgHeadway)) }}</dd>
+        <dd>{{ formatDuration(Math.round(totals.avgHeadway)) }}</dd>
       </div>
     </dl>
   </div>
@@ -71,7 +71,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { format } from 'date-fns'
-import { formatDuration, formatGtfsTimeFull } from '~~/src/core'
+import { formatDuration } from '~~/src/core'
 
 export interface ChartDeparture {
   serviceDate: string


### PR DESCRIPTION
## Summary
Median and average headway in the hourly-departures chart were rendered with `formatGtfsTimeFull` (clock-style HH:MM:SS), a format reserved for actual times of day. A headway is a duration, so values like a 9.5-minute headway displayed as `00:09:30` and could be misread as hours. This switches them to `formatDuration`, which renders humanized, self-labeling values like `9m 30s`. Follow-up polish to the frequency caveat work in #368.

## User-facing changes

### Frequency details
- Median headway and average headway now display as durations (e.g. `9m 30s`, `2h 45m`) instead of clock times (e.g. `00:09:30`), removing the ambiguity of HH:MM:SS being read as a time of day.

## Implementation details

### Headway formatting
- `app/components/cal/hourly-departures-chart.vue`: replace `formatGtfsTimeFull` with `formatDuration` for `totals.medianHeadway` and `totals.avgHeadway`; drop the now-unused `formatGtfsTimeFull` import.

## User test plan
- Open the hourly-departures / frequency details for a route and confirm Median headway and Average headway read as durations (e.g. `9m 30s`) rather than `00:09:30`.
- Check a route with a multi-hour headway and confirm it renders as e.g. `2h 45m`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
