### PR TITLE
Accessible datagrid filtering and sorting for screen-reader users

### DIFF
--- a/app/components/cal/datagrid.vue
+++ b/app/components/cal/datagrid.vue
@@ -2,7 +2,12 @@
   <div class="mb-6">
     <div class="is-flex is-align-items-center mb-4" style="gap: 0.5rem;">
       <!-- Search landmark so screen-reader users can jump to the table filter;
-           labelled (via filterLabel) to distinguish it from other filters. -->
+           labelled (via filterLabel) to distinguish it from other filters.
+           Landmarks of the same role must be uniquely labelled when more than
+           one is exposed at once. Views with several datagrids only ever show
+           one — cat-tabs uses v-show (display:none drops it from the
+           accessibility tree) and census-details uses v-if — so keep that
+           invariant if a layout ever puts two datagrids side by side. -->
       <div class="cal-datagrid-filter" role="search" :aria-label="filterLabel">
         <!-- ariaLabel/aria-controls passed via a v-bind object: cat-search-bar
              sets inheritAttrs:false, so vue-tsc checks attributes against its
@@ -11,7 +16,7 @@
              (which vue-tsc then couldn't map back to the prop). -->
         <cat-search-bar
           v-model="searchQuery"
-          placeholder="Search..."
+          :placeholder="FILTER_PLACEHOLDER"
           v-bind="{ 'ariaLabel': filterLabel, 'aria-controls': tableId }"
         >
           <!-- Announced politely to screen readers as the filter changes. -->
@@ -45,7 +50,7 @@
               :key="column.key"
               scope="col"
               :class="{ 'is-sortable-th': column.sortable, 'is-sorted': sortKey === column.key }"
-              :aria-sort="column.sortable ? ariaSort(column) : undefined"
+              :aria-sort="ariaSort(column)"
             >
               <!-- Sortable columns render the header as a real <button> so
                    sorting is keyboard-operable (Enter/Space) and announced as a
@@ -174,6 +179,12 @@ const props = defineProps<{
   // readers announce the table's purpose; sighted users still see surrounding
   // heading/tab UI for context.
   caption?: string
+  // Short name for what this grid holds ("Routes", "Stops"), used to
+  // distinguish this filter from others on the page. Deliberately not derived
+  // from `caption`: a caption describes the whole table and may carry a date
+  // range, which makes for a long name that is re-read on every focus and
+  // changes whenever the range does.
+  filterLabel?: string
 }>()
 
 // cat-search-bar clears to null (not ''), so the model is nullable.
@@ -184,15 +195,22 @@ const sortDir = ref<'asc' | 'desc' | null>(null)
 // SSR-stable id so the filter's aria-controls can point at this table.
 const tableId = useId()
 
-// Accessible name for the filter (search fields have no visible label).
+// Accessible name for the filter (search fields have no visible label). The
+// placeholder is the field's only visible text, so the name must contain it
+// verbatim — otherwise a speech-input user who says what they see gets no
+// match (WCAG 2.5.3 Label in Name).
+const FILTER_PLACEHOLDER = 'Filter rows'
 const filterLabel = computed(() =>
-  props.caption ? `Filter ${props.caption}` : 'Filter table rows')
+  props.filterLabel ? `${FILTER_PLACEHOLDER} in ${props.filterLabel}` : FILTER_PLACEHOLDER)
 
