### PR TITLE
Minor description adjustments

### DIFF
--- a/app/components/cal/census-details.vue
+++ b/app/components/cal/census-details.vue
@@ -70,7 +70,7 @@
         <p class="mb-2">
           One row per census geography.
           <strong>Intersection %</strong> shows the fraction of each geography
-          that falls inside the query area or stop buffer.
+          that falls inside the area being analyzed.
         </p>
         <p class="mb-3">
           Demographic columns show the <strong>full ACS value for the whole

--- a/app/components/cal/census-panel.vue
+++ b/app/components/cal/census-panel.vue
@@ -39,19 +39,19 @@
           <tr>
             <th>Statistic</th>
             <th>
-              <cat-tooltip text="The full raw ACS value for this geography — not scaled by the intersection with the query area.">
+              <cat-tooltip text="The full raw ACS value for this geography — not scaled by the intersection with the area being analyzed.">
                 Full Geography
                 <cat-icon size="small" icon="information" />
               </cat-tooltip>
             </th>
             <th>
-              <cat-tooltip text="This geography's raw ACS value scaled by its intersection with the query area. Ratios (% columns) and medians are unchanged.">
+              <cat-tooltip text="This geography's raw ACS value scaled by its intersection with the area being analyzed. Ratios (% columns) and medians are unchanged.">
                 Intersection
                 <cat-icon size="small" icon="information" />
               </cat-tooltip>
             </th>
             <th>
-              <cat-tooltip text="Sum of every geography's Intersection value across the query area. This is the apportioned total, not the sum of the full geographies. Medians are not summable and render as —.">
+              <cat-tooltip text="Sum of every geography's Intersection value across the area being analyzed. This is the apportioned total, not the sum of the full geographies. Medians are not summable and render as —.">
                 Query Area Total
                 <cat-icon size="small" icon="information" />
               </cat-tooltip>

--- a/app/components/cal/filter-fixed-route.vue
+++ b/app/components/cal/filter-fixed-route.vue
@@ -70,6 +70,7 @@
                 v-model="stopBufferRadius"
                 type="number"
                 min="0"
+                max="1600"
               />
             </div>
             <div class="ml-2">


### PR DESCRIPTION
Fixes the census intersection wording flagged in #422. The Census Details help text said the Intersection column shows the fraction of a geography "inside the query area **or** stop buffer" — a union the app has never computed; what it actually shows is the query-area intersection. Now reads "inside the area being analyzed", which is also true once the later PRs let that value be narrowed to the stop buffers. Same change to the three column tooltips in the map sidebar census panel.

Also adds `max="1600"` to the radius number input, matching the slider and the backend clamp. This bounds the spinner arrows and native validation only — it does not prevent typing a larger value, and no client-side clamp was added. The server clamps to 1600 regardless, so the apportionment stays correct; only the displayed radius would disagree with the buffer actually used.

First of four PRs splitting #422; see the decomposition plan on #438. No computed value changes here.
