### PR TITLE
useBboxEditor

### DIFF
--- a/app/components/cal/map.vue
+++ b/app/components/cal/map.vue
@@ -67,11 +67,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, toRaw, shallowRef, watch } from 'vue'
+import { ref, computed, toRaw, watch, toRef } from 'vue'
 import { useToggle } from '@vueuse/core'
 import { type CensusGeography, type Stop, stopToStopCsv, type Route, routeToRouteCsv } from '~~/src/tl'
-import type { Marker } from 'maplibre-gl'
-import type { Bbox, Feature, Point, PopupFeature, MarkerFeature, MarkerDragEvent, ChoroplethClassification, ClusterMemberInfo } from '~~/src/core'
+import type { Bbox, Feature, Point, PopupFeature, ChoroplethClassification, ClusterMemberInfo } from '~~/src/core'
 import { categoricalColors, routeTypeNames, flexColors, createCategoryColorScale } from '~~/src/core'
 import { buildStyleData, type Matcher, type ScenarioFilterResult, type StopCluster } from '~~/src/scenario'
 
@@ -138,259 +137,20 @@ watch(bbox, (newBbox, oldBbox) => {
   fitBoundsKey.value++
 }, { flush: 'sync' })
 
-interface CornerData {
-  marker?: Marker
-  element: HTMLElement
-  iconElement: HTMLElement
-  point: Point
+// Persist a user-drawn bbox, flagged map-originated so the external-change
+// watch above won't refit.
+function commitBbox (box: Bbox) {
+  bboxChangeFromMap = true
+  bbox.value = box
 }
 
-// They will be ordered clockwise:  ne, se, sw, nw
-let corners: CornerData[] = []
-
-// Arrow icon class for each compass corner, also ordered clockwise
-const cornerIcons = [
-  'mdi-arrow-top-right', //  ne
-  'mdi-arrow-bottom-right', //  se
-  'mdi-arrow-bottom-left', //  sw
-  'mdi-arrow-top-left' //  nw
-]
-
-// Track the bounding box shape during a drag.  This allows us to render
-// an updated shape, but only persist the final bbox state on dragend.
-const draggingBbox = ref<Bbox | null>(null)
-
-// Track which corner marker is actively being dragged (only one at a time)
-// null = no drag in progress, otherwise holds a reference to the marker being dragged
-const draggingMarker = shallowRef<Marker | null>(null)
-
-// Polygon for drawing bbox area
-const bboxArea = computed(() => {
-  const f: Feature[] = []
-  const activeBbox = draggingBbox.value || bbox.value
-  if (activeBbox.valid && (props.displayEditBboxMode || props.showBbox)) {
-    const p = activeBbox
-    const coords = [[
-      [p.sw.lon, p.sw.lat],
-      [p.sw.lon, p.ne.lat],
-      [p.ne.lon, p.ne.lat],
-      [p.ne.lon, p.sw.lat],
-      [p.sw.lon, p.sw.lat]
-    ]]
-    f.push({
-      id: 'bbox',
-      type: 'Feature',
-      properties: {
-        'fill-color': '#ccc',
-        'line-color': '#ff0000',
-      },
-      geometry: { type: 'Polygon', coordinates: coords }
-    })
-  }
-  return f
+// Interactive bbox editor: draggable corner markers, body-drag, and the drawn polygon.
+const { bboxArea, bboxMarkers, onOverlayDragStart, onOverlayDrag, onOverlayDragEnd } = useBboxEditor({
+  bbox,
+  displayEditBboxMode: toRef(props, 'displayEditBboxMode'),
+  showBbox: toRef(props, 'showBbox'),
+  commitBbox,
 })
-
-// Compute a normalized bbox from the current corner markers
-// Because the markers may be dragged, we need to check them.
-// This will also fix the corner icons too
-function getNormalizedBbox (): Bbox | null {
-  if (corners.length !== 4) { return null }
-  const copy = corners.slice() // make a copy
-
-  // Determine ranges
-  let minLon = Infinity
-  let minLat = Infinity
-  let maxLon = -Infinity
-  let maxLat = -Infinity
-
-  for (const corner of copy) {
-    const { lon, lat } = corner.point
-
-    if (lon < minLon) { minLon = lon }
-    if (lat < minLat) { minLat = lat }
-    if (lon > maxLon) { maxLon = lon }
-    if (lat > maxLat) { maxLat = lat }
-  }
-
-  const midLon = (minLon + maxLon) / 2
-  const midLat = (minLat + maxLat) / 2
-
-  // Reorder clockwise: ne, se, sw, nw
-  // Assign each corner to its quadrant based on position relative to center
-  for (const corner of copy) {
-    const isRight = corner.point.lon >= midLon
-    const isTop = corner.point.lat >= midLat
-    const idx = isTop ? (isRight ? 0 : 3) : (isRight ? 1 : 2)
-    corners[idx] = corner
-    corner.iconElement.className = `mdi ${cornerIcons[idx]}`
-  }
-
-  const sw = { lon: minLon, lat: minLat }
-  const ne = { lon: maxLon, lat: maxLat }
-  return { sw, ne, valid: true } as Bbox
-}
-
-// Bbox corner markers — recreated when edit mode toggles on/off or when the bbox prop changes.
-// Position updates during drag and after dragEnd are also handled imperatively
-const bboxMarkers = computed(() => {
-  const result: MarkerFeature[] = []
-
-  if (!props.displayEditBboxMode) {
-    return result
-  }
-
-  // Read bbox once for initial positions only (not tracked reactively after this)
-  const initialBbox = bbox.value
-
-  // Build the corners array, order as clockwise:  ne, se, sw, nw
-  corners = [
-    { point: { lon: initialBbox.ne.lon, lat: initialBbox.ne.lat } },
-    { point: { lon: initialBbox.ne.lon, lat: initialBbox.sw.lat } },
-    { point: { lon: initialBbox.sw.lon, lat: initialBbox.sw.lat } },
-    { point: { lon: initialBbox.sw.lon, lat: initialBbox.ne.lat } }
-  ] as CornerData[]
-
-  for (let i = 0; i < 4; i++) {
-    const corner = corners[i]!
-    const element = document.createElement('div')
-    corner.element = element
-    element.className = 'custom-marker'
-    const iconElement = document.createElement('i')
-    corner.iconElement = iconElement
-    iconElement.className = `mdi ${cornerIcons[i]}`
-    element.appendChild(iconElement)
-
-    result.push({
-      point: corner.point,
-      color: '#888',
-      draggable: true,
-      element,
-      onCreated: (marker: Marker) => {
-        // We can find the marker again by its element
-        const corner = corners.find(c => c.element === marker.getElement())
-        if (corner) {
-          corner.marker = marker
-        }
-      },
-      onDrag: (e: MarkerDragEvent) => {
-        if (corners.length !== 4) { return }
-        const marker = e.target
-        if (draggingMarker.value === null) {
-          draggingMarker.value = marker
-        } else if (draggingMarker.value !== e.target) {
-          return
-        }
-
-        // Update the point corresponding to this marker.
-        const { lng, lat } = marker.getLngLat()
-        const index = corners.findIndex(c => c.marker === marker)
-        if (index === -1) { return } // shouldn't happen
-        corners[index]!.point.lon = lng
-        corners[index]!.point.lat = lat
-
-        // When dragging a marker, we also need to move its neighbors.
-        // The marker at the opposite corner does not move.
-        const c0 = corners[0]!
-        const c1 = corners[1]!
-        const c2 = corners[2]!
-        const c3 = corners[3]!
-
-        if (index === 0) { // moving ne
-          c3.point.lat = lat
-          c3.marker?.setLngLat(c3.point)
-          c1.point.lon = lng
-          c1.marker?.setLngLat(c1.point)
-        } else if (index === 1) { // moving se
-          c0.point.lon = lng
-          c0.marker?.setLngLat(c0.point)
-          c2.point.lat = lat
-          c2.marker?.setLngLat(c2.point)
-        } else if (index === 2) { // moving sw
-          c1.point.lat = lat
-          c1.marker?.setLngLat(c1.point)
-          c3.point.lon = lng
-          c3.marker?.setLngLat(c3.point)
-        } else if (index === 3) { // moving nw
-          c2.point.lon = lng
-          c2.marker?.setLngLat(c2.point)
-          c0.point.lat = lat
-          c0.marker?.setLngLat(c0.point)
-        }
-
-        // Dragging a corner may cause the box to flip, so we renormalize it
-        const box = getNormalizedBbox()
-        if (box) {
-          draggingBbox.value = box
-        }
-      },
-      onDragEnd: (e: MarkerDragEvent) => {
-        if (draggingMarker.value !== null && draggingMarker.value !== e.target) {
-          return
-        }
-
-        const box = getNormalizedBbox()
-        draggingMarker.value = null
-        draggingBbox.value = null
-        if (box) {
-          bboxChangeFromMap = true
-          bbox.value = box
-        }
-      }
-    })
-  }
-
-  return result
-})
-
-// Clear marker refs when edit mode is turned off (markers will be removed by drawBboxMarkers)
-watch(() => props.displayEditBboxMode, (editing) => {
-  if (!editing) {
-    corners = []
-    draggingMarker.value = null
-    bboxBodyDragStart = null
-    bboxBodyCornerStarts = []
-  }
-})
-
-// --- Bbox body drag: move entire bbox by dragging its interior ---
-let bboxBodyDragStart: Point | null = null
-let bboxBodyCornerStarts: Point[] = []
-
-function onOverlayDragStart (startPoint: Point) {
-  if (corners.length !== 4) { return }
-  bboxBodyDragStart = startPoint
-  bboxBodyCornerStarts = corners.map(c => ({ lon: c.point.lon, lat: c.point.lat }))
-}
-
-function onOverlayDrag (currentPoint: Point) {
-  if (!bboxBodyDragStart || bboxBodyCornerStarts.length !== 4) { return }
-
-  const deltaLon = currentPoint.lon - bboxBodyDragStart.lon
-  const deltaLat = currentPoint.lat - bboxBodyDragStart.lat
-
-  for (let i = 0; i < 4; i++) {
-    corners[i]!.point.lon = bboxBodyCornerStarts[i]!.lon + deltaLon
-    corners[i]!.point.lat = bboxBodyCornerStarts[i]!.lat + deltaLat
-    corners[i]!.marker?.setLngLat(corners[i]!.point)
-  }
-
-  const box = getNormalizedBbox()
-  if (box) {
-    draggingBbox.value = box
-  }
-}
-
-function onOverlayDragEnd () {
-  const box = getNormalizedBbox()
-  bboxBodyDragStart = null
-  bboxBodyCornerStarts = []
-  draggingBbox.value = null
-
-  if (box) {
-    bboxChangeFromMap = true
-    bbox.value = box
-  }
-}
 
 // Lookup for stop features
 // This is necessary because the geojson properties are stringified

--- a/app/composables/useBboxEditor.ts
+++ b/app/composables/useBboxEditor.ts
@@ -1,0 +1,285 @@
+// Interactive bbox editor for the scenario map: the draggable corner markers,
+// the body-drag to move the whole box, and the polygon drawn while editing.
+
+import { ref, computed, shallowRef, watch, type Ref, type ComputedRef } from 'vue'
+import type { Marker } from 'maplibre-gl'
+import type { Bbox, Feature, Point, MarkerFeature, MarkerDragEvent } from '~~/src/core'
+
+interface UseBboxEditorDeps {
+  // Bbox being edited.
+  bbox: Ref<Bbox>
+  // Edit mode (draggable markers) vs. read-only outline.
+  displayEditBboxMode: Ref<boolean | undefined>
+  showBbox: Ref<boolean | undefined>
+  // Persist a user-drawn bbox.
+  commitBbox: (box: Bbox) => void
+}
+
+export interface UseBboxEditorReturn {
+  // Polygon feature(s) for the box outline.
+  bboxArea: ComputedRef<Feature[]>
+  // Draggable corner markers.
+  bboxMarkers: ComputedRef<MarkerFeature[]>
+  // Body-drag handlers to move the whole box.
+  onOverlayDragStart: (startPoint: Point) => void
+  onOverlayDrag: (currentPoint: Point) => void
+  onOverlayDragEnd: () => void
+}
+
+interface CornerData {
+  marker?: Marker
+  element: HTMLElement
+  iconElement: HTMLElement
+  point: Point
+}
+
+export function useBboxEditor (deps: UseBboxEditorDeps): UseBboxEditorReturn {
+  const { bbox, displayEditBboxMode, showBbox, commitBbox } = deps
+
+  // They will be ordered clockwise:  ne, se, sw, nw
+  let corners: CornerData[] = []
+
+  // Arrow icon class for each compass corner, also ordered clockwise
+  const cornerIcons = [
+    'mdi-arrow-top-right', //  ne
+    'mdi-arrow-bottom-right', //  se
+    'mdi-arrow-bottom-left', //  sw
+    'mdi-arrow-top-left' //  nw
+  ]
+
+  // Track the bounding box shape during a drag.  This allows us to render
+  // an updated shape, but only persist the final bbox state on dragend.
+  const draggingBbox = ref<Bbox | null>(null)
+
+  // Track which corner marker is actively being dragged (only one at a time)
+  // null = no drag in progress, otherwise holds a reference to the marker being dragged
+  const draggingMarker = shallowRef<Marker | null>(null)
+
+  // Polygon for drawing bbox area
+  const bboxArea = computed(() => {
+    const f: Feature[] = []
+    const activeBbox = draggingBbox.value || bbox.value
+    if (activeBbox.valid && (displayEditBboxMode.value || showBbox.value)) {
+      const p = activeBbox
+      const coords = [[
+        [p.sw.lon, p.sw.lat],
+        [p.sw.lon, p.ne.lat],
+        [p.ne.lon, p.ne.lat],
+        [p.ne.lon, p.sw.lat],
+        [p.sw.lon, p.sw.lat]
+      ]]
+      f.push({
+        id: 'bbox',
+        type: 'Feature',
+        properties: {
+          'fill-color': '#ccc',
+          'line-color': '#ff0000',
+        },
+        geometry: { type: 'Polygon', coordinates: coords }
+      })
+    }
+    return f
+  })
+
+  // Compute a normalized bbox from the current corner markers
+  // Because the markers may be dragged, we need to check them.
+  // This will also fix the corner icons too
+  function getNormalizedBbox (): Bbox | null {
+    if (corners.length !== 4) { return null }
+    const copy = corners.slice() // make a copy
+
+    // Determine ranges
+    let minLon = Infinity
+    let minLat = Infinity
+    let maxLon = -Infinity
+    let maxLat = -Infinity
+
+    for (const corner of copy) {
+      const { lon, lat } = corner.point
+
+      if (lon < minLon) { minLon = lon }
+      if (lat < minLat) { minLat = lat }
+      if (lon > maxLon) { maxLon = lon }
+      if (lat > maxLat) { maxLat = lat }
+    }
+
+    const midLon = (minLon + maxLon) / 2
+    const midLat = (minLat + maxLat) / 2
+
+    // Reorder clockwise: ne, se, sw, nw
+    // Assign each corner to its quadrant based on position relative to center
+    for (const corner of copy) {
+      const isRight = corner.point.lon >= midLon
+      const isTop = corner.point.lat >= midLat
+      const idx = isTop ? (isRight ? 0 : 3) : (isRight ? 1 : 2)
+      corners[idx] = corner
+      corner.iconElement.className = `mdi ${cornerIcons[idx]}`
+    }
+
+    const sw = { lon: minLon, lat: minLat }
+    const ne = { lon: maxLon, lat: maxLat }
+    return { sw, ne, valid: true } as Bbox
+  }
+
+  // Bbox corner markers — recreated when edit mode toggles on/off or when the bbox prop changes.
+  // Position updates during drag and after dragEnd are also handled imperatively
+  const bboxMarkers = computed(() => {
+    const result: MarkerFeature[] = []
+
+    if (!displayEditBboxMode.value) {
+      return result
+    }
+
+    // Read bbox once for initial positions only (not tracked reactively after this)
+    const initialBbox = bbox.value
+
+    // Build the corners array, order as clockwise:  ne, se, sw, nw
+    corners = [
+      { point: { lon: initialBbox.ne.lon, lat: initialBbox.ne.lat } },
+      { point: { lon: initialBbox.ne.lon, lat: initialBbox.sw.lat } },
+      { point: { lon: initialBbox.sw.lon, lat: initialBbox.sw.lat } },
+      { point: { lon: initialBbox.sw.lon, lat: initialBbox.ne.lat } }
+    ] as CornerData[]
+
+    for (let i = 0; i < 4; i++) {
+      const corner = corners[i]!
+      const element = document.createElement('div')
+      corner.element = element
+      element.className = 'custom-marker'
+      const iconElement = document.createElement('i')
+      corner.iconElement = iconElement
+      iconElement.className = `mdi ${cornerIcons[i]}`
+      element.appendChild(iconElement)
+
+      result.push({
+        point: corner.point,
+        color: '#888',
+        draggable: true,
+        element,
+        onCreated: (marker: Marker) => {
+          // We can find the marker again by its element
+          const corner = corners.find(c => c.element === marker.getElement())
+          if (corner) {
+            corner.marker = marker
+          }
+        },
+        onDrag: (e: MarkerDragEvent) => {
+          if (corners.length !== 4) { return }
+          const marker = e.target
+          if (draggingMarker.value === null) {
+            draggingMarker.value = marker
+          } else if (draggingMarker.value !== e.target) {
+            return
+          }
+
+          // Update the point corresponding to this marker.
+          const { lng, lat } = marker.getLngLat()
+          const index = corners.findIndex(c => c.marker === marker)
+          if (index === -1) { return } // shouldn't happen
+          corners[index]!.point.lon = lng
+          corners[index]!.point.lat = lat
+
+          // When dragging a marker, we also need to move its neighbors.
+          // The marker at the opposite corner does not move.
+          const c0 = corners[0]!
+          const c1 = corners[1]!
+          const c2 = corners[2]!
+          const c3 = corners[3]!
+
+          if (index === 0) { // moving ne
+            c3.point.lat = lat
+            c3.marker?.setLngLat(c3.point)
+            c1.point.lon = lng
+            c1.marker?.setLngLat(c1.point)
+          } else if (index === 1) { // moving se
+            c0.point.lon = lng
+            c0.marker?.setLngLat(c0.point)
+            c2.point.lat = lat
+            c2.marker?.setLngLat(c2.point)
+          } else if (index === 2) { // moving sw
+            c1.point.lat = lat
+            c1.marker?.setLngLat(c1.point)
+            c3.point.lon = lng
+            c3.marker?.setLngLat(c3.point)
+          } else if (index === 3) { // moving nw
+            c2.point.lon = lng
+            c2.marker?.setLngLat(c2.point)
+            c0.point.lat = lat
+            c0.marker?.setLngLat(c0.point)
+          }
+
+          // Dragging a corner may cause the box to flip, so we renormalize it
+          const box = getNormalizedBbox()
+          if (box) {
+            draggingBbox.value = box
+          }
+        },
+        onDragEnd: (e: MarkerDragEvent) => {
+          if (draggingMarker.value !== null && draggingMarker.value !== e.target) {
+            return
+          }
+
+          const box = getNormalizedBbox()
+          draggingMarker.value = null
+          draggingBbox.value = null
+          if (box) {
+            commitBbox(box)
+          }
+        }
+      })
+    }
+
+    return result
+  })
+
+  // Clear marker refs when edit mode is turned off (markers will be removed by drawBboxMarkers)
+  watch(displayEditBboxMode, (editing) => {
+    if (!editing) {
+      corners = []
+      draggingMarker.value = null
+      bboxBodyDragStart = null
+      bboxBodyCornerStarts = []
+    }
+  })
+
+  // --- Bbox body drag: move entire bbox by dragging its interior ---
+  let bboxBodyDragStart: Point | null = null
+  let bboxBodyCornerStarts: Point[] = []
+
+  function onOverlayDragStart (startPoint: Point) {
+    if (corners.length !== 4) { return }
+    bboxBodyDragStart = startPoint
+    bboxBodyCornerStarts = corners.map(c => ({ lon: c.point.lon, lat: c.point.lat }))
+  }
+
+  function onOverlayDrag (currentPoint: Point) {
+    if (!bboxBodyDragStart || bboxBodyCornerStarts.length !== 4) { return }
+
+    const deltaLon = currentPoint.lon - bboxBodyDragStart.lon
+    const deltaLat = currentPoint.lat - bboxBodyDragStart.lat
+
+    for (let i = 0; i < 4; i++) {
+      corners[i]!.point.lon = bboxBodyCornerStarts[i]!.lon + deltaLon
+      corners[i]!.point.lat = bboxBodyCornerStarts[i]!.lat + deltaLat
+      corners[i]!.marker?.setLngLat(corners[i]!.point)
+    }
+
+    const box = getNormalizedBbox()
+    if (box) {
+      draggingBbox.value = box
+    }
+  }
+
+  function onOverlayDragEnd () {
+    const box = getNormalizedBbox()
+    bboxBodyDragStart = null
+    bboxBodyCornerStarts = []
+    draggingBbox.value = null
+
+    if (box) {
+      commitBbox(box)
+    }
+  }
+
+  return { bboxArea, bboxMarkers, onOverlayDragStart, onOverlayDrag, onOverlayDragEnd }
+}


### PR DESCRIPTION
## Summary

Behavior-preserving refactor that extracts the scenario map's bbox-editing interaction out of `map.vue` into a new `useBboxEditor` composable. This is the first piece of the "map internals" cleanup tracked in #406 (Item 8). `map.vue` drops from 1212 to 973 lines; no runtime behavior changes.

## User-facing changes

None. This is an internal refactor — the Edit-bbox interaction (draggable corner markers, drag-to-move, the drawn outline) behaves exactly as before.

## Implementation details

### New `useBboxEditor` composable

Moved the entire bbox-editing block out of `map.vue` into `app/composables/useBboxEditor.ts`: the clockwise corner-marker DOM construction, `getNormalizedBbox` (which also reorients the corner arrow icons as the box flips), the corner-drag and body-drag handlers, the `draggingBbox`/`draggingMarker` interaction state, and the `bboxArea` polygon drawn while editing. The composable takes `bbox`, `displayEditBboxMode`, `showBbox`, and a `commitBbox` callback, and returns `bboxArea`, `bboxMarkers`, and the three `onOverlayDrag*` handlers.

### Fit-coordination stays in `map.vue`

The map-originated-change flag (`bboxChangeFromMap`), `fitBoundsKey`, and the external-bbox watch remain in `map.vue` because the pan/zoom path (`mapMove`) shares that same flag — pulling it into the editor would put it out of reach of the viewport-sync logic. Instead, the composable persists a user-drawn bbox by calling the `commitBbox` callback, and `map.vue`'s `commitBbox` sets the flag before writing the URL-backed bbox. So the editor owns the interaction; `map.vue` keeps the one line that suppresses the refit.

### Import cleanup

`map.vue` no longer needs the `maplibre-gl` `Marker` type or the `MarkerFeature`/`MarkerDragEvent` core types (they moved with the editor); it gains `toRef` to pass the two display-mode props into the composable as refs.

## User test plan

- Enable Edit bbox mode and drag a corner marker, including dragging it past the opposite edge so the box flips — confirm the box renormalizes and the corner arrow icons reorient correctly.
- Drag the box interior to move the whole box; confirm it follows the cursor and persists on release.
- After committing a map-drawn bbox (corner or body drag), confirm the map does not jump or refit to the new box; then trigger an external bbox change (e.g. pick a canned area) and confirm the map does refit.
- Toggle the non-edit "show bbox" outline and confirm it renders without draggable markers.