-// aria-sort value for a sortable column's <th>, reflecting the current sort so
-// screen readers announce the direction (WCAG 4.1.2).
-function ariaSort (column: TableColumn): 'ascending' | 'descending' | 'none' {
+// aria-sort for the <th> of the column that is currently sorted, so screen
+// readers announce the direction (WCAG 4.1.2). Set only on the active column,
+// per the APG sortable-table pattern — an explicit "none" on every sortable
+// header makes screen readers announce "not sorted" column by column, which on
+// a wide census table is pure noise.
+function ariaSort (column: TableColumn): 'ascending' | 'descending' | undefined {
   if (sortKey.value !== column.key || !sortDir.value) {
-    return 'none'
+    return undefined
   }
   return sortDir.value === 'asc' ? 'ascending' : 'descending'
 }
@@ -338,20 +356,26 @@ const rangeEnd = computed(() => {
 
 // Screen-reader announcement of the filter's effect, fed into cat-search-bar's
 // polite live region (its #status slot) so filtering has audible feedback.
-const totalRowCount = computed(() => tableReport.value?.data?.length ?? 0)
+//
+// Empty unless a filter is actually applied, for two reasons. The live region
+// must start empty: this component remounts on every tab switch, and a region
+// inserted with content already in it gets read out immediately. And a status
+// message reports the outcome of a user action (WCAG 4.1.3) — row counts that
+// move because the scenario re-ran or the user changed report sub-tabs are not
+// the outcome of a search, and announcing them from inside the search landmark
+// misattributes them to the filter.
 const filterStatus = computed(() => {
-  const all = totalRowCount.value
-  if (all === 0) {
+  // Trimmed to match filteredData, so a whitespace-only query (which filters
+  // nothing) stays silent rather than claiming "Showing N of N".
+  if (!(searchQuery.value || '').trim()) {
     return ''
-  }
-  if (!searchQuery.value) {
-    return `Showing all ${all} ${all === 1 ? 'row' : 'rows'}`
   }
   const shown = total.value
   if (shown === 0) {
     return 'No rows match the filter'
   }
-  return `Showing ${shown} of ${all} rows`
+  const all = tableReport.value?.data?.length ?? 0
+  return `Showing ${shown} of ${all} ${all === 1 ? 'row' : 'rows'}`
 })
 </script>
 
@@ -399,14 +423,17 @@ const filterStatus = computed(() => {
     }
 
     // Sortable header rendered as a button. Reset to look like plain header
-    // text, but fill the cell so the whole header stays a click target.
+    // text, but carry the cell's own padding (see .is-sortable-th below) so the
+    // button fills the header rather than shrinking the target to the label's
+    // line box — which would leave a ring that still shows the pointer cursor
+    // and hover highlight but no longer sorts.
     .cal-datagrid-sort-button {
       display: flex;
       align-items: center;
       gap: 0.25rem;
       width: 100%;
       margin: 0;
-      padding: 0;
+      padding: 0.5rem 0.75rem;
       border: none;
       background: transparent;
       font: inherit;
@@ -437,6 +464,9 @@ const filterStatus = computed(() => {
     }
 
     &.is-sortable-th {
+      // Padding lives on the inner button instead, so the padded area is part
+      // of the click target and matches the pointer/hover affordance below.
+      padding: 0;
       cursor: pointer;
       user-select: none;
 

--- a/app/components/cal/datagrid.vue
+++ b/app/components/cal/datagrid.vue
@@ -1,12 +1,25 @@
 <template>
   <div class="mb-6">
     <div class="is-flex is-align-items-center mb-4" style="gap: 0.5rem;">
-      <cat-input
-        v-model="searchQuery"
-        type="search"
-        placeholder="Search..."
-        icon="magnify"
-      />
+      <!-- Search landmark so screen-reader users can jump to the table filter;
+           labelled (via filterLabel) to distinguish it from other filters. -->
+      <div class="cal-datagrid-filter" role="search" :aria-label="filterLabel">
+        <!-- ariaLabel/aria-controls passed via a v-bind object: cat-search-bar
+             sets inheritAttrs:false, so vue-tsc checks attributes against its
+             declared props and rejects a plain :aria-controls; the object also
+             keeps vue/attribute-hyphenation from rewriting ariaLabel to kebab
+             (which vue-tsc then couldn't map back to the prop). -->
+        <cat-search-bar
+          v-model="searchQuery"
+          placeholder="Search..."
+          v-bind="{ 'ariaLabel': filterLabel, 'aria-controls': tableId }"
+        >
+          <!-- Announced politely to screen readers as the filter changes. -->
+          <template #status>
+            {{ filterStatus }}
+          </template>
+        </cat-search-bar>
+      </div>
 
       <!-- Slot for additional download buttons, such as GeoJSON -->
       <slot name="additional-downloads" :data="tableReport.data" :loading="loading" />
@@ -21,7 +34,7 @@
     </div>
 
     <div class="table-container" :class="{ 'is-freeze-first': props.freezeFirstColumn }">
-      <table class="cal-report-table table is-bordered is-striped is-hoverable is-fullwidth">
+      <table :id="tableId" class="cal-report-table table is-bordered is-striped is-hoverable is-fullwidth">
         <caption v-if="props.caption" class="is-sr-only">
           {{ props.caption }}
         </caption>
@@ -30,37 +43,60 @@
             <th
               v-for="column in tableReport.columns"
               :key="column.key"
+              scope="col"
               :class="{ 'is-sortable-th': column.sortable, 'is-sorted': sortKey === column.key }"
-              @click="cycleSort(column)"
+              :aria-sort="column.sortable ? ariaSort(column) : undefined"
             >
-              <span class="th-content">
+              <!-- Sortable columns render the header as a real <button> so
+                   sorting is keyboard-operable (Enter/Space) and announced as a
+                   button; aria-sort on the <th> conveys the current direction.
+                   When the column also has a tooltip, the button lives inside
+                   cat-tooltip — cat-tooltip detects the focusable button and
+                   describes it (aria-describedby) rather than adding its own tab
+                   stop, so there's no nested interactive content. -->
+              <cat-tooltip
+                v-if="column.sortable && column.tooltip"
+                :text="column.tooltip"
+                position="bottom"
+                class="cal-datagrid-sort-tooltip"
+              >
+                <button type="button" class="cal-datagrid-sort-button" @click="cycleSort(column)">
+                  {{ column.label }}
+                  <cat-icon icon="information" size="small" />
+                  <span class="cal-datagrid-sort-icon">
+                    <cat-icon
+                      :icon="sortIcon(column)"
+                      size="small"
+                      :class="{ 'cal-datagrid-sort-icon-placeholder': sortKey !== column.key }"
+                    />
+                  </span>
+                </button>
+              </cat-tooltip>
+              <button
+                v-else-if="column.sortable"
+                type="button"
+                class="cal-datagrid-sort-button"
+                @click="cycleSort(column)"
+              >
+                {{ column.label }}
+                <!-- Sort indicator. Always rendered for sortable columns so
+                     toggling the active chevron doesn't change column width;
+                     the inactive state shows a hidden chevron as a spacer. -->
+                <span class="cal-datagrid-sort-icon">
+                  <cat-icon
+                    :icon="sortIcon(column)"
+                    size="small"
+                    :class="{ 'cal-datagrid-sort-icon-placeholder': sortKey !== column.key }"
+                  />
+                </span>
+              </button>
+              <!-- Non-sortable columns: plain header content. -->
+              <span v-else class="th-content">
                 <cat-tooltip v-if="column.tooltip" :text="column.tooltip" position="bottom" class="col-header-tooltip">
                   {{ column.label }}
                   <cat-icon icon="information" size="small" />
                 </cat-tooltip>
                 <span v-else>{{ column.label }}</span>
-                <!-- Sort indicator slot. Always rendered for sortable
-                     columns so adding/removing the active chevron doesn't
-                     change column width. Inactive state uses a hidden
-                     chevron-up as a width spacer. -->
-                <span v-if="column.sortable" class="cal-datagrid-sort-icon">
-                  <cat-icon
-                    v-if="sortKey === column.key && sortDir === 'asc'"
-                    icon="chevron-up"
-                    size="small"
-                  />
-                  <cat-icon
-                    v-else-if="sortKey === column.key && sortDir === 'desc'"
-                    icon="chevron-down"
-                    size="small"
-                  />
-                  <cat-icon
-                    v-else
-                    icon="chevron-up"
-                    size="small"
-                    class="cal-datagrid-sort-icon-placeholder"
-                  />
-                </span>
               </span>
             </th>
           </tr>
@@ -140,9 +176,34 @@ const props = defineProps<{
   caption?: string
 }>()
 
-const searchQuery = ref('')
+// cat-search-bar clears to null (not ''), so the model is nullable.
+const searchQuery = ref<string | null>('')
 const sortKey = ref<string | null>(null)
 const sortDir = ref<'asc' | 'desc' | null>(null)
+
+// SSR-stable id so the filter's aria-controls can point at this table.
+const tableId = useId()
+
+// Accessible name for the filter (search fields have no visible label).
+const filterLabel = computed(() =>
+  props.caption ? `Filter ${props.caption}` : 'Filter table rows')
+
+// aria-sort value for a sortable column's <th>, reflecting the current sort so
+// screen readers announce the direction (WCAG 4.1.2).
+function ariaSort (column: TableColumn): 'ascending' | 'descending' | 'none' {
+  if (sortKey.value !== column.key || !sortDir.value) {
+    return 'none'
+  }
+  return sortDir.value === 'asc' ? 'ascending' : 'descending'
+}
+
+// Chevron shown in a sortable header: down when this column is the active
+// descending sort, up otherwise (ascending, or the hidden inactive spacer).
+function sortIcon (column: TableColumn): string {
+  return sortKey.value === column.key && sortDir.value === 'desc'
+    ? 'chevron-down'
+    : 'chevron-up'
+}
 
 function cycleSort (column: TableColumn) {
   if (!column.sortable) {
@@ -165,7 +226,7 @@ function cycleSort (column: TableColumn) {
 
 const filteredData = computed(() => {
   const data = tableReport?.value?.data || []
-  const query = searchQuery.value.trim().toLowerCase()
+  const query = (searchQuery.value || '').trim().toLowerCase()
   if (!query) {
     return data
   }
@@ -274,9 +335,34 @@ const rangeStart = computed(() => {
 const rangeEnd = computed(() => {
   return Math.min(current.value * perPage, total.value)
 })
+
+// Screen-reader announcement of the filter's effect, fed into cat-search-bar's
+// polite live region (its #status slot) so filtering has audible feedback.
+const totalRowCount = computed(() => tableReport.value?.data?.length ?? 0)
+const filterStatus = computed(() => {
+  const all = totalRowCount.value
+  if (all === 0) {
+    return ''
+  }
+  if (!searchQuery.value) {
+    return `Showing all ${all} ${all === 1 ? 'row' : 'rows'}`
+  }
+  const shown = total.value
+  if (shown === 0) {
+    return 'No rows match the filter'
+  }
+  return `Showing ${shown} of ${all} rows`
+})
 </script>
 
 <style scoped lang="scss">
+// cat-search-bar renders full-width; cap it so it stays a filter box in the
+// toolbar rather than stretching to the download buttons.
+.cal-datagrid-filter {
+  flex: 0 1 22rem;
+  min-width: 12rem;
+}
+
 .table-container {
   border: 1px solid var(--bulma-border);
   border-radius: var(--bulma-radius);
@@ -310,6 +396,35 @@ const rangeEnd = computed(() => {
       display: inline-flex;
       align-items: center;
       gap: 0.25rem;
+    }
+
+    // Sortable header rendered as a button. Reset to look like plain header
+    // text, but fill the cell so the whole header stays a click target.
+    .cal-datagrid-sort-button {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      border: none;
+      background: transparent;
+      font: inherit;
+      color: inherit;
+      text-align: left;
+      cursor: pointer;
+
+      &:focus-visible {
+        outline: 2px solid var(--bulma-primary);
+        outline-offset: -2px;
+      }
+    }
+
+    // When a sortable header also has a tooltip, the tooltip wraps the button;
+    // keep it filling the cell so the button underneath still spans the header.
+    .cal-datagrid-sort-tooltip {
+      display: block;
+      width: 100%;
     }
 
     .cal-datagrid-sort-icon {

--- a/app/components/cal/report.vue
+++ b/app/components/cal/report.vue
@@ -71,6 +71,7 @@
     <cal-datagrid
       :table-report="activeTableReport"
       :caption="`${activeReportTabLabel} — ${reportHeading}`"
+      :filter-label="activeReportTabLabel"
     >
       <!-- Custom rendering for URLs column (flex areas) -->
       <template #column-urls="{ row }">

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aitodotai/json-stringify-pretty-compact": "1.3.0",
     "@apollo/client": "3.13.4",
-    "@interline-io/catenary": "0.6.1",
+    "@interline-io/catenary": "0.8.0",
     "@interline-io/tlv2-auth": "0.1.0-sha.ad5c03e",
     "@mdi/font": "7.4.47",
     "@nuxt/eslint": "1.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 3.13.4
         version: 3.13.4(graphql@16.10.0)
       '@interline-io/catenary':
-        specifier: 0.6.1
-        version: 0.6.1(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
+        specifier: 0.8.0
+        version: 0.8.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@25.5.0)(jiti@2.7.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
       '@interline-io/tlv2-auth':
         specifier: 0.1.0-sha.ad5c03e
         version: 0.1.0-sha.ad5c03e(h3@1.15.11)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.5(@types/node@25.5.0)(jiti@2.7.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.9.0))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
@@ -839,16 +839,13 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@interline-io/catenary@0.6.1':
-    resolution: {integrity: sha512-r0JdnsacPMJ+UyFFMHVOpVW0amAs3Bg2D8000E82J832447yPvb6isqSeDLit3UX0ceRrc2XaeYkN0mfouTR7Q==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.6.1/0e5397a66246a31f289e371d24f0b2aa3f8a4d59}
+  '@interline-io/catenary@0.8.0':
+    resolution: {integrity: sha512-oyKL+A2u2Y8cu3OBAoBMHLypWMMf57DqaMKEDh5hQPT3xAkrm1LZFs8/7qKsQc1pWCSxl4VlxeEKlg3UDzPHrg==, tarball: https://npm.pkg.github.com/download/@interline-io/catenary/0.8.0/ef9562d588c1ba5def088237fe1268189d2024d1}
     peerDependencies:
       '@mdi/font': ^7.4.0
       bulma: ^1.0.0
       vue: ^3.5.0
       vue-router: ^4.0.0
-    peerDependenciesMeta:
-      vue-router:
-        optional: true
 
   '@interline-io/tlv2-auth@0.1.0-sha.ad5c03e':
     resolution: {integrity: sha512-dMswf/nbodsEvRtLZSMwVnL8cQkxPSZRLGAh9AbqJoUpNFgztE8iRfv/h86NOXgZ+X78pebY/om38PmntkPGYg==, tarball: https://npm.pkg.github.com/download/@interline-io/tlv2-auth/0.1.0-sha.ad5c03e/da21c358d305fb9439fc3bee298626ba46302027}
@@ -2376,9 +2373,6 @@ packages:
 
   '@vue/compiler-ssr@3.5.38':
     resolution: {integrity: sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==}
-
-  '@vue/devtools-api@6.6.4':
-    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/devtools-api@8.1.3':
     resolution: {integrity: sha512-73NMCvxXh8Hyozc/jiwqTFWVcCMyi11U1zmrq4DoukQJnuo8JHt6FsNu4HdeUDa8SpIp5vb7Q22GWgIq0efsXg==}
@@ -5420,11 +5414,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
-  vue-router@4.6.4:
-    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
-    peerDependencies:
-      vue: ^3.5.0
-
   vue-router@5.1.0:
     resolution: {integrity: sha512-HAbiLzLEHQwxPgvsbOJDAwtavszEgLwri6XfyrsPECIFez8+59xc9LofWVdc/HEaSRT822lJ8H9Ns38VVond5g==}
     peerDependencies:
@@ -6211,15 +6200,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@interline-io/catenary@0.6.1(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))':
+  '@interline-io/catenary@0.8.0(@mdi/font@7.4.47)(bulma@1.0.4)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@25.5.0)(jiti@2.7.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))':
     dependencies:
       '@mdi/font': 7.4.47
       bulma: 1.0.4
       csv-stringify: 6.7.0
       date-fns: 4.1.0
       vue: 3.5.38(typescript@5.9.3)
-    optionalDependencies:
-      vue-router: 4.6.4(vue@3.5.38(typescript@5.9.3))
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@25.5.0)(jiti@2.7.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
 
   '@interline-io/tlv2-auth@0.1.0-sha.ad5c03e(h3@1.15.11)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(typescript@5.9.3)(vite@7.3.5(@types/node@25.5.0)(jiti@2.7.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.9.0))(vue-tsc@3.1.1(typescript@5.9.3))(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))':
     dependencies:
@@ -7789,9 +7777,6 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.38
       '@vue/shared': 3.5.38
-
-  '@vue/devtools-api@6.6.4':
-    optional: true
 
   '@vue/devtools-api@8.1.3':
     dependencies:
@@ -11118,12 +11103,6 @@ snapshots:
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
-
-  vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)):
-    dependencies:
-      '@vue/devtools-api': 6.6.4
-      vue: 3.5.38(typescript@5.9.3)
-    optional: true
 
   vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@25.5.0)(jiti@2.7.0)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.1)(tsx@4.20.3)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## Summary

Makes the report/analysis datagrid filter and sort usable by screen-reader and keyboard users. Adopts catenary 0.8.0's new `cat-search-bar` for the filter input — which brings an accessible name, focus management on clear, and a polite result-count live region — and finishes the sortable-header accessibility work that catenary #57 explicitly deferred to this repo: sortable column headers are now real keyboard-operable buttons that announce their sort state via `aria-sort`.

## User-facing changes

### Filtering
- The table filter now has a proper accessible name and announces result counts to screen readers as you type ("Showing 12 of 40 rows" / "No rows match the filter").
- The filter sits in a labelled search landmark, so screen-reader users can jump straight to it.
- Clearing the filter (the ✕ button or Escape) keeps focus in the field instead of dropping it to the page body.

### Sorting
- Column headers can now be sorted with the keyboard: Tab to a header, then Enter/Space to cycle ascending → descending → unsorted.
- Each sortable header announces its current sort direction to screen readers.
- No visual change for mouse users; the whole header remains a click target and column widths stay stable across sort, pagination, and filtering.

## Implementation details

### Filter (cat-search-bar adoption)
- Bumped `@interline-io/catenary` 0.6.1 → 0.8.0, which provides `cat-search-bar`.
- Replaced the bare `cat-input type="search"` with `cat-search-bar`, feeding a computed `filterStatus` into its polite `#status` live region and pointing `aria-controls` at the table id.
- `ariaLabel` / `aria-controls` are passed via a `v-bind` object: `cat-search-bar` sets `inheritAttrs: false`, so `vue-tsc` checks attributes against its declared props and rejects the plain forms; the object also sidesteps the `vue/attribute-hyphenation` ↔ prop-casing conflict. This mirrors the existing pattern in `end-date-field.vue`.
- Added a labelled `role="search"` landmark on the filter wrapper. Safe against duplicate landmarks because multi-datagrid views use `cat-tabs` (`v-show`), so only the active datagrid's landmark is in the accessibility tree.

### Sortable headers
- Sortable `<th>` now render their label and sort chevron inside a real `<button type="button">` (keyboard-operable, announced as a button); the `@click` moved off the `<th>`.
- `aria-sort` on the `<th>` reflects the active direction (via an `ariaSort()` helper); `scope="col"` added to the header cells.
- For columns that are both sortable and tooltipped (e.g. Average Frequency, census columns), the button is nested inside `cat-tooltip`, which in 0.8.0 detects the focusable button and applies `aria-describedby` to it rather than adding its own tab stop — avoiding nested interactive content.
- The three-way chevron `v-if` collapsed into a `sortIcon()` helper; the button is styled as a reset (transparent, `font: inherit`, full-cell width) with a `:focus-visible` outline matching the codebase convention.

### Not included (tracked separately)
- Table `<caption>` coverage across the rest of the Report tab (census panel/details, route timetable, and the analysis-view datagrids) is its own follow-up.
- `type="search"` / `role="searchbox"` semantics belong in `cat-search-bar` as an opt-in; `type="search"` would also conflict with its custom clear button.

## User test plan

- With a screen reader, open a report that has results. Navigate landmarks — a labelled "search" landmark should take you to the filter. Type into it and confirm the result count is announced ("Showing X of N rows"); clear it (✕ or Escape) and confirm focus stays in the field.
- Tab to a sortable column header: it should announce as a button with its sort state. Press Enter/Space to cycle ascending → descending → unsorted, and confirm the announced `aria-sort` state and the visible chevron stay in sync.
- For a header that both has an info tooltip and is sortable (e.g. Average Frequency), confirm focusing it shows the tooltip and Enter/Space sorts, with a single tab stop on the header.
- Mouse-only regression check: clicking anywhere on a sortable header still cycles the sort, and column widths don't shift across sort/pagination/filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
