### PR TITLE
Remove the frontend feed bbox denylist now that geohash filtering is live (#376)

### DIFF
--- a/app/components/cal/feed-version-picker.vue
+++ b/app/components/cal/feed-version-picker.vue
@@ -55,7 +55,6 @@ import {
   pinnedFeedVersionsQuery,
   serializeFvids,
   type FeedVersionDetailWithFeed,
-  HIDDEN_FEED_ONESTOP_IDS,
   DEPRIORITIZED_FEED_ONESTOP_IDS,
   watchJob,
   jobApiPath,
@@ -184,12 +183,7 @@ const { result, loading, error, refetch } = useQuery<{ feeds: FeedWithVersions[]
 const feeds = computed<FeedWithVersions[]>(() => result.value?.feeds || [])
 
 watch(feeds, (fs) => {
-  const ids: string[] = []
-  for (const f of fs) {
-    if (HIDDEN_FEED_ONESTOP_IDS.has(f.onestop_id)) { continue }
-    ids.push(f.onestop_id)
-  }
-  emit('update:feedOnestopIds', ids)
+  emit('update:feedOnestopIds', fs.map(f => f.onestop_id))
 }, { immediate: true })
 
 // Explicitly-pinned versions are fetched by id so the user's current selection
@@ -225,7 +219,6 @@ const visibleFeeds = computed<FeedWithVersions[]>(() => {
 
   const decorated: { feed: FeedWithVersions, sortKey: number, demoted: boolean }[] = []
   for (const f of feeds.value) {
-    if (HIDDEN_FEED_ONESTOP_IDS.has(f.onestop_id)) { continue }
     const activeId = f.feed_state?.feed_version?.id ?? null
     const kept = f.feed_versions.filter(fv =>
       fv.id === activeId || feedVersionHasServiceInRange(fv.service_levels, startIso, endIso)

--- a/src/scenario/phases/feed-versions.ts
+++ b/src/scenario/phases/feed-versions.ts
@@ -9,7 +9,6 @@ import {
   applyFeedVersionOverrides,
   feedVersionQuery,
   feedVersionsByIdsQuery,
-  HIDDEN_FEED_ONESTOP_IDS,
   type FeedGql,
   type FeedVersion,
 } from '~~/src/tl'
@@ -173,12 +172,7 @@ export async function runFeedVersionsPhase (
     const variables = { where: { bbox: bboxForQuery }, limit: FEED_VERSION_PAGE_SIZE, after }
     const response = await client.query<{ feeds: FeedGql[] }>(feedVersionQuery, variables)
     const page = response.data?.feeds || []
-    // Drop feeds with known-broken bbox metadata so they don't poison
-    // every other bbox query with their over-broad coverage claim.
-    for (const f of page) {
-      if (HIDDEN_FEED_ONESTOP_IDS.has(f.onestop_id)) { continue }
-      allFeeds.push(f)
-    }
+    allFeeds.push(...page)
     if (page.length < FEED_VERSION_PAGE_SIZE) {
       break
     }

--- a/src/tl/feed-version.ts
+++ b/src/tl/feed-version.ts
@@ -35,14 +35,6 @@ export interface FeedGql {
   } | null
 }
 
-// Hardcoded denylist of feeds with broken bbox metadata that pollute
-// otherwise-unrelated bbox queries (their reported geometry covers far more
-// area than the actual service). Apply this in any flow that consumes the
-// bbox-feeds query — picker and scenario fetcher — so users never see them.
-export const HIDDEN_FEED_ONESTOP_IDS: ReadonlySet<string> = new Set([
-  'f-r6-nswtrainlink~sydneytrains~buswayswesternsydney~interlinebus',
-])
-
 // Intercity / charter feeds that match many bboxes but rarely match user
 // intent. Sorted last in the picker so they don't crowd local agencies.
 export const DEPRIORITIZED_FEED_ONESTOP_IDS: ReadonlySet<string> = new Set([


### PR DESCRIPTION
## Summary

Removes the hardcoded `HIDDEN_FEED_ONESTOP_IDS` frontend denylist and its two consumers, now that the backend geohash-based feed-version bbox filter excludes broken-bbox feeds server-side. The denylist was a stopgap for feeds whose reported convex-hull geometry covers far more area than their real service, so they polluted unrelated bbox queries; the backend now filters those out directly. This is the final code cleanup tracked in #376 (backend implementation: interline-io/transitland-lib#622, merged and deployed).

## User-facing changes

None visible. The one denied feed (the Sydney NSW TrainLink convex-hull feed) is still excluded from bbox results — it's now filtered upstream by the backend geohash filter instead of skipped on the client.

## Implementation details

- Deleted `HIDDEN_FEED_ONESTOP_IDS` (and its comment) from `src/tl/feed-version.ts`. The unrelated `DEPRIORITIZED_FEED_ONESTOP_IDS` picker-sort list is untouched.
- `feed-version-picker.vue`: dropped the import and both skip-guards; the `update:feedOnestopIds` watch now maps onestop ids directly, and the `visibleFeeds` loop no longer filters.
- `src/scenario/phases/feed-versions.ts` (scenario fetcher): dropped the import and the per-page skip-guard; the paging loop now appends the whole page (page size 100), and the now-stale "drop broken-bbox feeds" comment is gone.

## User test plan

- In the feed-version picker, browse a bbox that previously surfaced the denied feed (Sydney NSW TrainLink) and confirm it no longer appears — now excluded by the backend filter rather than the frontend skip.
- Run a scenario over the same bbox and confirm the feed is absent from results while normal feeds in the area still load.
- Confirm picker ordering still deprioritizes the intercity/charter feeds (Flixbus, Amtrak charter) as before.
