### PR TITLE
Fix flex popup pagination for overlapping zones (#421)

### DIFF
--- a/app/components/cal/map.vue
+++ b/app/components/cal/map.vue
@@ -760,12 +760,18 @@ function mapClickFeatures (pt: any, features: Feature[]) {
       continue
     }
 
-    // Only dedupe if we have a valid ID (skip deduplication for empty IDs)
-    if (featureId && seenIds.has(featureId)) {
+    // Dedupe by a stable key. MapLibre coerces non-numeric GeoJSON string ids to
+    // NaN in queryRenderedFeatures, so flex polygons all report the same id and
+    // every overlapping zone but the first would be dropped (#421); key flex on
+    // its feed+location id instead. Other layers keep feature.id. Empty keys skip
+    // dedupe.
+    const isFlexPolygon = (ft === 'Polygon' || ft === 'MultiPolygon') && fp.location_id
+    const dedupeKey = isFlexPolygon ? `flex:${fp.feed_onestop_id}:${fp.location_id}` : featureId
+    if (dedupeKey && seenIds.has(dedupeKey)) {
       continue // Skip duplicate
     }
-    if (featureId) {
-      seenIds.add(featureId)
+    if (dedupeKey) {
+      seenIds.add(dedupeKey)
     }
 
     let popupFeature: PopupFeature | undefined = undefined


### PR DESCRIPTION
## Summary

Fixes #421 (reported by Thomas). On staging, clicking a point covered by several overlapping GTFS-Flex / demand-response service zones showed only one zone in the identify popup instead of a paginated list of all of them. The regression arrived with the MapLibre GL 5.24.0 upgrade (#400): the map-click dedupe keyed on `feature.id`, and MapLibre now coerces non-numeric GeoJSON string ids to `NaN` in `queryRenderedFeatures` results, so every flex feature reported the same id and all but the first overlapping zone was discarded as a duplicate.

## User-facing changes

- Clicking where multiple flex service areas overlap again shows every area as its own page in the popup pager, matching production behavior.
- No change to stop, route, cluster, or aggregation-area popups.

## Implementation details

- Flex feature ids are built as `${feed_onestop_id}:${location_id}` — a non-numeric string. Under MapLibre 5.24.0 the `flexPolygons` GeoJSON source (which sets no `promoteId`) returns these as `feature.id = NaN` from `queryRenderedFeatures`, so `feature.id.toString()` is `"NaN"` for every flex feature and the dedupe `Set` collapsed them all to one popup page. Under the previous 5.2.0 the same string id came back as `undefined`, which the dedupe treated as an empty key and skipped — which is why production was unaffected.
- `mapClickFeatures` now derives a per-feature dedupe key: flex polygons key on `flex:${feed_onestop_id}:${location_id}` (the same globally-unique pair the feature id is built from), while every other layer keeps using `feature.id` (still valid for their numeric and `promoteId`-promoted ids).
- The change is localized to the click handler; the flex source config, feature construction, and rendering are untouched.

## User test plan

- On the flex repro (`geomSource=adminBoundary`, `geomLayer=county`, flex enabled, fixed-route disabled), click a point where several demand-response zones overlap and confirm the popup pager steps through all of them ("1 of N"), not just one.
- Confirm stop and route popups still open, and that clicking a single (non-overlapping) flex area still shows exactly one page.
- Click an aggregation (census) area and confirm the row-select behavior is unchanged.
