### PR TITLE
Stop buffer overlay

### DIFF
--- a/app/components/cal/filter-map-display.vue
+++ b/app/components/cal/filter-map-display.vue
@@ -92,6 +92,13 @@
           Show geographic filters
         </cat-checkbox>
       </li>
+      <li>
+        <cat-tooltip text="Outlines the area within the stop statistical radius of each route's stops.">
+          <cat-checkbox v-model="showStopBuffer" :disabled="stopBufferRadius <= 0">
+            Show stop buffers
+          </cat-checkbox>
+        </cat-tooltip>
+      </li>
     </ul>
     <p class="menu-label">
       Display Options
@@ -120,6 +127,7 @@ const props = defineProps<{
 
 const {
   showAggAreas,
+  showStopBuffer,
   aggregateLayer,
   choroplethElement,
   shadeByDensity,

--- a/app/components/cal/map-viewer-ts.vue
+++ b/app/components/cal/map-viewer-ts.vue
@@ -31,6 +31,7 @@ const emit = defineEmits([
 ])
 
 const overlayFeatures = defineModel<Feature[]>('overlayFeatures', { default: [] })
+const stopBufferFeatures = defineModel<Feature[]>('stopBufferFeatures', { default: [] })
 const choroplethFeatures = defineModel<Feature[]>('choroplethFeatures', { default: [] })
 const selectableGeographies = defineModel<Feature[]>('selectableGeographies', { default: [] })
 const features = defineModel<Feature[]>('features', { default: [] })
@@ -78,6 +79,12 @@ let choroplethTooltip: HTMLDivElement | undefined
 
 //////////////////////
 // Watchers
+
+watch(() => stopBufferFeatures.value, (v) => {
+  nextTick(() => {
+    updateStopBufferFeatures(v)
+  })
+})
 
 watch(() => overlayFeatures.value, (v) => {
   nextTick(() => {
@@ -272,6 +279,7 @@ function initMap () {
     createSources()
     createLayers()
     updateOverlayFeatures(overlayFeatures.value)
+    updateStopBufferFeatures(stopBufferFeatures.value)
     updateChoroplethFeatures(choroplethFeatures.value)
     updateSelectableGeographies(selectableGeographies.value)
     updateFeatures(features.value)
@@ -453,6 +461,10 @@ function createSources () {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] }
   })
+  map?.addSource('stopBufferPolygons', {
+    type: 'geojson',
+    data: { type: 'FeatureCollection', features: [] }
+  })
   map?.addSource('choropleth', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -579,6 +591,21 @@ function createLayers () {
       'line-width': 2,
       'line-color': '#ff0000',
       'line-opacity': 0.6
+    }
+  })
+  // Outline only: one polygon per route, so a fill would stack opacity
+  // wherever routes overlap. Dashed to separate it from the solid
+  // geographic-filter outline in the same red.
+  map?.addLayer({
+    id: 'stop-buffer-outline',
+    type: 'line',
+    source: 'stopBufferPolygons',
+    layout: {},
+    paint: {
+      'line-width': 2,
+      'line-color': '#ff0000',
+      'line-opacity': 0.6,
+      'line-dasharray': [3, 2]
     }
   })
 
@@ -812,6 +839,10 @@ function updateChoroplethFeatures (features: Feature[]) {
 
 function updateOverlayFeatures (features: Feature[]) {
   setSourceData('overlayPolygons', features, isPolygon)
+}
+
+function updateStopBufferFeatures (features: Feature[]) {
+  setSourceData('stopBufferPolygons', features, isPolygon)
 }
 
 function updateSelectableGeographies (features: Feature[]) {

--- a/app/components/cal/map.vue
+++ b/app/components/cal/map.vue
@@ -39,6 +39,7 @@
       :zoom="14"
       :initial-bounds="bbox"
       :overlay-features="overlayFeatures"
+      :stop-buffer-features="props.stopBufferFeatures || []"
       :choropleth-features="props.choroplethFeatures || []"
       :selectable-geographies="selectableGeographies"
       :features="displayFeatures"
@@ -93,6 +94,7 @@ const props = defineProps<{
   scenarioFilterResult?: ScenarioFilterResult
   // Choropleth aggregation overlay
   choroplethFeatures?: Feature[]
+  stopBufferFeatures?: Feature[]
   choroplethClassification?: ChoroplethClassification
   // Flex display features (pre-filtered and styled from useFlexAreas composable)
   flexDisplayFeatures?: Feature[]

--- a/app/components/cal/map.vue
+++ b/app/components/cal/map.vue
@@ -94,8 +94,9 @@ const props = defineProps<{
   scenarioFilterResult?: ScenarioFilterResult
   // Choropleth aggregation overlay
   choroplethFeatures?: Feature[]
-  stopBufferFeatures?: Feature[]
   choroplethClassification?: ChoroplethClassification
+  // Stop buffer overlay
+  stopBufferFeatures?: Feature[]
   // Flex display features (pre-filtered and styled from useFlexAreas composable)
   flexDisplayFeatures?: Feature[]
   // Loading stage - allow map updates during geometry stages, skip during schedules

--- a/app/composables/useScenarioDisplay.ts
+++ b/app/composables/useScenarioDisplay.ts
@@ -4,6 +4,7 @@ import { useUrlQuery } from './useUrlQuery'
 
 interface ScenarioDisplay {
   showAggAreas: WritableComputedRef<boolean>
+  showStopBuffer: WritableComputedRef<boolean>
   aggregateLayer: WritableComputedRef<string>
   choroplethElement: WritableComputedRef<string>
   shadeByDensity: WritableComputedRef<boolean>
@@ -26,6 +27,11 @@ export function useScenarioDisplay (): ScenarioDisplay {
   const showAggAreas = computed<boolean>({
     get: () => route.query.showAggAreas?.toString() === 'true',
     set: (v) => { setQuery({ showAggAreas: v ? 'true' : undefined }) }
+  })
+
+  const showStopBuffer = computed<boolean>({
+    get: () => route.query.showStopBuffer?.toString() === 'true',
+    set: (v) => { setQuery({ showStopBuffer: v ? 'true' : undefined }) }
   })
 
   const aggregateLayer = computed<string>({
@@ -81,6 +87,7 @@ export function useScenarioDisplay (): ScenarioDisplay {
 
   return {
     showAggAreas,
+    showStopBuffer,
     aggregateLayer,
     choroplethElement,
     shadeByDensity,

--- a/app/composables/useStopBufferFeatures.ts
+++ b/app/composables/useStopBufferFeatures.ts
@@ -1,0 +1,69 @@
+// Map features for the stop buffer overlay: the area within the stop
+// statistical radius of each marked route's stops, unioned server-side. The
+// filtered scenario result is passed in by the container; the URL-backed
+// radius and display toggle are read from the useScenario* composables.
+
+import { computed, type Ref, type ComputedRef } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import { useScenarioDisplay } from './useScenarioDisplay'
+import { useScenarioInputs } from './useScenarioInputs'
+import { routeStopBufferQuery, type RouteStopBufferResponse } from '~~/src/tl'
+import type { Feature } from '~~/src/core'
+import type { ScenarioFilterResult } from '~~/src/scenario'
+
+// The backend clamps `routes(limit:)` to this; asking for more silently
+// returns the same page.
+const ROUTE_LIMIT = 1000
+
+interface UseStopBufferFeaturesDeps {
+  scenarioFilterResult: Ref<ScenarioFilterResult | undefined>
+}
+
+export interface UseStopBufferFeaturesReturn {
+  // Empty when the overlay is off, the radius is 0, or no route is marked.
+  stopBufferFeatures: ComputedRef<Feature[]>
+}
+
+export function useStopBufferFeatures (deps: UseStopBufferFeaturesDeps): UseStopBufferFeaturesReturn {
+  const { showStopBuffer } = useScenarioDisplay()
+  const { stopBufferRadius } = useScenarioInputs()
+
+  // Marked only, so the outlines trace what the map is drawing.
+  const routeIds = computed((): number[] => {
+    if (!showStopBuffer.value || stopBufferRadius.value <= 0) { return [] }
+    return (deps.scenarioFilterResult.value?.routes || []).filter(r => r.marked).map(r => r.id)
+  })
+
+  const { result } = useQuery<{ routes: RouteStopBufferResponse[] }>(
+    routeStopBufferQuery,
+    () => ({
+      ids: routeIds.value,
+      radius: stopBufferRadius.value,
+      limit: ROUTE_LIMIT,
+    }),
+    () => ({
+      enabled: routeIds.value.length > 0,
+      // The radius is a slider; without this every step fires its own union.
+      debounce: 300,
+      // Holds the current outlines while the next radius is in flight.
+      keepPreviousResult: true,
+      // Each radius would otherwise pin its own copy of every route's
+      // geometry in the store for the session, and none of it is reused.
+      fetchPolicy: 'no-cache',
+    })
+  )
+
+  const stopBufferFeatures = computed((): Feature[] => {
+    // keepPreviousResult holds the last union after the query is disabled.
+    if (routeIds.value.length === 0) { return [] }
+    const out: Feature[] = []
+    for (const route of result.value?.routes || []) {
+      const g = route.route_stop_buffer?.stop_buffer
+      if (!g) { continue }
+      out.push({ id: `route-buffer-${route.id}`, type: 'Feature', geometry: g, properties: {} })
+    }
+    return out
+  })
+
+  return { stopBufferFeatures }
+}

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -90,6 +90,7 @@
           :display-edit-bbox-mode="displayEditBboxMode"
           :show-bbox="showBboxOnMap"
           :choropleth-features="choroplethFeatures"
+          :stop-buffer-features="stopBufferFeatures"
           :choropleth-classification="choroplethClassification"
           :flex-display-features="flexDisplayFeatures"
           :loading-stage="loadingProgress?.currentStage"
@@ -200,6 +201,7 @@ import { useBufferDetails } from '~/composables/useBufferDetails'
 import { useCensusGeographyLayers } from '~/composables/useCensusGeographyLayers'
 import {
   geographyLayerQuery,
+  routeStopBufferQuery,
   geographyBboxQuery,
   stopGeoAggregateCsv,
   parseFvids,
@@ -208,6 +210,7 @@ import type {
   CensusDataset,
   CensusGeography,
   Route,
+  RouteStopBufferResponse,
 } from '~~/src/tl'
 import {
   type Bbox,
@@ -240,6 +243,7 @@ const {
   aggregateLayer,
   onlyWithStops,
   showBbox,
+  showStopBuffer,
 } = useScenarioDisplay()
 const {
   bbox,
@@ -792,6 +796,41 @@ const aggregateLayerLabel = computed((): string => {
     return aggregateGeoCount.value === 1 ? 'area' : 'areas'
   }
   return aggregateGeoCount.value === 1 ? labels.singular : labels.plural
+})
+
+/////////////////
+// Stop buffer overlay
+/////////////////
+
+// Server-side union of each route's stop buffers. Independent of the census
+// query, so it renders in any query mode.
+const stopBufferRouteIds = computed((): number[] => {
+  if (!showStopBuffer.value || stopBufferRadius.value <= 0) { return [] }
+  return (scenarioFilterResult.value?.routes || []).map(r => r.id)
+})
+
+const { result: stopBufferResult } = useQuery<{ routes: RouteStopBufferResponse[] }>(
+  routeStopBufferQuery,
+  () => ({
+    ids: stopBufferRouteIds.value,
+    radius: stopBufferRadius.value,
+  }),
+  () => ({
+    enabled: stopBufferRouteIds.value.length > 0,
+  })
+)
+
+// Outlines only, one polygon per route — dissolving them into a single ring
+// would be a client-side geometry operation.
+const stopBufferFeatures = computed((): Feature[] => {
+  if (!showStopBuffer.value) { return [] }
+  const out: Feature[] = []
+  for (const route of stopBufferResult.value?.routes || []) {
+    const g = route.route_stop_buffer?.stop_buffer
+    if (!g) { continue }
+    out.push({ id: `route-buffer-${route.id}`, type: 'Feature', geometry: g, properties: {} } as Feature)
+  }
+  return out
 })
 
 /////////////////

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -198,10 +198,10 @@ import { computed, shallowRef, watch } from 'vue'
 import { useQuery, useLazyQuery } from '@vue/apollo-composable'
 import { useFlexDisplayFeatures } from '~/composables/useFlexDisplayFeatures'
 import { useBufferDetails } from '~/composables/useBufferDetails'
+import { useStopBufferFeatures } from '~/composables/useStopBufferFeatures'
 import { useCensusGeographyLayers } from '~/composables/useCensusGeographyLayers'
 import {
   geographyLayerQuery,
-  routeStopBufferQuery,
   geographyBboxQuery,
   stopGeoAggregateCsv,
   parseFvids,
@@ -210,7 +210,6 @@ import type {
   CensusDataset,
   CensusGeography,
   Route,
-  RouteStopBufferResponse,
 } from '~~/src/tl'
 import {
   type Bbox,
@@ -243,7 +242,6 @@ const {
   aggregateLayer,
   onlyWithStops,
   showBbox,
-  showStopBuffer,
 } = useScenarioDisplay()
 const {
   bbox,
@@ -799,46 +797,6 @@ const aggregateLayerLabel = computed((): string => {
 })
 
 /////////////////
-// Stop buffer overlay
-/////////////////
-
-// Server-side union of each route's stop buffers. Independent of the census
-// query, so it renders in any query mode.
-// Marked only, so the outlines match the routes the map is drawing rather
-// than every route in the scenario.
-const stopBufferRouteIds = computed((): number[] => {
-  if (!showStopBuffer.value || stopBufferRadius.value <= 0) { return [] }
-  return (scenarioFilterResult.value?.routes || []).filter(r => r.marked).map(r => r.id)
-})
-
-const { result: stopBufferResult } = useQuery<{ routes: RouteStopBufferResponse[] }>(
-  routeStopBufferQuery,
-  () => ({
-    ids: stopBufferRouteIds.value,
-    radius: stopBufferRadius.value,
-  }),
-  () => ({
-    enabled: stopBufferRouteIds.value.length > 0,
-    // The radius is a slider; without this every step fires its own union.
-    debounce: 300,
-    keepPreviousResult: true,
-  })
-)
-
-// Outlines only, one polygon per route — dissolving them into a single ring
-// would be a client-side geometry operation.
-const stopBufferFeatures = computed((): Feature[] => {
-  if (!showStopBuffer.value) { return [] }
-  const out: Feature[] = []
-  for (const route of stopBufferResult.value?.routes || []) {
-    const g = route.route_stop_buffer?.stop_buffer
-    if (!g) { continue }
-    out.push({ id: `route-buffer-${route.id}`, type: 'Feature', geometry: g, properties: {} } as Feature)
-  }
-  return out
-})
-
-/////////////////
 // Choropleth aggregation overlay
 /////////////////
 
@@ -879,6 +837,8 @@ const choroplethAggregateData = computed(() => {
     { onlyWithStops: onlyWithStops.value },
   )
 })
+
+const { stopBufferFeatures } = useStopBufferFeatures({ scenarioFilterResult })
 
 const { choroplethClassification, choroplethFeatures } = useChoroplethClassification({
   choroplethAggregateData,

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -804,9 +804,11 @@ const aggregateLayerLabel = computed((): string => {
 
 // Server-side union of each route's stop buffers. Independent of the census
 // query, so it renders in any query mode.
+// Marked only, so the outlines match the routes the map is drawing rather
+// than every route in the scenario.
 const stopBufferRouteIds = computed((): number[] => {
   if (!showStopBuffer.value || stopBufferRadius.value <= 0) { return [] }
-  return (scenarioFilterResult.value?.routes || []).map(r => r.id)
+  return (scenarioFilterResult.value?.routes || []).filter(r => r.marked).map(r => r.id)
 })
 
 const { result: stopBufferResult } = useQuery<{ routes: RouteStopBufferResponse[] }>(
@@ -817,6 +819,9 @@ const { result: stopBufferResult } = useQuery<{ routes: RouteStopBufferResponse[
   }),
   () => ({
     enabled: stopBufferRouteIds.value.length > 0,
+    // The radius is a slider; without this every step fires its own union.
+    debounce: 300,
+    keepPreviousResult: true,
   })
 )
 

--- a/src/tl/stop-buffer.ts
+++ b/src/tl/stop-buffer.ts
@@ -216,8 +216,8 @@ export async function fetchEntityBufferGeographies (
 // Union of circles of `radius` around each of a route's stops, computed
 // server-side. Independent of census data, so it renders in any query mode.
 export const routeStopBufferQuery = gql`
-  query ($ids: [Int!], $radius: Float) {
-    routes(ids: $ids, limit: 10000) {
+  query ($ids: [Int!], $radius: Float, $limit: Int) {
+    routes(ids: $ids, limit: $limit) {
       id
       route_stop_buffer(radius: $radius) {
         stop_buffer
@@ -226,7 +226,8 @@ export const routeStopBufferQuery = gql`
   }
 `
 
+// Raw GraphQL shape for one route in the stop-buffer query response.
 export interface RouteStopBufferResponse {
   id: number
-  route_stop_buffer?: { stop_buffer?: Geometry | null } | null
+  route_stop_buffer?: { stop_buffer?: Geometry }
 }

--- a/src/tl/stop-buffer.ts
+++ b/src/tl/stop-buffer.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-tag'
-import type { CensusValues, GraphQLClient } from '~~/src/core'
+import type { CensusValues, Geometry, GraphQLClient } from '~~/src/core'
 import { parseAcsValues } from './census'
 
 // #315 — per-entity buffer ∩ census intersections + inline ACS values.
@@ -211,4 +211,22 @@ export async function fetchEntityBufferGeographies (
     }
     return [ent.id, geographies]
   })
+}
+
+// Union of circles of `radius` around each of a route's stops, computed
+// server-side. Independent of census data, so it renders in any query mode.
+export const routeStopBufferQuery = gql`
+  query ($ids: [Int!], $radius: Float) {
+    routes(ids: $ids, limit: 10000) {
+      id
+      route_stop_buffer(radius: $radius) {
+        stop_buffer
+      }
+    }
+  }
+`
+
+export interface RouteStopBufferResponse {
+  id: number
+  route_stop_buffer?: { stop_buffer?: Geometry | null } | null
 }


### PR DESCRIPTION
Adds a "Show stop buffers" checkbox under Map Display > Overlay, drawing the area within the stop statistical radius of each route's stops.

Until now the radius has been an invisible parameter: it silently reshapes the demographic columns in the Stops, Routes, Agencies and Aggregation tables, but nothing on the map shows where those buffers actually are. That makes a number like "38% of this tract" impossible to sanity-check visually — which is how #422 was diagnosed in the first place, by comparing intersection values against what was on screen.

Geometry comes from the API's `route_stop_buffer`, a server-side union of circles around each route's stops. No client-side geometry, and no dependency on the census query, the aggregation layer, or `geographyIds` — so it works in bbox mode and with census demographics turned off entirely.

Rendered as a dashed outline with no fill. There is one polygon per route rather than one dissolved union, since merging them client-side would be a geometry operation, so a fill would stack opacity wherever routes overlap. The dashes distinguish it from the solid "Show geographic filters" outline, which uses the same red because both mark the extent of something the analysis is bounded by.

Only marked routes are drawn, so the outlines trace what the map is showing rather than every route in the scenario. Applying an agency, mode or frequency filter narrows the buffers to match, and when filters exclude everything no request is made at all.

The pipeline lives in `app/composables/useStopBufferFeatures.ts` rather than inline in `tne.vue`, matching `useFlexDisplayFeatures` and `useCensusGeographyLayers`: the container passes `scenarioFilterResult` in, the composable reads the URL-backed radius and display toggle itself and returns map features. Query options worth noting — `debounce: 300` because the radius is a slider and each step would otherwise fire its own set of server-side unions; `keepPreviousResult` so outlines do not blink out mid-drag; and `fetchPolicy: 'no-cache'`, because each distinct radius would otherwise pin a full copy of every route's geometry in the Apollo store for the session with no reuse (same reason `useBufferDetails` does this).

## Known limitations

- `route_stop_buffer` is an unbatched N+1 upstream — one PostGIS union per route per request — and the marked-route set changes whenever a filter changes, so adjusting an unrelated filter with the overlay on re-issues the whole fetch. Fixing this properly wants a batched resolver on the API side rather than anything on this branch.
- `routes()` is clamped to 1000 server-side, so a scenario with more than 1000 marked routes silently omits some buffers. `ROUTE_LIMIT` names the real cap rather than hiding it behind a larger literal; chunking the id list is the fix, and it is entangled with the N+1 above.
- `route_stop_buffer` clamps the radius to 2000 while the census stop_buffer filter clamps to 1600, so between those values the drawn buffer would be larger than the one the numbers used. The radius slider stops at 1600, so this is only reachable by hand-editing the URL.
- No tests. The feature-building half of the composable is a pure function of the query result and is the testable piece; nothing currently pins the GraphQL document's shape either, so renaming `route_stop_buffer` would blank the overlay with a green suite.

## User test plan

- Run a scenario in bbox mode with a stop statistical radius above 0, then check "Show stop buffers" under Map Display > Overlay. Dashed red outlines should appear around the stops, distinct from the solid red query-area outline.
- Drag the radius slider and confirm the outlines resize without flickering and without a request per step.
- Set the radius to 0 and confirm the checkbox is disabled and the outlines disappear.
- Apply an agency or route-type filter and confirm the buffers narrow to the routes still drawn on the map. Filter everything out and confirm the outlines clear.
- Repeat with an administrative boundary as the query area rather than a bbox, and with "Include census demographics" unchecked on the Query tab — the overlay should render in both cases.

Second of four PRs splitting #422; see the decomposition plan on #438. Independent of the others — no computed value changes, and nothing here waits on a backend deploy. The `showStopBuffer` flag is a plain boolean defaulting off; the PR that introduces the aggregation display modes will make it default on in buffer mode, where the shaded values only make sense alongside the coverage they were computed from.
