### PR TITLE
Aggregate area mode

### DIFF
--- a/app/components/cal/census-panel.vue
+++ b/app/components/cal/census-panel.vue
@@ -52,7 +52,7 @@
             </th>
             <th>
               <cat-tooltip text="Sum of every geography's Intersection value across the area being analyzed. This is the apportioned total, not the sum of the full geographies. Medians are not summable and render as —.">
-                Query Area Total
+                Analysis Area Total
                 <cat-icon size="small" icon="information" />
               </cat-tooltip>
             </th>

--- a/app/components/cal/census-panel.vue
+++ b/app/components/cal/census-panel.vue
@@ -44,7 +44,7 @@
                 <cat-icon size="small" icon="information" />
               </cat-tooltip>
             </th>
-            <th>
+            <th v-if="showIntersection">
               <cat-tooltip text="This geography's raw ACS value scaled by its intersection with the area being analyzed. Ratios (% columns) and medians are unchanged.">
                 Intersection
                 <cat-icon size="small" icon="information" />
@@ -79,7 +79,7 @@
             <td class="cal-census-panel-num">
               {{ formatCensusValue(valueFor(col.id), col.format) }}
             </td>
-            <td class="cal-census-panel-num">
+            <td v-if="showIntersection" class="cal-census-panel-num">
               {{ intersectionCell(col) }}
             </td>
             <td class="cal-census-panel-num">
@@ -119,7 +119,10 @@ defineEmits<{
   viewDetails: []
 }>()
 
-const { choroplethElement, unitSystem } = useScenarioDisplay()
+const { choroplethElement, unitSystem, aggClipMode } = useScenarioDisplay()
+
+// Unclipped apportions at 1, so the column would only restate Full Geography.
+const showIntersection = computed(() => aggClipMode.value !== 'unclipped')
 
 function valueFor (id: string): number | null {
   return toFiniteNumber(props.row?.[id])

--- a/app/components/cal/filter-map-display.vue
+++ b/app/components/cal/filter-map-display.vue
@@ -60,7 +60,7 @@
           :key="option.value"
           :value="option.value"
         >
-          {{ option.label }}{{ option.value === 'buffer' && !props.hasBufferClip ? ' (no stop radius set)' : '' }}
+          {{ option.label }}{{ option.value === 'buffer' && stopBufferRadius <= 0 ? ' (no stop radius set)' : '' }}
         </option>
       </cat-select>
     </cat-field>
@@ -145,8 +145,6 @@ import {
 
 const props = defineProps<{
   censusGeographyLayerOptions?: { label: string, value: string }[]
-  // False until a loaded scenario carries buffer-clipped intersections.
-  hasBufferClip?: boolean
 }>()
 
 defineEmits<{

--- a/app/components/cal/filter-map-display.vue
+++ b/app/components/cal/filter-map-display.vue
@@ -59,9 +59,8 @@
           v-for="option of AGG_CLIP_MODE_OPTIONS"
           :key="option.value"
           :value="option.value"
-          :disabled="option.value === 'buffer' && !props.hasBufferClip"
         >
-          {{ option.label }}{{ option.value === 'buffer' && !props.hasBufferClip ? ' (needs a stop radius)' : '' }}
+          {{ option.label }}{{ option.value === 'buffer' && !props.hasBufferClip ? ' (no stop radius set)' : '' }}
         </option>
       </cat-select>
     </cat-field>
@@ -121,13 +120,6 @@
           Show geographic filters
         </cat-checkbox>
       </li>
-      <li>
-        <cat-tooltip text="Outlines the area within the stop statistical radius of each route's stops. Draws nothing when the radius is 0.">
-          <cat-checkbox v-model="showStopBuffer">
-            Show stop buffers
-          </cat-checkbox>
-        </cat-tooltip>
-      </li>
     </ul>
     <p class="menu-label">
       Display Options
@@ -164,7 +156,6 @@ defineEmits<{
 const {
   showAggAreas,
   aggClipMode,
-  showStopBuffer,
   aggregateLayer,
   choroplethElement,
   shadeByDensity,

--- a/app/components/cal/filter-map-display.vue
+++ b/app/components/cal/filter-map-display.vue
@@ -41,6 +41,16 @@
         Clipping mode <cat-tooltip text="How much of each census geography the map measures and draws. Clipped modes scale demographics to the part of the geography inside the area, draw it as that clipped footprint rather than its whole outline, and hide geographies the area doesn't reach.">
           <i class="mdi mdi-information-outline" />
         </cat-tooltip>
+        <cat-tooltip text="Recompute the stop buffer clip against the stops matching your current filters. The clip is a server-side calculation, so it isn't redone automatically as you change filters.">
+          <button
+            type="button"
+            class="cal-agg-refresh"
+            aria-label="Recompute for current filters"
+            @click="$emit('refreshCensus')"
+          >
+            <i class="mdi mdi-refresh" />
+          </button>
+        </cat-tooltip>
       </template>
       <cat-select
         v-model="aggClipMode"
@@ -112,7 +122,7 @@
         </cat-checkbox>
       </li>
       <li>
-        <cat-tooltip text="Shades the part of the query area within the stop statistical radius of the stops matching your filters — the same footprint the stop-buffer clipping mode measures. Draws nothing when the radius is 0.">
+        <cat-tooltip text="Outlines the area within the stop statistical radius of each route's stops. Draws nothing when the radius is 0.">
           <cat-checkbox v-model="showStopBuffer">
             Show stop buffers
           </cat-checkbox>
@@ -147,6 +157,10 @@ const props = defineProps<{
   hasBufferClip?: boolean
 }>()
 
+defineEmits<{
+  refreshCensus: []
+}>()
+
 const {
   showAggAreas,
   aggClipMode,
@@ -168,3 +182,18 @@ const showFiltered = computed({
   set: (v: boolean) => { hideUnmarked.value = !v }
 })
 </script>
+
+<style scoped lang="scss">
+.cal-agg-refresh {
+  background: none;
+  border: 0;
+  padding: 0 2px;
+  font: inherit;
+  color: var(--bulma-link);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--bulma-link-hover);
+  }
+}
+</style>

--- a/app/components/cal/filter-map-display.vue
+++ b/app/components/cal/filter-map-display.vue
@@ -112,7 +112,7 @@
         </cat-checkbox>
       </li>
       <li>
-        <cat-tooltip text="Outlines the area within the stop statistical radius of each route's stops. Draws nothing when the radius is 0.">
+        <cat-tooltip text="Shades the part of the query area within the stop statistical radius of the stops matching your filters — the same footprint the stop-buffer clipping mode measures. Draws nothing when the radius is 0.">
           <cat-checkbox v-model="showStopBuffer">
             Show stop buffers
           </cat-checkbox>

--- a/app/components/cal/filter-map-display.vue
+++ b/app/components/cal/filter-map-display.vue
@@ -31,7 +31,7 @@
     </p>
     <cat-field>
       <template #label>
-        Show agg. areas <cat-tooltip text="Whether the map shades census geographies by their full values, or scales them to the part of each geography inside the query area, or inside the stop buffers.">
+        Show agg. areas <cat-tooltip text="Whether the map shades census geographies by their full values, or scales them to the part of each geography inside the query area — optionally narrowed again to what falls within the stop buffer radius. Clipped modes also draw each geography as the clipped footprint rather than its whole outline.">
           <i class="mdi mdi-information-outline" />
         </cat-tooltip>
       </template>

--- a/app/components/cal/filter-map-display.vue
+++ b/app/components/cal/filter-map-display.vue
@@ -29,13 +29,25 @@
     <p class="menu-label">
       Aggregation
     </p>
-    <ul>
-      <li>
-        <cat-checkbox v-model="showAggAreas">
-          Show Agg. Areas
-        </cat-checkbox>
-      </li>
-    </ul>
+    <cat-field>
+      <template #label>
+        Show agg. areas <cat-tooltip text="Whether the map shades census geographies by their full values, or scales them to the part of each geography inside the query area, or inside the stop buffers.">
+          <i class="mdi mdi-information-outline" />
+        </cat-tooltip>
+      </template>
+      <cat-select
+        v-model="aggAreaMode"
+      >
+        <option
+          v-for="option of AGG_AREA_MODE_OPTIONS"
+          :key="option.value"
+          :value="option.value"
+          :disabled="option.value === 'buffer' && !props.hasBufferClip"
+        >
+          {{ option.label }}{{ option.value === 'buffer' && !props.hasBufferClip ? ' (needs a stop radius)' : '' }}
+        </option>
+      </cat-select>
+    </cat-field>
     <cat-field class="mt-2">
       <template #label>
         Aggregate by
@@ -115,6 +127,7 @@
 
 <script setup lang="ts">
 import {
+  AGG_AREA_MODE_OPTIONS,
   baseMapStyles,
   CHOROPLETH_ELEMENT_OPTIONS,
   isElementDensityEligible,
@@ -123,10 +136,12 @@ import {
 
 const props = defineProps<{
   censusGeographyLayerOptions?: { label: string, value: string }[]
+  // False until a loaded scenario carries buffer-clipped intersections.
+  hasBufferClip?: boolean
 }>()
 
 const {
-  showAggAreas,
+  aggAreaMode,
   showStopBuffer,
   aggregateLayer,
   choroplethElement,

--- a/app/components/cal/filter-map-display.vue
+++ b/app/components/cal/filter-map-display.vue
@@ -29,17 +29,24 @@
     <p class="menu-label">
       Aggregation
     </p>
-    <cat-field>
+    <ul>
+      <li>
+        <cat-checkbox v-model="showAggAreas">
+          Show Agg. Areas
+        </cat-checkbox>
+      </li>
+    </ul>
+    <cat-field class="mt-2">
       <template #label>
-        Show agg. areas <cat-tooltip text="Whether the map shades census geographies by their full values, or scales them to the part of each geography inside the query area — optionally narrowed again to what falls within the stop buffer radius. Clipped modes also draw each geography as the clipped footprint rather than its whole outline.">
+        Clipping mode <cat-tooltip text="How much of each census geography the map measures and draws. Clipped modes scale demographics to the part of the geography inside the area, draw it as that clipped footprint rather than its whole outline, and hide geographies the area doesn't reach.">
           <i class="mdi mdi-information-outline" />
         </cat-tooltip>
       </template>
       <cat-select
-        v-model="aggAreaMode"
+        v-model="aggClipMode"
       >
         <option
-          v-for="option of AGG_AREA_MODE_OPTIONS"
+          v-for="option of AGG_CLIP_MODE_OPTIONS"
           :key="option.value"
           :value="option.value"
           :disabled="option.value === 'buffer' && !props.hasBufferClip"
@@ -127,7 +134,7 @@
 
 <script setup lang="ts">
 import {
-  AGG_AREA_MODE_OPTIONS,
+  AGG_CLIP_MODE_OPTIONS,
   baseMapStyles,
   CHOROPLETH_ELEMENT_OPTIONS,
   isElementDensityEligible,
@@ -141,7 +148,8 @@ const props = defineProps<{
 }>()
 
 const {
-  aggAreaMode,
+  showAggAreas,
+  aggClipMode,
   showStopBuffer,
   aggregateLayer,
   choroplethElement,

--- a/app/components/cal/filter.vue
+++ b/app/components/cal/filter.vue
@@ -153,6 +153,7 @@
         <cal-filter-map-display
           :census-geography-layer-options="props.censusGeographyLayerOptions"
           :has-buffer-clip="hasBufferClip"
+          @refresh-census="emit('refreshCensus')"
         />
       </div>
 
@@ -251,6 +252,7 @@ const panelPaddingPx = `${PANEL_PADDING}px`
 const emit = defineEmits([
   'resetFilters',
   'showQuery',
+  'refreshCensus',
 ])
 const activeTab = defineModel<string>('activeTab')
 

--- a/app/components/cal/filter.vue
+++ b/app/components/cal/filter.vue
@@ -152,7 +152,6 @@
       >
         <cal-filter-map-display
           :census-geography-layer-options="props.censusGeographyLayerOptions"
-          :has-buffer-clip="hasBufferClip"
           @refresh-census="emit('refreshCensus')"
         />
       </div>
@@ -199,22 +198,6 @@ const props = defineProps<{
   aggregateGeoCount?: number
   aggregateLayerLabel?: string
 }>()
-
-// The buffer clip is a second census pass that only runs when the scenario has
-// a stop buffer radius, so the mode it enables stays disabled until the data
-// is actually loaded.
-const hasBufferClip = computed((): boolean => {
-  const geos = props.scenarioFilterResult?.censusGeographies
-  if (!geos) {
-    return false
-  }
-  for (const geo of geos.values()) {
-    if (geo.bufferIntersectionRatio != null) {
-      return true
-    }
-  }
-  return false
-})
 
 const {
   startDate,

--- a/app/components/cal/filter.vue
+++ b/app/components/cal/filter.vue
@@ -150,7 +150,10 @@
         aria-labelledby="cal-filter-tab-data-display"
         tabindex="0"
       >
-        <cal-filter-map-display :census-geography-layer-options="props.censusGeographyLayerOptions" />
+        <cal-filter-map-display
+          :census-geography-layer-options="props.censusGeographyLayerOptions"
+          :has-buffer-clip="hasBufferClip"
+        />
       </div>
 
       <!-- SETTINGS -->
@@ -195,6 +198,22 @@ const props = defineProps<{
   aggregateGeoCount?: number
   aggregateLayerLabel?: string
 }>()
+
+// The buffer clip is a second census pass that only runs when the scenario has
+// a stop buffer radius, so the mode it enables stays disabled until the data
+// is actually loaded.
+const hasBufferClip = computed((): boolean => {
+  const geos = props.scenarioFilterResult?.censusGeographies
+  if (!geos) {
+    return false
+  }
+  for (const geo of geos.values()) {
+    if (geo.bufferIntersectionRatio != null) {
+      return true
+    }
+  }
+  return false
+})
 
 const {
   startDate,

--- a/app/components/cal/legend.vue
+++ b/app/components/cal/legend.vue
@@ -140,7 +140,7 @@
             <div><em>Not</em> satisfying all filters</div>
           </div>
         </div>
-        <div v-if="showAggAreas && props.hasChoroplethData" class="choropleth-legend">
+        <div v-if="showChoropleth" class="choropleth-legend">
           <div class="legend-heading">
             {{ props.choroplethClassification?.label || 'Aggregated Areas' }}
             <span v-if="props.choroplethClassification?.isDensity" class="cal-legend-unit-suffix">
@@ -204,10 +204,12 @@ defineEmits<{
   viewDetails: []
 }>()
 
-const { showAggAreas, hideUnmarked, dataDisplayMode, unitSystem, isAllDayMode } = useScenarioDisplay()
+const { aggAreaMode, hideUnmarked, dataDisplayMode, unitSystem, isAllDayMode } = useScenarioDisplay()
 const { geomSource } = useScenarioInputs()
 
-const shouldShowLegend = computed(() => props.hasData || props.hasFlexData || props.hasClusterData || props.displayEditBboxMode || props.showBbox || geomSource.value === 'adminBoundary' || (showAggAreas.value && props.hasChoroplethData))
+const showChoropleth = computed(() => aggAreaMode.value !== 'off' && props.hasChoroplethData)
+
+const shouldShowLegend = computed(() => props.hasData || props.hasFlexData || props.hasClusterData || props.displayEditBboxMode || props.showBbox || geomSource.value === 'adminBoundary' || showChoropleth.value)
 
 function bucketLabel (i: number): string {
   const c = props.choroplethClassification

--- a/app/components/cal/legend.vue
+++ b/app/components/cal/legend.vue
@@ -204,10 +204,10 @@ defineEmits<{
   viewDetails: []
 }>()
 
-const { aggAreaMode, hideUnmarked, dataDisplayMode, unitSystem, isAllDayMode } = useScenarioDisplay()
+const { showAggAreas, hideUnmarked, dataDisplayMode, unitSystem, isAllDayMode } = useScenarioDisplay()
 const { geomSource } = useScenarioInputs()
 
-const showChoropleth = computed(() => aggAreaMode.value !== 'off' && props.hasChoroplethData)
+const showChoropleth = computed(() => showAggAreas.value && props.hasChoroplethData)
 
 const shouldShowLegend = computed(() => props.hasData || props.hasFlexData || props.hasClusterData || props.displayEditBboxMode || props.showBbox || geomSource.value === 'adminBoundary' || showChoropleth.value)
 

--- a/app/components/cal/map-viewer-ts.vue
+++ b/app/components/cal/map-viewer-ts.vue
@@ -572,6 +572,8 @@ function createLayers () {
       'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1.0],
     }
   })
+  // Kept at zero opacity rather than dropped: it's the hit target for
+  // dragging the bbox by its interior in edit mode.
   map?.addLayer({
     id: 'overlay-polygons',
     type: 'fill',
@@ -579,7 +581,7 @@ function createLayers () {
     layout: {},
     paint: {
       'fill-color': '#ccc',
-      'fill-opacity': 0.3
+      'fill-opacity': 0
     }
   })
   map?.addLayer({
@@ -590,22 +592,20 @@ function createLayers () {
     paint: {
       'line-width': 2,
       'line-color': '#ff0000',
-      'line-opacity': 0.6
+      'line-opacity': 0.6,
+      'line-dasharray': [6, 3]
     }
   })
-  // Outline only: one polygon per route, so a fill would stack opacity
-  // wherever routes overlap. Dashed to separate it from the solid
-  // geographic-filter outline in the same red.
+  // Filled, not outlined: the pieces are per-geography and disjoint, so an
+  // outline would draw geography seams that aren't part of the buffer.
   map?.addLayer({
-    id: 'stop-buffer-outline',
-    type: 'line',
+    id: 'stop-buffer-fill',
+    type: 'fill',
     source: 'stopBufferPolygons',
     layout: {},
     paint: {
-      'line-width': 2,
-      'line-color': '#ff0000',
-      'line-opacity': 0.6,
-      'line-dasharray': [3, 2]
+      'fill-color': '#ff0000',
+      'fill-opacity': 0.15
     }
   })
 

--- a/app/components/cal/map-viewer-ts.vue
+++ b/app/components/cal/map-viewer-ts.vue
@@ -596,16 +596,19 @@ function createLayers () {
       'line-dasharray': [6, 3]
     }
   })
-  // Filled, not outlined: the pieces are per-geography and disjoint, so an
-  // outline would draw geography seams that aren't part of the buffer.
+  // Outline only: one polygon per route, so a fill would stack opacity
+  // wherever routes overlap. Shorter dashes than the query-area outline it
+  // shares a red with.
   map?.addLayer({
-    id: 'stop-buffer-fill',
-    type: 'fill',
+    id: 'stop-buffer-outline',
+    type: 'line',
     source: 'stopBufferPolygons',
     layout: {},
     paint: {
-      'fill-color': '#ff0000',
-      'fill-opacity': 0.15
+      'line-width': 2,
+      'line-color': '#ff0000',
+      'line-opacity': 0.6,
+      'line-dasharray': [3, 2]
     }
   })
 

--- a/app/composables/useAggregateRefetch.ts
+++ b/app/composables/useAggregateRefetch.ts
@@ -5,7 +5,7 @@
 // census-values map needs refetching. Streaming/abort/debounce machinery lives
 // in useStreamingRefetch.
 
-import { computed, ref, watchEffect, type Ref } from 'vue'
+import { ref, watchEffect, type Ref } from 'vue'
 import { aggClipNeedsGeometry } from '~~/src/core'
 import { useScenarioDisplay } from './useScenarioDisplay'
 import { useScenarioInputs } from './useScenarioInputs'
@@ -21,38 +21,38 @@ export interface UseAggregateRefetchDeps extends StreamingRefetchDeps {
   markedStopIds: Ref<number[]>
 }
 
-export function useAggregateRefetch (deps: UseAggregateRefetchDeps): void {
-  const { aggregateLayer, showAggAreas, aggClipMode, showStopBuffer } = useScenarioDisplay()
+export interface UseAggregateRefetchReturn {
+  // Recompute the clip against the current filters. Manual rather than
+  // watched: the marked set churns while results stream in, so watching it
+  // fires a recompute in the middle of a scenario load, where it fights the
+  // main run for the loading modal and the census slice of the receiver.
+  refresh: () => void
+}
+
+export function useAggregateRefetch (deps: UseAggregateRefetchDeps): UseAggregateRefetchReturn {
+  const { aggregateLayer, showAggAreas, aggClipMode } = useScenarioDisplay()
   // The census-values phase pads the fetch bbox by the stop buffer radius, so a
   // radius change (not just a layer change) can shift which edge geographies the
   // map needs — refetch on both.
   const { stopBufferRadius } = useScenarioInputs()
 
-  // Clipped outlines aren't fetched by the initial scenario run, so the first
-  // display that draws them costs one refetch. Latched rather than tracked, so
-  // hiding the overlay or switching back to unclipped doesn't throw the
-  // outlines away and make returning cost another round trip. Both clips
-  // arrive together, so queryArea↔buffer is free either way.
+  // The scenario run fetches clipped outlines when the display already wants
+  // them, so this only has to cover turning a clipped mode on afterwards.
+  // Latched, so switching back to unclipped doesn't throw the outlines away
+  // and make returning cost another round trip.
   const geometryLatch = ref(false)
   watchEffect(() => {
-    const forChoropleth = showAggAreas.value && aggClipNeedsGeometry(aggClipMode.value)
-    if (forChoropleth || showStopBuffer.value) {
+    if (showAggAreas.value && aggClipNeedsGeometry(aggClipMode.value)) {
       geometryLatch.value = true
     }
   })
-  const needsGeometry = computed(() => geometryLatch.value)
 
-  // An unfiltered scenario collapses to one sentinel: the initial run already
-  // clipped against every stop, and the marked set churns as results stream
-  // in, which would otherwise fire a pointless recompute on every load.
-  const markedStopKey = computed(() => {
-    const marked = deps.markedStopIds.value
-    const total = deps.scenarioData.value?.stops.length ?? 0
-    return marked.length >= total ? 'all' : marked.join(',')
-  })
+  // Bumped by `refresh()`; see UseAggregateRefetchReturn for why the marked
+  // set isn't watched directly.
+  const manualRefresh = ref(0)
 
   useStreamingRefetch(deps, {
-    watchSources: [aggregateLayer, stopBufferRadius, needsGeometry, markedStopKey],
+    watchSources: [aggregateLayer, stopBufferRadius, geometryLatch, manualRefresh],
     // Reuse the standalone census-values phase endpoint (it re-resolves
     // geographyIds or a plain bbox server-side) rather than a bespoke one.
     endpoint: '/api/scenario/census-values',
@@ -86,9 +86,11 @@ export function useAggregateRefetch (deps: UseAggregateRefetchDeps): void {
         // Marked only. An empty set means the filter excluded everything, so
         // the clip pass correctly skips and the values stay query-area.
         stopIds: deps.markedStopIds.value,
-        includeIntersectionGeometry: needsGeometry.value,
+        includeIntersectionGeometry: geometryLatch.value,
       }
       return body
     },
   })
+
+  return { refresh: () => { manualRefresh.value++ } }
 }

--- a/app/composables/useAggregateRefetch.ts
+++ b/app/composables/useAggregateRefetch.ts
@@ -5,6 +5,8 @@
 // census-values map needs refetching. Streaming/abort/debounce machinery lives
 // in useStreamingRefetch.
 
+import { computed } from 'vue'
+import { aggAreaModeNeedsGeometry } from '~~/src/core'
 import { useScenarioDisplay } from './useScenarioDisplay'
 import { useScenarioInputs } from './useScenarioInputs'
 import { useStreamingRefetch, type StreamingRefetchDeps } from './useStreamingRefetch'
@@ -15,14 +17,19 @@ import type { CensusValuesPhaseConfig } from '~~/src/scenario'
 export type UseAggregateRefetchDeps = StreamingRefetchDeps
 
 export function useAggregateRefetch (deps: UseAggregateRefetchDeps): void {
-  const { aggregateLayer } = useScenarioDisplay()
+  const { aggregateLayer, aggAreaMode } = useScenarioDisplay()
   // The census-values phase pads the fetch bbox by the stop buffer radius, so a
   // radius change (not just a layer change) can shift which edge geographies the
   // map needs — refetch on both.
   const { stopBufferRadius } = useScenarioInputs()
+  // Clipped outlines aren't fetched by the initial scenario run, so entering a
+  // mode that draws them costs one refetch. Watching the boolean rather than
+  // the mode keeps the other transitions (off↔unclipped, queryArea↔buffer)
+  // free — both clips already arrive together.
+  const needsGeometry = computed(() => aggAreaModeNeedsGeometry(aggAreaMode.value))
 
   useStreamingRefetch(deps, {
-    watchSources: [aggregateLayer, stopBufferRadius],
+    watchSources: [aggregateLayer, stopBufferRadius, needsGeometry],
     // Reuse the standalone census-values phase endpoint (it re-resolves
     // geographyIds or a plain bbox server-side) rather than a bespoke one.
     endpoint: '/api/scenario/census-values',
@@ -50,6 +57,7 @@ export function useAggregateRefetch (deps: UseAggregateRefetchDeps): void {
         // Same stop set the scenario resolved; without it the refetch drops
         // back to query-area-only values.
         stopIds: data.stops.map(s => s.id),
+        includeIntersectionGeometry: needsGeometry.value,
       }
       return body
     },

--- a/app/composables/useAggregateRefetch.ts
+++ b/app/composables/useAggregateRefetch.ts
@@ -6,7 +6,6 @@
 // in useStreamingRefetch.
 
 import { ref, watchEffect, type Ref } from 'vue'
-import { aggClipNeedsGeometry } from '~~/src/core'
 import { useScenarioDisplay } from './useScenarioDisplay'
 import { useScenarioInputs } from './useScenarioInputs'
 import { useStreamingRefetch, type StreamingRefetchDeps } from './useStreamingRefetch'
@@ -21,19 +20,10 @@ export interface UseAggregateRefetchDeps extends StreamingRefetchDeps {
   markedStopIds: Ref<number[]>
 }
 
-export interface UseAggregateRefetchReturn {
-  // Recompute the clip against the current filters. Manual rather than
-  // watched: the marked set churns while results stream in, so watching it
-  // fires a recompute in the middle of a scenario load, where it fights the
-  // main run for the loading modal and the census slice of the receiver.
-  refresh: () => void
-}
-
-export function useAggregateRefetch (deps: UseAggregateRefetchDeps): UseAggregateRefetchReturn {
+export function useAggregateRefetch (deps: UseAggregateRefetchDeps): { refresh: () => void } {
   const { aggregateLayer, showAggAreas, aggClipMode } = useScenarioDisplay()
-  // The census-values phase pads the fetch bbox by the stop buffer radius, so a
-  // radius change (not just a layer change) can shift which edge geographies the
-  // map needs — refetch on both.
+  // The radius defines the stop buffer clip, so changing it changes the
+  // numbers just as much as changing the layer does.
   const { stopBufferRadius } = useScenarioInputs()
 
   // The scenario run fetches clipped outlines when the display already wants
@@ -42,13 +32,14 @@ export function useAggregateRefetch (deps: UseAggregateRefetchDeps): UseAggregat
   // and make returning cost another round trip.
   const geometryLatch = ref(false)
   watchEffect(() => {
-    if (showAggAreas.value && aggClipNeedsGeometry(aggClipMode.value)) {
+    if (showAggAreas.value && aggClipMode.value !== 'unclipped') {
       geometryLatch.value = true
     }
   })
 
-  // Bumped by `refresh()`; see UseAggregateRefetchReturn for why the marked
-  // set isn't watched directly.
+  // The marked set churns while results stream in, so watching it would fire a
+  // recompute mid-load and fight the main run for the loading modal and the
+  // receiver's census slice. Bumped by `refresh()` instead.
   const manualRefresh = ref(0)
 
   useStreamingRefetch(deps, {

--- a/app/composables/useAggregateRefetch.ts
+++ b/app/composables/useAggregateRefetch.ts
@@ -42,6 +42,11 @@ export function useAggregateRefetch (deps: UseAggregateRefetchDeps): { refresh: 
   // receiver's census slice. Bumped by `refresh()` instead.
   const manualRefresh = ref(0)
 
+  // Until the user asks for it, the clip uses the same stop set the main run
+  // did. Sticky once asked, so a later layer or radius change doesn't quietly
+  // revert the clip to every stop in the query area.
+  const clipToMarkedStops = ref(false)
+
   useStreamingRefetch(deps, {
     watchSources: [aggregateLayer, stopBufferRadius, geometryLatch, manualRefresh],
     // Reuse the standalone census-values phase endpoint (it re-resolves
@@ -74,14 +79,21 @@ export function useAggregateRefetch (deps: UseAggregateRefetchDeps): { refresh: 
         tableDatasetName: config.tableDatasetName,
         aggregateLayer: config.aggregateLayer,
         stopBufferRadius: config.stopBufferRadius,
-        // Marked only. An empty set means the filter excluded everything, so
-        // the clip pass correctly skips and the values stay query-area.
-        stopIds: deps.markedStopIds.value,
+        // An empty marked set means the filter excluded everything, so the
+        // clip pass correctly skips and the values stay query-area.
+        stopIds: clipToMarkedStops.value
+          ? deps.markedStopIds.value
+          : data.stops.map(s => s.id),
         includeIntersectionGeometry: geometryLatch.value,
       }
       return body
     },
   })
 
-  return { refresh: () => { manualRefresh.value++ } }
+  return {
+    refresh: () => {
+      clipToMarkedStops.value = true
+      manualRefresh.value++
+    },
+  }
 }

--- a/app/composables/useAggregateRefetch.ts
+++ b/app/composables/useAggregateRefetch.ts
@@ -5,8 +5,8 @@
 // census-values map needs refetching. Streaming/abort/debounce machinery lives
 // in useStreamingRefetch.
 
-import { computed } from 'vue'
-import { aggAreaModeNeedsGeometry } from '~~/src/core'
+import { computed, ref, watchEffect } from 'vue'
+import { aggClipNeedsGeometry } from '~~/src/core'
 import { useScenarioDisplay } from './useScenarioDisplay'
 import { useScenarioInputs } from './useScenarioInputs'
 import { useStreamingRefetch, type StreamingRefetchDeps } from './useStreamingRefetch'
@@ -17,16 +17,24 @@ import type { CensusValuesPhaseConfig } from '~~/src/scenario'
 export type UseAggregateRefetchDeps = StreamingRefetchDeps
 
 export function useAggregateRefetch (deps: UseAggregateRefetchDeps): void {
-  const { aggregateLayer, aggAreaMode } = useScenarioDisplay()
+  const { aggregateLayer, showAggAreas, aggClipMode } = useScenarioDisplay()
   // The census-values phase pads the fetch bbox by the stop buffer radius, so a
   // radius change (not just a layer change) can shift which edge geographies the
   // map needs — refetch on both.
   const { stopBufferRadius } = useScenarioInputs()
-  // Clipped outlines aren't fetched by the initial scenario run, so entering a
-  // mode that draws them costs one refetch. Watching the boolean rather than
-  // the mode keeps the other transitions (off↔unclipped, queryArea↔buffer)
-  // free — both clips already arrive together.
-  const needsGeometry = computed(() => aggAreaModeNeedsGeometry(aggAreaMode.value))
+
+  // Clipped outlines aren't fetched by the initial scenario run, so the first
+  // display that draws them costs one refetch. Latched rather than tracked, so
+  // hiding the overlay or switching back to unclipped doesn't throw the
+  // outlines away and make returning cost another round trip. Both clips
+  // arrive together, so queryArea↔buffer is free either way.
+  const geometryLatch = ref(false)
+  watchEffect(() => {
+    if (showAggAreas.value && aggClipNeedsGeometry(aggClipMode.value)) {
+      geometryLatch.value = true
+    }
+  })
+  const needsGeometry = computed(() => geometryLatch.value)
 
   useStreamingRefetch(deps, {
     watchSources: [aggregateLayer, stopBufferRadius, needsGeometry],

--- a/app/composables/useAggregateRefetch.ts
+++ b/app/composables/useAggregateRefetch.ts
@@ -5,7 +5,7 @@
 // census-values map needs refetching. Streaming/abort/debounce machinery lives
 // in useStreamingRefetch.
 
-import { computed, ref, watchEffect } from 'vue'
+import { computed, ref, watchEffect, type Ref } from 'vue'
 import { aggClipNeedsGeometry } from '~~/src/core'
 import { useScenarioDisplay } from './useScenarioDisplay'
 import { useScenarioInputs } from './useScenarioInputs'
@@ -14,10 +14,15 @@ import type { CensusValuesPhaseConfig } from '~~/src/scenario'
 
 // scenarioReceiver is created by useScenarioRun and shared so refetched
 // census values land in the same accumulator.
-export type UseAggregateRefetchDeps = StreamingRefetchDeps
+export interface UseAggregateRefetchDeps extends StreamingRefetchDeps {
+  // Marked stops from the filtered result. The stop-buffer clip follows the
+  // filter, so buffer coverage answers "within reach of the service you
+  // selected" rather than of every stop in the query area.
+  markedStopIds: Ref<number[]>
+}
 
 export function useAggregateRefetch (deps: UseAggregateRefetchDeps): void {
-  const { aggregateLayer, showAggAreas, aggClipMode } = useScenarioDisplay()
+  const { aggregateLayer, showAggAreas, aggClipMode, showStopBuffer } = useScenarioDisplay()
   // The census-values phase pads the fetch bbox by the stop buffer radius, so a
   // radius change (not just a layer change) can shift which edge geographies the
   // map needs — refetch on both.
@@ -30,22 +35,38 @@ export function useAggregateRefetch (deps: UseAggregateRefetchDeps): void {
   // arrive together, so queryArea↔buffer is free either way.
   const geometryLatch = ref(false)
   watchEffect(() => {
-    if (showAggAreas.value && aggClipNeedsGeometry(aggClipMode.value)) {
+    const forChoropleth = showAggAreas.value && aggClipNeedsGeometry(aggClipMode.value)
+    if (forChoropleth || showStopBuffer.value) {
       geometryLatch.value = true
     }
   })
   const needsGeometry = computed(() => geometryLatch.value)
 
+  // An unfiltered scenario collapses to one sentinel: the initial run already
+  // clipped against every stop, and the marked set churns as results stream
+  // in, which would otherwise fire a pointless recompute on every load.
+  const markedStopKey = computed(() => {
+    const marked = deps.markedStopIds.value
+    const total = deps.scenarioData.value?.stops.length ?? 0
+    return marked.length >= total ? 'all' : marked.join(',')
+  })
+
   useStreamingRefetch(deps, {
-    watchSources: [aggregateLayer, stopBufferRadius, needsGeometry],
+    watchSources: [aggregateLayer, stopBufferRadius, needsGeometry, markedStopKey],
     // Reuse the standalone census-values phase endpoint (it re-resolves
     // geographyIds or a plain bbox server-side) rather than a bespoke one.
     endpoint: '/api/scenario/census-values',
     phase: 'census-values',
     loadingMessage: 'Recomputing aggregation demographics...',
     // Drop the previous layer's geographies up-front so a slow/failed refetch
-    // can't leave the choropleth painting the old layer.
-    clearBeforeFetch: true,
+    // can't leave the choropleth painting the old layer. Only for a layer
+    // change: a filter change keeps the same geographies and only moves their
+    // numbers, so blanking the map on every checkbox would be worse than a
+    // moment of staleness.
+    clearBeforeFetch: () => {
+      const loaded = deps.scenarioData.value?.censusGeographies?.values().next().value
+      return !!loaded && loaded.layer !== aggregateLayer.value
+    },
     clearStale: receiver => receiver.clearCensusGeographies(),
     plan: (data, config) => {
       // Census was excluded at query time; nothing to recompute.
@@ -62,9 +83,9 @@ export function useAggregateRefetch (deps: UseAggregateRefetchDeps): void {
         tableDatasetName: config.tableDatasetName,
         aggregateLayer: config.aggregateLayer,
         stopBufferRadius: config.stopBufferRadius,
-        // Same stop set the scenario resolved; without it the refetch drops
-        // back to query-area-only values.
-        stopIds: data.stops.map(s => s.id),
+        // Marked only. An empty set means the filter excluded everything, so
+        // the clip pass correctly skips and the values stay query-area.
+        stopIds: deps.markedStopIds.value,
         includeIntersectionGeometry: needsGeometry.value,
       }
       return body

--- a/app/composables/useChoroplethClassification.ts
+++ b/app/composables/useChoroplethClassification.ts
@@ -27,7 +27,7 @@ interface UseChoroplethClassificationInput {
 
 // Wires the pure choropleth math from `src/core/choropleth.ts` to Vue refs.
 export function useChoroplethClassification (input: UseChoroplethClassificationInput) {
-  const { aggAreaMode, choroplethElement, shadeByDensity, unitSystem } = useScenarioDisplay()
+  const { showAggAreas, aggClipMode, choroplethElement, shadeByDensity, unitSystem } = useScenarioDisplay()
 
   const isDensityEligible = computed(() => isElementDensityEligible(choroplethElement.value))
 
@@ -38,7 +38,7 @@ export function useChoroplethClassification (input: UseChoroplethClassificationI
     const isDensity = shadeByDensity.value && isDensityEligible.value
     const geos = input.censusGeographies.value
     const unit = unitSystem.value
-    const mode = aggAreaMode.value
+    const mode = aggClipMode.value
     const out = new Map<string, number | null>()
     for (const a of aggData) {
       const row = a as Record<string, any>
@@ -74,8 +74,8 @@ export function useChoroplethClassification (input: UseChoroplethClassificationI
   // Feature properties carry only geoid/name + styling — the census panel
   // looks up the full row by geoid on click instead of bloating each feature.
   const choroplethFeatures = computed((): Feature[] => {
-    const mode = aggAreaMode.value
-    if (mode === 'off') { return [] }
+    if (!showAggAreas.value) { return [] }
+    const mode = aggClipMode.value
 
     const aggData = input.choroplethAggregateData.value
     if (aggData.length === 0) { return [] }

--- a/app/composables/useChoroplethClassification.ts
+++ b/app/composables/useChoroplethClassification.ts
@@ -3,6 +3,7 @@ import {
   CENSUS_COLUMNS,
   CHOROPLETH_ELEMENT_OPTIONS,
   buildChoroplethClassification,
+  censusApportionGeometry,
   censusApportionRatio,
   densityPerArea,
   deriveApportionedColumn,
@@ -73,7 +74,8 @@ export function useChoroplethClassification (input: UseChoroplethClassificationI
   // Feature properties carry only geoid/name + styling — the census panel
   // looks up the full row by geoid on click instead of bloating each feature.
   const choroplethFeatures = computed((): Feature[] => {
-    if (aggAreaMode.value === 'off') { return [] }
+    const mode = aggAreaMode.value
+    if (mode === 'off') { return [] }
 
     const aggData = input.choroplethAggregateData.value
     if (aggData.length === 0) { return [] }
@@ -90,7 +92,15 @@ export function useChoroplethClassification (input: UseChoroplethClassificationI
     for (const agg of aggData) {
       const aggRow = agg as Record<string, any>
       const geo = geoLookup.get(aggRow.geoid as string)
-      if (!geo || !geo.geometry) { continue }
+      const censusGeo = censusGeos?.get(aggRow.geoid as string)
+
+      // The clipped outline when the scenario fetched one, so the polygon
+      // covers the footprint its value was computed over. Falls back to the
+      // full geography — which is all `unclipped` ever wants, and what a
+      // geography outside every stop buffer is drawn as.
+      const geometry = (censusGeo && censusApportionGeometry(censusGeo, mode)) || geo?.geometry
+      const featureId = censusGeo?.id ?? geo?.id
+      if (!geometry || featureId == null) { continue }
 
       const isSelected = aggRow.geoid === selectedGeoid
       const pickedValue = picked.get(aggRow.geoid as string) ?? null
@@ -101,11 +111,10 @@ export function useChoroplethClassification (input: UseChoroplethClassificationI
       // null for non-census shading elements.
       let scaledValue: number | null = null
       let densityValue: number | null = null
-      const censusGeo = elementCol ? censusGeos?.get(aggRow.geoid as string) : undefined
       if (elementCol && censusGeo) {
         scaledValue = deriveApportionedColumn(
           censusGeo.values,
-          censusApportionRatio(censusGeo, aggAreaMode.value),
+          censusApportionRatio(censusGeo, mode),
           element,
         )
         if (elementIsDensityEligible) {
@@ -115,8 +124,8 @@ export function useChoroplethClassification (input: UseChoroplethClassificationI
 
       features.push({
         type: 'Feature',
-        id: geo.id.toString(),
-        geometry: geo.geometry,
+        id: featureId.toString(),
+        geometry,
         properties: {
           'geoid': aggRow.geoid,
           'name': aggRow.name,

--- a/app/composables/useChoroplethClassification.ts
+++ b/app/composables/useChoroplethClassification.ts
@@ -3,6 +3,7 @@ import {
   CENSUS_COLUMNS,
   CHOROPLETH_ELEMENT_OPTIONS,
   buildChoroplethClassification,
+  censusApportionRatio,
   densityPerArea,
   deriveApportionedColumn,
   getChoroplethColor,
@@ -25,7 +26,7 @@ interface UseChoroplethClassificationInput {
 
 // Wires the pure choropleth math from `src/core/choropleth.ts` to Vue refs.
 export function useChoroplethClassification (input: UseChoroplethClassificationInput) {
-  const { showAggAreas, choroplethElement, shadeByDensity, unitSystem } = useScenarioDisplay()
+  const { aggAreaMode, choroplethElement, shadeByDensity, unitSystem } = useScenarioDisplay()
 
   const isDensityEligible = computed(() => isElementDensityEligible(choroplethElement.value))
 
@@ -36,10 +37,11 @@ export function useChoroplethClassification (input: UseChoroplethClassificationI
     const isDensity = shadeByDensity.value && isDensityEligible.value
     const geos = input.censusGeographies.value
     const unit = unitSystem.value
+    const mode = aggAreaMode.value
     const out = new Map<string, number | null>()
     for (const a of aggData) {
       const row = a as Record<string, any>
-      out.set(row.geoid as string, pickChoroplethValue(row, element, isDensity, geos, unit))
+      out.set(row.geoid as string, pickChoroplethValue(row, element, isDensity, geos, unit, mode))
     }
     return out
   })
@@ -71,7 +73,7 @@ export function useChoroplethClassification (input: UseChoroplethClassificationI
   // Feature properties carry only geoid/name + styling — the census panel
   // looks up the full row by geoid on click instead of bloating each feature.
   const choroplethFeatures = computed((): Feature[] => {
-    if (!showAggAreas.value) { return [] }
+    if (aggAreaMode.value === 'off') { return [] }
 
     const aggData = input.choroplethAggregateData.value
     if (aggData.length === 0) { return [] }
@@ -101,7 +103,11 @@ export function useChoroplethClassification (input: UseChoroplethClassificationI
       let densityValue: number | null = null
       const censusGeo = elementCol ? censusGeos?.get(aggRow.geoid as string) : undefined
       if (elementCol && censusGeo) {
-        scaledValue = deriveApportionedColumn(censusGeo.values, censusGeo.intersectionRatio, element)
+        scaledValue = deriveApportionedColumn(
+          censusGeo.values,
+          censusApportionRatio(censusGeo, aggAreaMode.value),
+          element,
+        )
         if (elementIsDensityEligible) {
           densityValue = densityPerArea(fullValue, censusGeo.geometryArea, unitSystem.value)
         }

--- a/app/composables/useScenarioDisplay.ts
+++ b/app/composables/useScenarioDisplay.ts
@@ -8,9 +8,10 @@ import {
 } from '~~/src/core'
 import { useUrlQuery } from './useUrlQuery'
 
-// Full geographies by default: the same numbers the overlay showed before
-// clipping existed, so clipping is something the user opts into.
-const AGG_CLIP_MODE_DEFAULT: AggClipMode = 'unclipped'
+// The overlay is off until asked for, so when it is asked for, answer the
+// question people actually have: what the transit service reaches. The less
+// clipped modes stay available for context.
+const AGG_CLIP_MODE_DEFAULT: AggClipMode = 'buffer'
 
 interface ScenarioDisplay {
   showAggAreas: WritableComputedRef<boolean>

--- a/app/composables/useScenarioDisplay.ts
+++ b/app/composables/useScenarioDisplay.ts
@@ -8,7 +8,9 @@ import {
 } from '~~/src/core'
 import { useUrlQuery } from './useUrlQuery'
 
-const AGG_CLIP_MODE_DEFAULT: AggClipMode = 'queryArea'
+// Full geographies by default: the same numbers the overlay showed before
+// clipping existed, so clipping is something the user opts into.
+const AGG_CLIP_MODE_DEFAULT: AggClipMode = 'unclipped'
 
 interface ScenarioDisplay {
   showAggAreas: WritableComputedRef<boolean>

--- a/app/composables/useScenarioDisplay.ts
+++ b/app/composables/useScenarioDisplay.ts
@@ -1,9 +1,15 @@
 import { computed, type ComputedRef, type WritableComputedRef } from 'vue'
-import { CHOROPLETH_DEFAULT_ELEMENT, type DataDisplayMode, type UnitSystem } from '~~/src/core'
+import {
+  AGG_AREA_MODE_OPTIONS,
+  CHOROPLETH_DEFAULT_ELEMENT,
+  type AggAreaMode,
+  type DataDisplayMode,
+  type UnitSystem,
+} from '~~/src/core'
 import { useUrlQuery } from './useUrlQuery'
 
 interface ScenarioDisplay {
-  showAggAreas: WritableComputedRef<boolean>
+  aggAreaMode: WritableComputedRef<AggAreaMode>
   showStopBuffer: WritableComputedRef<boolean>
   aggregateLayer: WritableComputedRef<string>
   choroplethElement: WritableComputedRef<string>
@@ -24,9 +30,16 @@ export function useScenarioDisplay (): ScenarioDisplay {
   const route = useRoute()
   const { setQuery } = useUrlQuery()
 
-  const showAggAreas = computed<boolean>({
-    get: () => route.query.showAggAreas?.toString() === 'true',
-    set: (v) => { setQuery({ showAggAreas: v ? 'true' : undefined }) }
+  // Same query parameter as the boolean this replaced, so shared links and
+  // canned examples keep working: `showAggAreas=true` reads as the query-area
+  // clip, which is the one the census panel already reported.
+  const aggAreaMode = computed<AggAreaMode>({
+    get: () => {
+      const v = route.query.showAggAreas?.toString()
+      if (v === 'true') { return 'queryArea' }
+      return AGG_AREA_MODE_OPTIONS.find(o => o.value === v)?.value || 'off'
+    },
+    set: (v) => { setQuery({ showAggAreas: v === 'off' ? undefined : v }) }
   })
 
   const showStopBuffer = computed<boolean>({
@@ -86,7 +99,7 @@ export function useScenarioDisplay (): ScenarioDisplay {
   const isAllDayMode = computed(() => !route.query.startTime && !route.query.endTime)
 
   return {
-    showAggAreas,
+    aggAreaMode,
     showStopBuffer,
     aggregateLayer,
     choroplethElement,

--- a/app/composables/useScenarioDisplay.ts
+++ b/app/composables/useScenarioDisplay.ts
@@ -1,15 +1,18 @@
 import { computed, type ComputedRef, type WritableComputedRef } from 'vue'
 import {
-  AGG_AREA_MODE_OPTIONS,
+  AGG_CLIP_MODE_OPTIONS,
   CHOROPLETH_DEFAULT_ELEMENT,
-  type AggAreaMode,
+  type AggClipMode,
   type DataDisplayMode,
   type UnitSystem,
 } from '~~/src/core'
 import { useUrlQuery } from './useUrlQuery'
 
+const AGG_CLIP_MODE_DEFAULT: AggClipMode = 'queryArea'
+
 interface ScenarioDisplay {
-  aggAreaMode: WritableComputedRef<AggAreaMode>
+  showAggAreas: WritableComputedRef<boolean>
+  aggClipMode: WritableComputedRef<AggClipMode>
   showStopBuffer: WritableComputedRef<boolean>
   aggregateLayer: WritableComputedRef<string>
   choroplethElement: WritableComputedRef<string>
@@ -30,16 +33,20 @@ export function useScenarioDisplay (): ScenarioDisplay {
   const route = useRoute()
   const { setQuery } = useUrlQuery()
 
-  // Same query parameter as the boolean this replaced, so shared links and
-  // canned examples keep working: `showAggAreas=true` reads as the query-area
-  // clip, which is the one the census panel already reported.
-  const aggAreaMode = computed<AggAreaMode>({
+  const showAggAreas = computed<boolean>({
+    get: () => route.query.showAggAreas?.toString() === 'true',
+    set: (v) => { setQuery({ showAggAreas: v ? 'true' : undefined }) }
+  })
+
+  // How the overlay measures each geography. Separate from the checkbox above:
+  // whether to draw and what to measure are different questions, and only the
+  // off state of each is worth a URL parameter.
+  const aggClipMode = computed<AggClipMode>({
     get: () => {
-      const v = route.query.showAggAreas?.toString()
-      if (v === 'true') { return 'queryArea' }
-      return AGG_AREA_MODE_OPTIONS.find(o => o.value === v)?.value || 'off'
+      const v = route.query.aggClip?.toString()
+      return AGG_CLIP_MODE_OPTIONS.find(o => o.value === v)?.value || AGG_CLIP_MODE_DEFAULT
     },
-    set: (v) => { setQuery({ showAggAreas: v === 'off' ? undefined : v }) }
+    set: (v) => { setQuery({ aggClip: v === AGG_CLIP_MODE_DEFAULT ? undefined : v }) }
   })
 
   const showStopBuffer = computed<boolean>({
@@ -99,7 +106,8 @@ export function useScenarioDisplay (): ScenarioDisplay {
   const isAllDayMode = computed(() => !route.query.startTime && !route.query.endTime)
 
   return {
-    aggAreaMode,
+    showAggAreas,
+    aggClipMode,
     showStopBuffer,
     aggregateLayer,
     choroplethElement,

--- a/app/composables/useStopBufferFeatures.ts
+++ b/app/composables/useStopBufferFeatures.ts
@@ -1,69 +1,46 @@
-// Map features for the stop buffer overlay: the area within the stop
-// statistical radius of each marked route's stops, unioned server-side. The
-// filtered scenario result is passed in by the container; the URL-backed
-// radius and display toggle are read from the useScenario* composables.
+// Map features for the stop buffer overlay: the part of each census geography
+// that falls inside both the query area and the stop buffers, as already
+// computed server-side for the `buffer` clipping mode. Derived from the
+// filtered scenario result the container passes in — no fetch of its own.
 
 import { computed, type Ref, type ComputedRef } from 'vue'
-import { useQuery } from '@vue/apollo-composable'
 import { useScenarioDisplay } from './useScenarioDisplay'
-import { useScenarioInputs } from './useScenarioInputs'
-import { routeStopBufferQuery, type RouteStopBufferResponse } from '~~/src/tl'
 import type { Feature } from '~~/src/core'
 import type { ScenarioFilterResult } from '~~/src/scenario'
-
-// The backend clamps `routes(limit:)` to this; asking for more silently
-// returns the same page.
-const ROUTE_LIMIT = 1000
 
 interface UseStopBufferFeaturesDeps {
   scenarioFilterResult: Ref<ScenarioFilterResult | undefined>
 }
 
 export interface UseStopBufferFeaturesReturn {
-  // Empty when the overlay is off, the radius is 0, or no route is marked.
+  // Empty unless the overlay is on and the buffer clip has been fetched.
   stopBufferFeatures: ComputedRef<Feature[]>
 }
 
 export function useStopBufferFeatures (deps: UseStopBufferFeaturesDeps): UseStopBufferFeaturesReturn {
   const { showStopBuffer } = useScenarioDisplay()
-  const { stopBufferRadius } = useScenarioInputs()
 
-  // Marked only, so the outlines trace what the map is drawing. Clamped to
-  // the server's cap: sending more ids returns the same page, and which
-  // buffers came back would depend on backend ordering.
-  const routeIds = computed((): number[] => {
-    if (!showStopBuffer.value || stopBufferRadius.value <= 0) { return [] }
-    const ids = (deps.scenarioFilterResult.value?.routes || []).filter(r => r.marked).map(r => r.id)
-    return ids.length > ROUTE_LIMIT ? ids.slice(0, ROUTE_LIMIT) : ids
-  })
-
-  const { result } = useQuery<{ routes: RouteStopBufferResponse[] }>(
-    routeStopBufferQuery,
-    () => ({
-      ids: routeIds.value,
-      radius: stopBufferRadius.value,
-      limit: ROUTE_LIMIT,
-    }),
-    () => ({
-      enabled: routeIds.value.length > 0,
-      // The radius is a slider; without this every step fires its own union.
-      debounce: 300,
-      // Holds the current outlines while the next radius is in flight.
-      keepPreviousResult: true,
-      // Each radius would otherwise pin its own copy of every route's
-      // geometry in the store for the session, and none of it is reused.
-      fetchPolicy: 'no-cache',
-    })
-  )
-
+  // One piece per geography rather than one polygon: geographies at a layer
+  // don't overlap, so the pieces are disjoint and paint as a single region
+  // without a union, and without the opacity stacking that made the old
+  // per-route buffers unusable as a fill.
+  //
+  // Independent of the clipping mode — the point is to see the analyzed
+  // footprint over whatever the choropleth is shading. In `buffer` mode the
+  // choropleth already draws these same shapes, so the two coincide.
   const stopBufferFeatures = computed((): Feature[] => {
-    // keepPreviousResult holds the last union after the query is disabled.
-    if (routeIds.value.length === 0) { return [] }
+    if (!showStopBuffer.value) { return [] }
+    const geos = deps.scenarioFilterResult.value?.censusGeographies
+    if (!geos) { return [] }
     const out: Feature[] = []
-    for (const route of result.value?.routes || []) {
-      const g = route.route_stop_buffer?.stop_buffer
-      if (!g) { continue }
-      out.push({ id: `route-buffer-${route.id}`, type: 'Feature', geometry: g, properties: {} })
+    for (const [geoid, geo] of geos) {
+      if (!geo.bufferIntersectionGeometry) { continue }
+      out.push({
+        id: `stop-buffer-${geoid}`,
+        type: 'Feature',
+        geometry: geo.bufferIntersectionGeometry,
+        properties: {},
+      })
     }
     return out
   })

--- a/app/composables/useStopBufferFeatures.ts
+++ b/app/composables/useStopBufferFeatures.ts
@@ -1,46 +1,69 @@
-// Map features for the stop buffer overlay: the part of each census geography
-// that falls inside both the query area and the stop buffers, as already
-// computed server-side for the `buffer` clipping mode. Derived from the
-// filtered scenario result the container passes in — no fetch of its own.
+// Map features for the stop buffer overlay: the area within the stop
+// statistical radius of each marked route's stops, unioned server-side. The
+// filtered scenario result is passed in by the container; the URL-backed
+// radius and display toggle are read from the useScenario* composables.
 
 import { computed, type Ref, type ComputedRef } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
 import { useScenarioDisplay } from './useScenarioDisplay'
+import { useScenarioInputs } from './useScenarioInputs'
+import { routeStopBufferQuery, type RouteStopBufferResponse } from '~~/src/tl'
 import type { Feature } from '~~/src/core'
 import type { ScenarioFilterResult } from '~~/src/scenario'
+
+// The backend clamps `routes(limit:)` to this; asking for more silently
+// returns the same page.
+const ROUTE_LIMIT = 1000
 
 interface UseStopBufferFeaturesDeps {
   scenarioFilterResult: Ref<ScenarioFilterResult | undefined>
 }
 
 export interface UseStopBufferFeaturesReturn {
-  // Empty unless the overlay is on and the buffer clip has been fetched.
+  // Empty when the overlay is off, the radius is 0, or no route is marked.
   stopBufferFeatures: ComputedRef<Feature[]>
 }
 
 export function useStopBufferFeatures (deps: UseStopBufferFeaturesDeps): UseStopBufferFeaturesReturn {
   const { showStopBuffer } = useScenarioDisplay()
+  const { stopBufferRadius } = useScenarioInputs()
 
-  // One piece per geography rather than one polygon: geographies at a layer
-  // don't overlap, so the pieces are disjoint and paint as a single region
-  // without a union, and without the opacity stacking that made the old
-  // per-route buffers unusable as a fill.
-  //
-  // Independent of the clipping mode — the point is to see the analyzed
-  // footprint over whatever the choropleth is shading. In `buffer` mode the
-  // choropleth already draws these same shapes, so the two coincide.
+  // Marked only, so the outlines trace what the map is drawing. Clamped to
+  // the server's cap: sending more ids returns the same page, and which
+  // buffers came back would depend on backend ordering.
+  const routeIds = computed((): number[] => {
+    if (!showStopBuffer.value || stopBufferRadius.value <= 0) { return [] }
+    const ids = (deps.scenarioFilterResult.value?.routes || []).filter(r => r.marked).map(r => r.id)
+    return ids.length > ROUTE_LIMIT ? ids.slice(0, ROUTE_LIMIT) : ids
+  })
+
+  const { result } = useQuery<{ routes: RouteStopBufferResponse[] }>(
+    routeStopBufferQuery,
+    () => ({
+      ids: routeIds.value,
+      radius: stopBufferRadius.value,
+      limit: ROUTE_LIMIT,
+    }),
+    () => ({
+      enabled: routeIds.value.length > 0,
+      // The radius is a slider; without this every step fires its own union.
+      debounce: 300,
+      // Holds the current outlines while the next radius is in flight.
+      keepPreviousResult: true,
+      // Each radius would otherwise pin its own copy of every route's
+      // geometry in the store for the session, and none of it is reused.
+      fetchPolicy: 'no-cache',
+    })
+  )
+
   const stopBufferFeatures = computed((): Feature[] => {
-    if (!showStopBuffer.value) { return [] }
-    const geos = deps.scenarioFilterResult.value?.censusGeographies
-    if (!geos) { return [] }
+    // keepPreviousResult holds the last union after the query is disabled.
+    if (routeIds.value.length === 0) { return [] }
     const out: Feature[] = []
-    for (const [geoid, geo] of geos) {
-      if (!geo.bufferIntersectionGeometry) { continue }
-      out.push({
-        id: `stop-buffer-${geoid}`,
-        type: 'Feature',
-        geometry: geo.bufferIntersectionGeometry,
-        properties: {},
-      })
+    for (const route of result.value?.routes || []) {
+      const g = route.route_stop_buffer?.stop_buffer
+      if (!g) { continue }
+      out.push({ id: `route-buffer-${route.id}`, type: 'Feature', geometry: g, properties: {} })
     }
     return out
   })

--- a/app/composables/useStreamingRefetch.ts
+++ b/app/composables/useStreamingRefetch.ts
@@ -53,15 +53,18 @@ export interface StreamingRefetchOptions {
   // Drop this feature's accumulated slice (e.g. clearBufferGeographies /
   // clearStopClusters). Used by the 'clear' plan and, if clearOnError, on failure.
   clearStale: (receiver: ScenarioDataReceiver) => void
-  // Clear the stale slice up-front, before the server responds.
-  clearBeforeFetch?: boolean
+  // Clear the stale slice up-front, before the server responds. A callback
+  // when only some triggers invalidate what's on screen.
+  clearBeforeFetch?: boolean | (() => boolean)
   // Clear the stale slice when a recompute fails, so a failed run doesn't strand
   // the previous (now mismatched) results.
   clearOnError?: boolean
 }
 
-// Without debounce a slider drag fires one request per step.
-const DEBOUNCE_MS = 500
+// Without debounce a slider drag fires one request per step, and a run of
+// filter toggles fires one per click. Long enough to treat a burst of input
+// as the single intent it usually is.
+const DEBOUNCE_MS = 1000
 
 export function useStreamingRefetch (deps: StreamingRefetchDeps, opts: StreamingRefetchOptions): void {
   let abort: AbortController | undefined
@@ -91,7 +94,10 @@ export function useStreamingRefetch (deps: StreamingRefetchDeps, opts: Streaming
       applyClear(receiver)
       return
     }
-    if (opts.clearBeforeFetch) {
+    const clearFirst = typeof opts.clearBeforeFetch === 'function'
+      ? opts.clearBeforeFetch()
+      : opts.clearBeforeFetch
+    if (clearFirst) {
       applyClear(receiver)
     }
 

--- a/app/composables/useStreamingRefetch.ts
+++ b/app/composables/useStreamingRefetch.ts
@@ -4,7 +4,7 @@
 // share — debounce, AbortController lifecycle, the NDJSON stream into the existing
 // receiver, loading-modal wiring — and leaves each feature its inputs/endpoint/body.
 
-import { markRaw, watch, onScopeDispose, type Ref, type ShallowRef, type WatchSource } from 'vue'
+import { markRaw, toValue, watch, onScopeDispose, type MaybeRefOrGetter, type Ref, type ShallowRef, type WatchSource } from 'vue'
 import {
   ScenarioStreamReceiver,
   type ScenarioConfig,
@@ -53,18 +53,16 @@ export interface StreamingRefetchOptions {
   // Drop this feature's accumulated slice (e.g. clearBufferGeographies /
   // clearStopClusters). Used by the 'clear' plan and, if clearOnError, on failure.
   clearStale: (receiver: ScenarioDataReceiver) => void
-  // Clear the stale slice up-front, before the server responds. A callback
-  // when only some triggers invalidate what's on screen.
-  clearBeforeFetch?: boolean | (() => boolean)
+  // Clear the stale slice up-front, before the server responds. A getter when
+  // only some triggers invalidate what's on screen.
+  clearBeforeFetch?: MaybeRefOrGetter<boolean>
   // Clear the stale slice when a recompute fails, so a failed run doesn't strand
   // the previous (now mismatched) results.
   clearOnError?: boolean
 }
 
-// Without debounce a slider drag fires one request per step, and a run of
-// filter toggles fires one per click. Long enough to treat a burst of input
-// as the single intent it usually is.
-const DEBOUNCE_MS = 1000
+// Without debounce a slider drag fires one request per step.
+const DEBOUNCE_MS = 500
 
 export function useStreamingRefetch (deps: StreamingRefetchDeps, opts: StreamingRefetchOptions): void {
   let abort: AbortController | undefined
@@ -94,10 +92,7 @@ export function useStreamingRefetch (deps: StreamingRefetchDeps, opts: Streaming
       applyClear(receiver)
       return
     }
-    const clearFirst = typeof opts.clearBeforeFetch === 'function'
-      ? opts.clearBeforeFetch()
-      : opts.clearBeforeFetch
-    if (clearFirst) {
+    if (toValue(opts.clearBeforeFetch)) {
       applyClear(receiver)
     }
 

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -59,6 +59,7 @@
             :active-tab="activeTab.sub"
             @reset-filters="resetFilters"
             @show-query="activeTab = { tab: 'query', sub: '' }"
+            @refresh-census="refreshCensusClip"
           />
         </div>
 
@@ -752,6 +753,7 @@ const scenarioConfig = computed((): ScenarioConfig => ({
     ? true
     : includeDepartures.value,
   includeCensus: includeCensus.value,
+  includeIntersectionGeometry: showAggAreas.value && aggClipMode.value !== 'unclipped',
   // Feed version picks from the Query-tab picker modal (URL-backed).
   feedVersionOverrides: fvidsForConfig.value.feedVersionOverrides,
   excludedFeeds: fvidsForConfig.value.excludedFeeds,
@@ -921,9 +923,9 @@ useClusterRefetch({
   refetchInFlight,
 })
 
-// recompute census values when the Aggregate-by layer, the stop buffer radius,
-// or the marked stop set changes, reusing the same receiver.
-useAggregateRefetch({
+// recompute census values when the Aggregate-by layer or the stop buffer radius
+// changes, and on demand from the Map Display refresh, reusing the same receiver.
+const { refresh: refreshCensusClip } = useAggregateRefetch({
   scenarioReceiver,
   scenarioData,
   scenarioConfig,

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -223,7 +223,9 @@ import {
   SCENARIO_DEFAULTS,
   censusLayerLabels,
   formatAcsDatasetLabel,
-  summarizeBbox,
+  summarizeApportioned,
+  censusApportionArea,
+  censusApportionRatio,
   deriveApportionedRow,
   censusGeographyMapToEntries,
   type CensusGeographyEntry,
@@ -238,7 +240,7 @@ import { getSelectedDateRange, type ScenarioConfig, type ScenarioData, type Scen
 // Initialize composables
 const { setQuery } = useUrlQuery()
 const {
-  showAggAreas,
+  aggAreaMode,
   aggregateLayer,
   onlyWithStops,
   showBbox,
@@ -410,27 +412,32 @@ const selectedPanelData = computed(() => {
   const row = choroplethAggregateData.value.find(r => r.geoid === geoid)
   if (!row) { return null }
   const geo = scenarioFilterResult.value?.censusGeographies?.get(geoid)
+  if (!geo) {
+    return { row, apportionedDerived: null, areaStats: null }
+  }
+  const mode = aggAreaMode.value
+  const ratio = censusApportionRatio(geo, mode)
   return {
     row,
-    apportionedDerived: geo ? deriveApportionedRow(geo.values, geo.intersectionRatio) : null,
-    areaStats: geo
-      ? {
-          geometryArea: geo.geometryArea,
-          intersectionArea: geo.intersectionArea,
-          intersectionRatio: geo.intersectionRatio,
-        }
-      : null,
+    apportionedDerived: deriveApportionedRow(geo.values, ratio),
+    areaStats: {
+      geometryArea: geo.geometryArea,
+      // Unclipped mode has no intersection to report — the panel hides the
+      // row rather than restating the full area at 100%.
+      intersectionArea: mode === 'unclipped' ? null : censusApportionArea(geo, mode),
+      intersectionRatio: mode === 'unclipped' ? null : ratio,
+    },
   }
 })
 
-// Bbox-wide aggregate, fed to the panel's "Query Area Total" column.
-// Independent of the selection so it doesn't recompute on every click.
+// Aggregate across every geography, fed to the panel's total column. Independent
+// of the selection so it doesn't recompute on every click.
 const allGeographiesDerived = computed((): Record<string, number | null> | null => {
   const geos = scenarioFilterResult.value?.censusGeographies
   if (!geos || geos.size === 0) {
     return null
   }
-  return summarizeBbox(geos.keys(), geos).derived
+  return summarizeApportioned(geos.keys(), geos, aggAreaMode.value).derived
 })
 
 /////////////////////////
@@ -687,7 +694,7 @@ const censusDetailsEntries = computed<CensusGeographyEntry[]>(() => {
       }
     }
   }
-  return censusGeographyMapToEntries(result.censusGeographies, geoid => nameMap.get(geoid))
+  return censusGeographyMapToEntries(result.censusGeographies, aggAreaMode.value, geoid => nameMap.get(geoid))
 })
 
 const {
@@ -703,10 +710,13 @@ const {
   loadGeometry: loadBufferGeometry,
 } = useBufferDetails()
 
-// Force the overlay on so the selection actually renders on the map.
+// Force the overlay on so the selection actually renders on the map, leaving
+// an already-chosen clip alone.
 function onSelectGeographyFromDetails (geoid: string) {
   showCensusDetails.value = false
-  showAggAreas.value = true
+  if (aggAreaMode.value === 'off') {
+    aggAreaMode.value = 'queryArea'
+  }
   selectedAggregationGeoid.value = geoid
 }
 const selectedDateRange = computed(() => getSelectedDateRange(scenarioConfig.value))
@@ -803,7 +813,7 @@ const aggregateLayerLabel = computed((): string => {
 // All census geographies in the query area, used to fetch geometry for the
 // choropleth. Empty when the overlay is off.
 const choroplethGeoIds = computed((): number[] => {
-  if (!showAggAreas.value) { return [] }
+  if (aggAreaMode.value === 'off') { return [] }
   const geos = scenarioFilterResult.value?.censusGeographies
   if (!geos) { return [] }
   return [...geos.values()].map(g => g.id)
@@ -826,7 +836,7 @@ const {
 
 // Compute aggregate stats per geography
 const choroplethAggregateData = computed(() => {
-  if (!showAggAreas.value || !scenarioFilterResult.value) {
+  if (aggAreaMode.value === 'off' || !scenarioFilterResult.value) {
     return []
   }
   const markedStops = scenarioFilterResult.value.stops.filter(s => s.marked)

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -1054,6 +1054,17 @@ async function resetFilters () {
     flexColorBy: undefined,
     stopBufferRadius: undefined,
     stopBufferLayer: undefined,
+    // Map Display panel — every key useScenarioDisplay owns, so a cleared
+    // scenario doesn't inherit an overlay configured for the last one.
+    showAggAreas: undefined,
+    aggClip: undefined,
+    aggregateLayer: undefined,
+    choroplethElement: undefined,
+    shadeByDensity: undefined,
+    onlyWithStops: undefined,
+    showStopBuffer: undefined,
+    showBbox: undefined,
+    dataDisplayMode: undefined,
   })
 }
 

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -241,7 +241,8 @@ import { getSelectedDateRange, type ScenarioConfig, type ScenarioData, type Scen
 // Initialize composables
 const { setQuery } = useUrlQuery()
 const {
-  aggAreaMode,
+  showAggAreas,
+  aggClipMode,
   aggregateLayer,
   onlyWithStops,
   showBbox,
@@ -416,7 +417,7 @@ const selectedPanelData = computed(() => {
   if (!geo) {
     return { row, apportionedDerived: null, areaStats: null }
   }
-  const mode = aggAreaMode.value
+  const mode = aggClipMode.value
   const ratio = censusApportionRatio(geo, mode)
   return {
     row,
@@ -438,7 +439,7 @@ const allGeographiesDerived = computed((): Record<string, number | null> | null 
   if (!geos || geos.size === 0) {
     return null
   }
-  return summarizeApportioned(geos.keys(), geos, aggAreaMode.value).derived
+  return summarizeApportioned(geos.keys(), geos, aggClipMode.value).derived
 })
 
 /////////////////////////
@@ -695,7 +696,7 @@ const censusDetailsEntries = computed<CensusGeographyEntry[]>(() => {
       }
     }
   }
-  return censusGeographyMapToEntries(result.censusGeographies, aggAreaMode.value, geoid => nameMap.get(geoid))
+  return censusGeographyMapToEntries(result.censusGeographies, aggClipMode.value, geoid => nameMap.get(geoid))
 })
 
 const {
@@ -715,9 +716,7 @@ const {
 // an already-chosen clip alone.
 function onSelectGeographyFromDetails (geoid: string) {
   showCensusDetails.value = false
-  if (aggAreaMode.value === 'off') {
-    aggAreaMode.value = 'queryArea'
-  }
+  showAggAreas.value = true
   selectedAggregationGeoid.value = geoid
 }
 const selectedDateRange = computed(() => getSelectedDateRange(scenarioConfig.value))
@@ -816,8 +815,8 @@ const aggregateLayerLabel = computed((): string => {
 // geography outside every stop buffer, or the window before those outlines
 // have streamed in. Empty when the overlay is off.
 const choroplethGeoIds = computed((): number[] => {
-  const mode = aggAreaMode.value
-  if (mode === 'off') { return [] }
+  if (!showAggAreas.value) { return [] }
+  const mode = aggClipMode.value
   const geos = scenarioFilterResult.value?.censusGeographies
   if (!geos) { return [] }
   return [...geos.values()]
@@ -842,16 +841,29 @@ const {
 
 // Compute aggregate stats per geography
 const choroplethAggregateData = computed(() => {
-  if (aggAreaMode.value === 'off' || !scenarioFilterResult.value) {
+  if (!showAggAreas.value || !scenarioFilterResult.value) {
     return []
   }
   const markedStops = scenarioFilterResult.value.stops.filter(s => s.marked)
-  return stopGeoAggregateCsv(
+  const rows = stopGeoAggregateCsv(
     markedStops,
     aggregateLayer.value,
     scenarioFilterResult.value.censusGeographies,
     { onlyWithStops: onlyWithStops.value },
   )
+  // A clipped mode measures nothing for a geography the clip doesn't reach, so
+  // drop it rather than paint an empty polygon at zero. Filtered here so the
+  // legend's breaks aren't skewed by a pile of zeroes either. Rows with no
+  // census entry are stop-derived and unaffected.
+  const mode = aggClipMode.value
+  if (mode === 'unclipped') {
+    return rows
+  }
+  const geos = scenarioFilterResult.value.censusGeographies
+  return rows.filter((r) => {
+    const geo = geos?.get(r.geoid)
+    return !geo || censusApportionRatio(geo, mode) > 0
+  })
 })
 
 const { stopBufferFeatures } = useStopBufferFeatures({ scenarioFilterResult })

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -840,6 +840,11 @@ const {
 )
 
 // Compute aggregate stats per geography
+// The stop set the census clip is computed against, so buffer coverage tracks
+// the filter rather than the whole query area.
+const markedStopIds = computed((): number[] =>
+  (scenarioFilterResult.value?.stops || []).filter(s => s.marked).map(s => s.id))
+
 const choroplethAggregateData = computed(() => {
   if (!showAggAreas.value || !scenarioFilterResult.value) {
     return []
@@ -916,7 +921,8 @@ useClusterRefetch({
   refetchInFlight,
 })
 
-// recompute census values when the Aggregate-by layer changes, reusing the same receiver.
+// recompute census values when the Aggregate-by layer, the stop buffer radius,
+// or the marked stop set changes, reusing the same receiver.
 useAggregateRefetch({
   scenarioReceiver,
   scenarioData,
@@ -927,6 +933,7 @@ useAggregateRefetch({
   phasePlan: scenarioPhasePlan,
   phaseFractions: scenarioPhaseFractions,
   refetchInFlight,
+  markedStopIds,
 })
 
 const loadExampleData = async (exampleName: string) => {

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -225,6 +225,7 @@ import {
   formatAcsDatasetLabel,
   summarizeApportioned,
   censusApportionArea,
+  censusApportionGeometry,
   censusApportionRatio,
   deriveApportionedRow,
   censusGeographyMapToEntries,
@@ -810,13 +811,18 @@ const aggregateLayerLabel = computed((): string => {
 // Choropleth aggregation overlay
 /////////////////
 
-// All census geographies in the query area, used to fetch geometry for the
-// choropleth. Empty when the overlay is off.
+// Geographies the choropleth still needs a full outline for. In a clipped mode
+// that's only the ones the census phase returned no clipped outline for — a
+// geography outside every stop buffer, or the window before those outlines
+// have streamed in. Empty when the overlay is off.
 const choroplethGeoIds = computed((): number[] => {
-  if (aggAreaMode.value === 'off') { return [] }
+  const mode = aggAreaMode.value
+  if (mode === 'off') { return [] }
   const geos = scenarioFilterResult.value?.censusGeographies
   if (!geos) { return [] }
-  return [...geos.values()].map(g => g.id)
+  return [...geos.values()]
+    .filter(g => !censusApportionGeometry(g, mode))
+    .map(g => g.id)
 })
 
 // Fetch geometry for the choropleth geographies

--- a/app/pages/tne.vue
+++ b/app/pages/tne.vue
@@ -863,9 +863,6 @@ const choroplethAggregateData = computed(() => {
   // legend's breaks aren't skewed by a pile of zeroes either. Rows with no
   // census entry are stop-derived and unaffected.
   const mode = aggClipMode.value
-  if (mode === 'unclipped') {
-    return rows
-  }
   const geos = scenarioFilterResult.value.censusGeographies
   return rows.filter((r) => {
     const geo = geos?.get(r.geoid)

--- a/src/core/census-buffer.ts
+++ b/src/core/census-buffer.ts
@@ -1,4 +1,4 @@
-import type { AggAreaMode, CensusValues, CensusGeographyData } from './census-columns'
+import type { AggClipMode, CensusValues, CensusGeographyData } from './census-columns'
 import {
   CENSUS_COLUMNS,
   NON_ADDITIVE_CENSUS_COLUMNS,
@@ -32,7 +32,7 @@ export interface CensusGeographyEntry {
 // report the same clip the map is shaded by.
 export function censusGeographyMapToEntries (
   m: Map<string, CensusGeographyData> | undefined,
-  mode: AggAreaMode,
+  mode: AggClipMode,
   nameFor?: (geoid: string) => string | undefined,
 ): CensusGeographyEntry[] {
   if (!m) {

--- a/src/core/census-buffer.ts
+++ b/src/core/census-buffer.ts
@@ -1,5 +1,10 @@
-import type { CensusValues, CensusGeographyData } from './census-columns'
-import { CENSUS_COLUMNS, NON_ADDITIVE_CENSUS_COLUMNS } from './census-columns'
+import type { AggAreaMode, CensusValues, CensusGeographyData } from './census-columns'
+import {
+  CENSUS_COLUMNS,
+  NON_ADDITIVE_CENSUS_COLUMNS,
+  censusApportionArea,
+  censusApportionRatio,
+} from './census-columns'
 
 // FIPS-prefix-rollup-safe layers, coarse→fine: a finer geoid's FIPS digits start with
 // its parent's (block group nests in tract, tract in county, county in state), so
@@ -23,8 +28,11 @@ export interface CensusGeographyEntry {
   intersectionGeometry?: GeoJSON.Geometry
 }
 
+// Entries carry the intersection selected by `mode`, so the details tables
+// report the same clip the map is shaded by.
 export function censusGeographyMapToEntries (
   m: Map<string, CensusGeographyData> | undefined,
+  mode: AggAreaMode,
   nameFor?: (geoid: string) => string | undefined,
 ): CensusGeographyEntry[] {
   if (!m) {
@@ -37,8 +45,8 @@ export function censusGeographyMapToEntries (
       name: nameFor?.(geoid) ?? data.name ?? undefined,
       layer: data.layer,
       geometryArea: data.geometryArea,
-      intersectionArea: data.intersectionArea,
-      intersectionRatio: data.intersectionRatio,
+      intersectionArea: censusApportionArea(data, mode),
+      intersectionRatio: censusApportionRatio(data, mode),
       values: data.values,
     })
   }

--- a/src/core/census-columns.test.ts
+++ b/src/core/census-columns.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   CENSUS_COLUMNS,
-  aggClipNeedsGeometry,
   censusApportionArea,
   censusApportionGeometry,
   censusApportionRatio,
@@ -174,14 +173,6 @@ describe('censusApportionGeometry', () => {
 
   it('is undefined when the outlines were never fetched', () => {
     expect(censusApportionGeometry(geo(), 'queryArea')).toBeUndefined()
-  })
-})
-
-describe('aggClipNeedsGeometry', () => {
-  it('is true only for the modes that draw a clipped outline', () => {
-    expect(aggClipNeedsGeometry('unclipped')).toBe(false)
-    expect(aggClipNeedsGeometry('queryArea')).toBe(true)
-    expect(aggClipNeedsGeometry('buffer')).toBe(true)
   })
 })
 

--- a/src/core/census-columns.test.ts
+++ b/src/core/census-columns.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   CENSUS_COLUMNS,
+  aggAreaModeNeedsGeometry,
   censusApportionArea,
+  censusApportionGeometry,
   censusApportionRatio,
   deriveApportionedRow,
   formatAcsDatasetLabel,
@@ -142,6 +144,45 @@ describe('censusApportionRatio / censusApportionArea', () => {
     const outsideBuffers = geo({ bufferIntersectionArea: 0, bufferIntersectionRatio: 0 })
     expect(censusApportionRatio(outsideBuffers, 'buffer')).toBe(0)
     expect(censusApportionArea(outsideBuffers, 'buffer')).toBe(0)
+  })
+})
+
+describe('censusApportionGeometry', () => {
+  const queryAreaGeom = { type: 'Polygon', coordinates: [[[0, 0]]] }
+  const bufferGeom = { type: 'Polygon', coordinates: [[[1, 1]]] }
+
+  it('picks the outline matching the mode', () => {
+    const g = geo({
+      intersectionGeometry: queryAreaGeom,
+      bufferIntersectionArea: 250,
+      bufferIntersectionRatio: 0.25,
+      bufferIntersectionGeometry: bufferGeom,
+    })
+    expect(censusApportionGeometry(g, 'queryArea')).toBe(queryAreaGeom)
+    expect(censusApportionGeometry(g, 'buffer')).toBe(bufferGeom)
+  })
+
+  it('has no outline for unclipped — the caller draws the full geography', () => {
+    const g = geo({ intersectionGeometry: queryAreaGeom })
+    expect(censusApportionGeometry(g, 'unclipped')).toBeUndefined()
+  })
+
+  it('falls back with the ratio when the scenario fetched no buffer clip', () => {
+    const g = geo({ intersectionGeometry: queryAreaGeom })
+    expect(censusApportionGeometry(g, 'buffer')).toBe(queryAreaGeom)
+  })
+
+  it('is undefined when the outlines were never fetched', () => {
+    expect(censusApportionGeometry(geo(), 'queryArea')).toBeUndefined()
+  })
+})
+
+describe('aggAreaModeNeedsGeometry', () => {
+  it('is true only for the modes that draw a clipped outline', () => {
+    expect(aggAreaModeNeedsGeometry('off')).toBe(false)
+    expect(aggAreaModeNeedsGeometry('unclipped')).toBe(false)
+    expect(aggAreaModeNeedsGeometry('queryArea')).toBe(true)
+    expect(aggAreaModeNeedsGeometry('buffer')).toBe(true)
   })
 })
 

--- a/src/core/census-columns.test.ts
+++ b/src/core/census-columns.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   CENSUS_COLUMNS,
-  aggAreaModeNeedsGeometry,
+  aggClipNeedsGeometry,
   censusApportionArea,
   censusApportionGeometry,
   censusApportionRatio,
@@ -177,12 +177,11 @@ describe('censusApportionGeometry', () => {
   })
 })
 
-describe('aggAreaModeNeedsGeometry', () => {
+describe('aggClipNeedsGeometry', () => {
   it('is true only for the modes that draw a clipped outline', () => {
-    expect(aggAreaModeNeedsGeometry('off')).toBe(false)
-    expect(aggAreaModeNeedsGeometry('unclipped')).toBe(false)
-    expect(aggAreaModeNeedsGeometry('queryArea')).toBe(true)
-    expect(aggAreaModeNeedsGeometry('buffer')).toBe(true)
+    expect(aggClipNeedsGeometry('unclipped')).toBe(false)
+    expect(aggClipNeedsGeometry('queryArea')).toBe(true)
+    expect(aggClipNeedsGeometry('buffer')).toBe(true)
   })
 })
 

--- a/src/core/census-columns.test.ts
+++ b/src/core/census-columns.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import {
   CENSUS_COLUMNS,
+  censusApportionArea,
+  censusApportionRatio,
   deriveApportionedRow,
   formatAcsDatasetLabel,
   formatArea,
   formatCensusBucketLabel,
   formatCensusValue,
-  summarizeBbox,
+  summarizeApportioned,
+  type CensusGeographyData,
   type CensusValues,
 } from './census-columns'
 
@@ -16,6 +19,18 @@ function byId (id: string) {
     throw new Error(`unknown column ${id}`)
   }
   return col
+}
+
+function geo (over: Partial<CensusGeographyData> = {}): CensusGeographyData {
+  return {
+    id: 1,
+    name: 'Tract 1',
+    values: {},
+    geometryArea: 1000,
+    intersectionArea: 600,
+    intersectionRatio: 0.6,
+    ...over,
+  }
 }
 
 describe('derivations', () => {
@@ -98,13 +113,45 @@ describe('formatCensusValue', () => {
   })
 })
 
-describe('summarizeBbox', () => {
+describe('censusApportionRatio / censusApportionArea', () => {
+  const clipped = geo({
+    geometryArea: 1000,
+    intersectionArea: 600,
+    intersectionRatio: 0.6,
+    bufferIntersectionArea: 250,
+    bufferIntersectionRatio: 0.25,
+  })
+
+  it('picks the clip named by the mode', () => {
+    expect(censusApportionRatio(clipped, 'unclipped')).toBe(1)
+    expect(censusApportionRatio(clipped, 'queryArea')).toBe(0.6)
+    expect(censusApportionRatio(clipped, 'buffer')).toBe(0.25)
+
+    expect(censusApportionArea(clipped, 'unclipped')).toBe(1000)
+    expect(censusApportionArea(clipped, 'queryArea')).toBe(600)
+    expect(censusApportionArea(clipped, 'buffer')).toBe(250)
+  })
+
+  it('falls back to the query area when no buffer clip was fetched', () => {
+    const noBuffer = geo({ intersectionRatio: 0.6, intersectionArea: 600 })
+    expect(censusApportionRatio(noBuffer, 'buffer')).toBe(0.6)
+    expect(censusApportionArea(noBuffer, 'buffer')).toBe(600)
+  })
+
+  it('keeps a zero buffer clip rather than falling back to the query area', () => {
+    const outsideBuffers = geo({ bufferIntersectionArea: 0, bufferIntersectionRatio: 0 })
+    expect(censusApportionRatio(outsideBuffers, 'buffer')).toBe(0)
+    expect(censusApportionArea(outsideBuffers, 'buffer')).toBe(0)
+  })
+})
+
+describe('summarizeApportioned', () => {
   it('sums raw values apportioned by intersection ratio and runs derivations', () => {
     const geos = new Map([
-      ['1', { values: { b01003_001: 1000, b02001_002: 600 }, intersectionRatio: 1.0 }],
-      ['2', { values: { b01003_001: 500, b02001_002: 400 }, intersectionRatio: 0.5 }],
+      ['1', geo({ values: { b01003_001: 1000, b02001_002: 600 }, intersectionRatio: 1.0 })],
+      ['2', geo({ values: { b01003_001: 500, b02001_002: 400 }, intersectionRatio: 0.5 })],
     ])
-    const { raw, derived } = summarizeBbox(['1', '2'], geos)
+    const { raw, derived } = summarizeApportioned(['1', '2'], geos, 'queryArea')
     // 1000*1.0 + 500*0.5 = 1250
     expect(raw.b01003_001).toBe(1250)
     // 600*1.0 + 400*0.5 = 800
@@ -112,6 +159,19 @@ describe('summarizeBbox', () => {
     // POC% = (1250 − 800) / 1250 = 0.36
     expect(derived.pct_people_of_color).toBeCloseTo(0.36)
     expect(derived.total_population).toBe(1250)
+  })
+
+  it('totals follow the selected clip', () => {
+    const geos = new Map([
+      ['1', geo({
+        values: { b01003_001: 1000 },
+        intersectionRatio: 0.5,
+        bufferIntersectionRatio: 0.2,
+      })],
+    ])
+    expect(summarizeApportioned(['1'], geos, 'unclipped').derived.total_population).toBe(1000)
+    expect(summarizeApportioned(['1'], geos, 'queryArea').derived.total_population).toBe(500)
+    expect(summarizeApportioned(['1'], geos, 'buffer').derived.total_population).toBe(200)
   })
 })
 

--- a/src/core/census-columns.ts
+++ b/src/core/census-columns.ts
@@ -96,22 +96,20 @@ export interface CensusGeographyData {
 }
 
 /** Which clip the aggregation overlay shades and reports by. */
-export type AggAreaMode = 'off' | 'unclipped' | 'queryArea' | 'buffer'
+export type AggClipMode = 'unclipped' | 'queryArea' | 'buffer'
 
-export const AGG_AREA_MODE_OPTIONS: { value: AggAreaMode, label: string }[] = [
-  { value: 'off', label: 'Off' },
-  { value: 'unclipped', label: 'Full geographies' },
-  { value: 'queryArea', label: 'Clipped to query area' },
+export const AGG_CLIP_MODE_OPTIONS: { value: AggClipMode, label: string }[] = [
+  { value: 'unclipped', label: 'None (full geographies)' },
+  { value: 'queryArea', label: 'Query area' },
   // The backend composes both clips, so this is the query area narrowed to
   // the stop buffers — never the buffers on their own.
-  { value: 'buffer', label: 'Clipped to query area + stop buffers' },
+  { value: 'buffer', label: 'Query area + stop buffers' },
 ]
 
 // Fraction of a geography attributed to the analysis area under the selected
 // clip. `buffer` falls back to the query-area clip when the scenario carries
-// no buffer intersection, which is also what `off` reports for the views that
-// stay reachable with the overlay hidden.
-export function censusApportionRatio (geo: CensusGeographyData, mode: AggAreaMode): number {
+// no buffer intersection.
+export function censusApportionRatio (geo: CensusGeographyData, mode: AggClipMode): number {
   if (mode === 'unclipped') {
     return 1
   }
@@ -122,7 +120,7 @@ export function censusApportionRatio (geo: CensusGeographyData, mode: AggAreaMod
 }
 
 // The clipped area in m² matching `censusApportionRatio`.
-export function censusApportionArea (geo: CensusGeographyData, mode: AggAreaMode): number {
+export function censusApportionArea (geo: CensusGeographyData, mode: AggClipMode): number {
   if (mode === 'unclipped') {
     return geo.geometryArea
   }
@@ -136,7 +134,7 @@ export function censusApportionArea (geo: CensusGeographyData, mode: AggAreaMode
 // scenario didn't fetch one — callers fall back to the full geography.
 export function censusApportionGeometry (
   geo: CensusGeographyData,
-  mode: AggAreaMode,
+  mode: AggClipMode,
 ): Geometry | undefined {
   if (mode === 'unclipped') {
     return undefined
@@ -150,8 +148,8 @@ export function censusApportionGeometry (
 
 // Whether a mode draws a clipped outline, so the fetch that supplies one can
 // stay off until it's actually needed.
-export function aggAreaModeNeedsGeometry (mode: AggAreaMode): boolean {
-  return mode === 'queryArea' || mode === 'buffer'
+export function aggClipNeedsGeometry (mode: AggClipMode): boolean {
+  return mode !== 'unclipped'
 }
 
 export type CensusFormat = 'integer' | 'percent' | 'currency' | 'decimal'
@@ -505,7 +503,7 @@ export function deriveApportionedColumn (
 export function summarizeApportioned (
   geoids: Iterable<string>,
   geographies: Map<string, CensusGeographyData> | undefined,
-  mode: AggAreaMode,
+  mode: AggClipMode,
 ): { raw: Record<string, number>, derived: Record<string, number | null> } {
   const raw: Record<string, number> = {}
   if (!geographies) {

--- a/src/core/census-columns.ts
+++ b/src/core/census-columns.ts
@@ -86,6 +86,41 @@ export interface CensusGeographyData {
   layer?: string
 }
 
+/** Which clip the aggregation overlay shades and reports by. */
+export type AggAreaMode = 'off' | 'unclipped' | 'queryArea' | 'buffer'
+
+export const AGG_AREA_MODE_OPTIONS: { value: AggAreaMode, label: string }[] = [
+  { value: 'off', label: 'Off' },
+  { value: 'unclipped', label: 'Full geographies' },
+  { value: 'queryArea', label: 'Clipped to query area' },
+  { value: 'buffer', label: 'Clipped to stop buffers' },
+]
+
+// Fraction of a geography attributed to the analysis area under the selected
+// clip. `buffer` falls back to the query-area clip when the scenario carries
+// no buffer intersection, which is also what `off` reports for the views that
+// stay reachable with the overlay hidden.
+export function censusApportionRatio (geo: CensusGeographyData, mode: AggAreaMode): number {
+  if (mode === 'unclipped') {
+    return 1
+  }
+  if (mode === 'buffer' && geo.bufferIntersectionRatio != null) {
+    return geo.bufferIntersectionRatio
+  }
+  return geo.intersectionRatio
+}
+
+// The clipped area in m² matching `censusApportionRatio`.
+export function censusApportionArea (geo: CensusGeographyData, mode: AggAreaMode): number {
+  if (mode === 'unclipped') {
+    return geo.geometryArea
+  }
+  if (mode === 'buffer' && geo.bufferIntersectionArea != null) {
+    return geo.bufferIntersectionArea
+  }
+  return geo.intersectionArea
+}
+
 export type CensusFormat = 'integer' | 'percent' | 'currency' | 'decimal'
 
 export interface CensusColumnDef {
@@ -434,9 +469,10 @@ export function deriveApportionedColumn (
 // Sum apportioned raw ACS values across geographies, then run derivations.
 // Non-additive columns (medians) come out as nonsense — callers must render
 // `NON_ADDITIVE_CENSUS_COLUMNS` as "—".
-export function summarizeBbox (
+export function summarizeApportioned (
   geoids: Iterable<string>,
-  geographies: Map<string, { values: CensusValues, intersectionRatio: number }> | undefined,
+  geographies: Map<string, CensusGeographyData> | undefined,
+  mode: AggAreaMode,
 ): { raw: Record<string, number>, derived: Record<string, number | null> } {
   const raw: Record<string, number> = {}
   if (!geographies) {
@@ -447,7 +483,7 @@ export function summarizeBbox (
     if (!geo) {
       continue
     }
-    const ratio = geo.intersectionRatio
+    const ratio = censusApportionRatio(geo, mode)
     for (const [key, v] of Object.entries(geo.values)) {
       if (typeof v !== 'number' || !Number.isFinite(v)) {
         continue

--- a/src/core/census-columns.ts
+++ b/src/core/census-columns.ts
@@ -1,3 +1,5 @@
+import type { Geometry } from './geom'
+
 // ACS demographic columns surfaced in aggregation tables and the map view (#302).
 // Column ID format: lowercase `<table>_<col>` (e.g. `b01001_001`). Derivations
 // return null when inputs are missing or denominators are zero so the UI can
@@ -78,6 +80,13 @@ export interface CensusGeographyData {
   /** Fraction of the geography inside both clips, in [0, 1]. */
   bufferIntersectionRatio?: number
   /**
+   * Clipped outlines matching the two areas above, present only when the
+   * phase was asked for them — they cost roughly as much as the full
+   * geometry. The choropleth draws the full geography without them.
+   */
+  intersectionGeometry?: Geometry
+  bufferIntersectionGeometry?: Geometry
+  /**
    * Census layer the geography belongs to ('state', 'county', 'tract', etc.).
    * Optional for backward compatibility with code paths that don't carry it,
    * but populated by the scenario pipeline so the UI can filter by layer
@@ -93,7 +102,9 @@ export const AGG_AREA_MODE_OPTIONS: { value: AggAreaMode, label: string }[] = [
   { value: 'off', label: 'Off' },
   { value: 'unclipped', label: 'Full geographies' },
   { value: 'queryArea', label: 'Clipped to query area' },
-  { value: 'buffer', label: 'Clipped to stop buffers' },
+  // The backend composes both clips, so this is the query area narrowed to
+  // the stop buffers — never the buffers on their own.
+  { value: 'buffer', label: 'Clipped to query area + stop buffers' },
 ]
 
 // Fraction of a geography attributed to the analysis area under the selected
@@ -119,6 +130,28 @@ export function censusApportionArea (geo: CensusGeographyData, mode: AggAreaMode
     return geo.bufferIntersectionArea
   }
   return geo.intersectionArea
+}
+
+// The clipped outline matching `censusApportionArea`, or undefined when the
+// scenario didn't fetch one — callers fall back to the full geography.
+export function censusApportionGeometry (
+  geo: CensusGeographyData,
+  mode: AggAreaMode,
+): Geometry | undefined {
+  if (mode === 'unclipped') {
+    return undefined
+  }
+  // Same guard as the ratio and area, so all three fall back together.
+  if (mode === 'buffer' && geo.bufferIntersectionArea != null) {
+    return geo.bufferIntersectionGeometry
+  }
+  return geo.intersectionGeometry
+}
+
+// Whether a mode draws a clipped outline, so the fetch that supplies one can
+// stay off until it's actually needed.
+export function aggAreaModeNeedsGeometry (mode: AggAreaMode): boolean {
+  return mode === 'queryArea' || mode === 'buffer'
 }
 
 export type CensusFormat = 'integer' | 'percent' | 'currency' | 'decimal'

--- a/src/core/census-columns.ts
+++ b/src/core/census-columns.ts
@@ -124,8 +124,8 @@ export function censusApportionArea (geo: CensusGeographyData, mode: AggClipMode
   if (mode === 'unclipped') {
     return geo.geometryArea
   }
-  if (mode === 'buffer' && geo.bufferIntersectionArea != null) {
-    return geo.bufferIntersectionArea
+  if (mode === 'buffer' && geo.bufferIntersectionRatio != null) {
+    return geo.bufferIntersectionArea ?? 0
   }
   return geo.intersectionArea
 }
@@ -140,16 +140,10 @@ export function censusApportionGeometry (
     return undefined
   }
   // Same guard as the ratio and area, so all three fall back together.
-  if (mode === 'buffer' && geo.bufferIntersectionArea != null) {
+  if (mode === 'buffer' && geo.bufferIntersectionRatio != null) {
     return geo.bufferIntersectionGeometry
   }
   return geo.intersectionGeometry
-}
-
-// Whether a mode draws a clipped outline, so the fetch that supplies one can
-// stay off until it's actually needed.
-export function aggClipNeedsGeometry (mode: AggClipMode): boolean {
-  return mode !== 'unclipped'
 }
 
 export type CensusFormat = 'integer' | 'percent' | 'currency' | 'decimal'

--- a/src/core/choropleth.test.ts
+++ b/src/core/choropleth.test.ts
@@ -13,28 +13,71 @@ function picked (entries: Array<[string, number | null]>): Map<string, number | 
 
 describe('pickChoroplethValue', () => {
   it('returns 0 when the value is 0 (not null)', () => {
-    expect(pickChoroplethValue({ x: 0, geoid: '1' }, 'x', false, undefined)).toBe(0)
+    expect(pickChoroplethValue({ x: 0, geoid: '1' }, 'x', false, undefined, 'eu', 'queryArea')).toBe(0)
   })
 
   it('returns null when the value is missing or non-finite', () => {
-    expect(pickChoroplethValue({ geoid: '1' }, 'x', false, undefined)).toBeNull()
-    expect(pickChoroplethValue({ x: null, geoid: '1' }, 'x', false, undefined)).toBeNull()
-    expect(pickChoroplethValue({ x: 'not a number', geoid: '1' }, 'x', false, undefined)).toBeNull()
-    expect(pickChoroplethValue({ x: Number.POSITIVE_INFINITY, geoid: '1' }, 'x', false, undefined)).toBeNull()
+    expect(pickChoroplethValue({ geoid: '1' }, 'x', false, undefined, 'eu', 'queryArea')).toBeNull()
+    expect(pickChoroplethValue({ x: null, geoid: '1' }, 'x', false, undefined, 'eu', 'queryArea')).toBeNull()
+    expect(pickChoroplethValue({ x: 'not a number', geoid: '1' }, 'x', false, undefined, 'eu', 'queryArea')).toBeNull()
+    expect(pickChoroplethValue({ x: Number.POSITIVE_INFINITY, geoid: '1' }, 'x', false, undefined, 'eu', 'queryArea')).toBeNull()
   })
 
   it('density mode scales by 1,000,000 / area_m² → counts per km²', () => {
     // 1000 commuters in a 5 km² (= 5,000,000 m²) area = 200 per km²
     const geos = new Map<string, CensusGeographyData>([
-      ['1', { values: {}, intersectionRatio: 1, geometryArea: 5_000_000, intersectionArea: 5_000_000 }],
+      ['1', { id: 1, name: '', values: {}, intersectionRatio: 1, geometryArea: 5_000_000, intersectionArea: 5_000_000 }],
     ])
-    expect(pickChoroplethValue({ x: 1000, geoid: '1' }, 'x', true, geos)).toBe(200)
+    expect(pickChoroplethValue({ x: 1000, geoid: '1' }, 'x', true, geos, 'eu', 'queryArea')).toBe(200)
   })
 
   it('density mode returns null when geometry area is missing', () => {
-    expect(pickChoroplethValue({ x: 1000, geoid: '1' }, 'x', true, undefined)).toBeNull()
+    expect(pickChoroplethValue({ x: 1000, geoid: '1' }, 'x', true, undefined, 'eu', 'queryArea')).toBeNull()
     const geos = new Map<string, CensusGeographyData>()
-    expect(pickChoroplethValue({ x: 1000, geoid: '1' }, 'x', true, geos)).toBeNull()
+    expect(pickChoroplethValue({ x: 1000, geoid: '1' }, 'x', true, geos, 'eu', 'queryArea')).toBeNull()
+  })
+
+  describe('apportionment by mode', () => {
+    // 1000 people, half the tract inside the query area, a fifth inside the
+    // stop buffers. The aggregation row carries the full-geography value.
+    const geos = new Map<string, CensusGeographyData>([
+      ['1', {
+        id: 1,
+        name: '',
+        values: { b01003_001: 1000, b02001_002: 600 },
+        geometryArea: 5_000_000,
+        intersectionArea: 2_500_000,
+        intersectionRatio: 0.5,
+        bufferIntersectionArea: 1_000_000,
+        bufferIntersectionRatio: 0.2,
+      }],
+    ])
+    const row = { geoid: '1', total_population: 1000, pct_people_of_color: 0.4, visit_count_total: 42 }
+
+    it('scales census counts by the selected clip', () => {
+      expect(pickChoroplethValue(row, 'total_population', false, geos, 'eu', 'unclipped')).toBe(1000)
+      expect(pickChoroplethValue(row, 'total_population', false, geos, 'eu', 'queryArea')).toBeCloseTo(500)
+      expect(pickChoroplethValue(row, 'total_population', false, geos, 'eu', 'buffer')).toBeCloseTo(200)
+    })
+
+    it('leaves ratio columns unchanged — apportionment is scale-invariant', () => {
+      for (const mode of ['unclipped', 'queryArea', 'buffer'] as const) {
+        expect(pickChoroplethValue(row, 'pct_people_of_color', false, geos, 'eu', mode)).toBeCloseTo(0.4)
+      }
+    })
+
+    it('leaves stop-aggregation elements unclipped — they already count what the query returned', () => {
+      for (const mode of ['unclipped', 'queryArea', 'buffer'] as const) {
+        expect(pickChoroplethValue(row, 'visit_count_total', false, geos, 'eu', mode)).toBe(42)
+      }
+    })
+
+    it('density is clip-invariant — value and area scale together', () => {
+      // 1000 people over the full 5 km², in every mode.
+      for (const mode of ['unclipped', 'queryArea', 'buffer'] as const) {
+        expect(pickChoroplethValue(row, 'total_population', true, geos, 'eu', mode)).toBe(200)
+      }
+    })
   })
 })
 

--- a/src/core/choropleth.ts
+++ b/src/core/choropleth.ts
@@ -1,5 +1,5 @@
 import { CHOROPLETH_INSUFFICIENT_COLOR, choroplethPalette } from './constants'
-import { CENSUS_COLUMNS, sqMetersPerLargeUnit, toFiniteNumber, type CensusFormat, type UnitSystem, type CensusGeographyData } from './census-columns'
+import { CENSUS_COLUMNS, censusApportionRatio, deriveApportionedColumn, sqMetersPerLargeUnit, toFiniteNumber, type AggAreaMode, type CensusFormat, type UnitSystem, type CensusGeographyData } from './census-columns'
 
 // Pure choropleth math. Convention: `null` means insufficient data (excluded
 // from breaks, painted with CHOROPLETH_INSUFFICIENT_COLOR); `0` is a real
@@ -56,17 +56,28 @@ export interface ChoroplethClassification {
   isDensity: boolean
 }
 
+// The number a geography is shaded by: the aggregation row's value for
+// `element`, apportioned to the clip `mode` selects.
 export function pickChoroplethValue (
   agg: Record<string, unknown>,
   element: string,
   isDensity: boolean,
   geographies: Map<string, CensusGeographyData> | undefined,
   unitSystem: UnitSystem,
+  mode: AggAreaMode,
 ): number | null {
   const n = toFiniteNumber(agg[element])
   if (n === null) { return null }
-  if (!isDensity) { return n }
-  return densityPerArea(n, geographies?.get(agg.geoid as string)?.geometryArea, unitSystem)
+  const geo = geographies?.get(agg.geoid as string)
+  // Density is clip-invariant — a clip scales the value and the area it covers
+  // by the same ratio — so it always reports over the full geography.
+  if (isDensity) { return densityPerArea(n, geo?.geometryArea, unitSystem) }
+  if (!geo) { return n }
+  const ratio = censusApportionRatio(geo, mode)
+  // Stop-aggregation elements count what the query actually returned, so
+  // there's nothing to apportion.
+  if (ratio === 1 || !CENSUS_COLUMNS.some(c => c.id === element)) { return n }
+  return deriveApportionedColumn(geo.values, ratio, element)
 }
 
 // Counts per km² (eu) or per mi² (us). Returns null when value/area missing.

--- a/src/core/choropleth.ts
+++ b/src/core/choropleth.ts
@@ -1,5 +1,5 @@
 import { CHOROPLETH_INSUFFICIENT_COLOR, choroplethPalette } from './constants'
-import { CENSUS_COLUMNS, censusApportionRatio, deriveApportionedColumn, sqMetersPerLargeUnit, toFiniteNumber, type AggAreaMode, type CensusFormat, type UnitSystem, type CensusGeographyData } from './census-columns'
+import { CENSUS_COLUMNS, censusApportionRatio, deriveApportionedColumn, sqMetersPerLargeUnit, toFiniteNumber, type AggClipMode, type CensusFormat, type UnitSystem, type CensusGeographyData } from './census-columns'
 
 // Pure choropleth math. Convention: `null` means insufficient data (excluded
 // from breaks, painted with CHOROPLETH_INSUFFICIENT_COLOR); `0` is a real
@@ -64,7 +64,7 @@ export function pickChoroplethValue (
   isDensity: boolean,
   geographies: Map<string, CensusGeographyData> | undefined,
   unitSystem: UnitSystem,
-  mode: AggAreaMode,
+  mode: AggClipMode,
 ): number | null {
   const n = toFiniteNumber(agg[element])
   if (n === null) { return null }

--- a/src/core/geom.ts
+++ b/src/core/geom.ts
@@ -115,24 +115,6 @@ export interface MarkerFeature {
   element?: HTMLElement // Optional HTML element for custom marker
 }
 
-// Widens Pass A's fetch bbox so census geographies just outside the user's
-// query area but inside a stop_buffer are still loaded for apportionment.
-// Arithmetic-only per CLAUDE.md geom rules; biased toward over-padding.
-export function padBboxMeters (bbox: Bbox | undefined, meters: number): Bbox | undefined {
-  if (!bbox || !bbox.valid || meters <= 0) {
-    return bbox
-  }
-  const latDelta = meters / 111320 // 1° latitude ≈ 111.32 km
-  const midLat = (bbox.sw.lat + bbox.ne.lat) / 2
-  const cosLat = Math.cos((midLat * Math.PI) / 180)
-  const lonDelta = cosLat > 0.001 ? meters / (111320 * cosLat) : latDelta
-  return {
-    sw: { lon: bbox.sw.lon - lonDelta, lat: bbox.sw.lat - latDelta },
-    ne: { lon: bbox.ne.lon + lonDelta, lat: bbox.ne.lat + latDelta },
-    valid: true,
-  }
-}
-
 export function convertBbox (bbox?: Bbox): { min_lon?: number, min_lat?: number, max_lon?: number, max_lat?: number } | undefined {
   if (!bbox) { return undefined }
   return {

--- a/src/scenario/buffer-passes.ts
+++ b/src/scenario/buffer-passes.ts
@@ -103,6 +103,9 @@ export async function runBufferPasses (
       .map(f => ({
         geoid: f.properties.geoid,
         layer: f.properties.layer_name || config.layer,
+        // Carried so the aggregation table can seed a named row for a
+        // geography only the buffer reaches.
+        name: f.properties.name,
         geometryArea: f.properties.geometry_area,
         intersectionArea: f.properties.intersection_area,
         values: f.properties.values,

--- a/src/scenario/phases/census-values.test.ts
+++ b/src/scenario/phases/census-values.test.ts
@@ -152,6 +152,16 @@ describe('runCensusValuesPhase stop-buffer clipping', () => {
     expect(geographies.get('unserved')!.intersectionRatio).toBe(1)
   })
 
+  // Both passes clip against the same padded bbox, so their two areas stay
+  // comparable. That the padding is there at all overstates both — #442.
+  it('clips both passes against the same bbox', async () => {
+    const { query } = await runPhase(
+      baseConfig({ within: undefined, stopIds: [1, 2], stopBufferRadius: 400 }),
+      [queryAreaResponse(), clipResponse()],
+    )
+    expect(query.mock.calls[1]![1].bbox).toEqual(query.mock.calls[0]![1].bbox)
+  })
+
   // The backend composes a bbox with a stop buffer, so a bbox-only scenario
   // clips too — it does not need an admin boundary.
   it('clips against a bbox when no within polygon is given', async () => {
@@ -164,6 +174,41 @@ describe('runCensusValuesPhase stop-buffer clipping', () => {
     expect(query.mock.calls[1]![1].within).toBeUndefined()
     expect(geographies.get('served')!.bufferIntersectionRatio).toBe(0.25)
     expect(geographies.get('unserved')!.bufferIntersectionRatio).toBe(0)
+  })
+
+  // The outlines roughly double the response, so nothing fetches them unless
+  // a mode is actually drawing the clipped footprint.
+  it('fetches clipped outlines only when asked, on both passes', async () => {
+    const { query: without } = await runPhase(
+      baseConfig({ stopIds: [1, 2], stopBufferRadius: 400 }),
+      [queryAreaResponse(), clipResponse()],
+    )
+    expect(without.mock.calls[0]![1].includeIntersectionGeometry).toBe(false)
+    expect(without.mock.calls[1]![1].includeGeometry).toBe(false)
+
+    const queryAreaGeom = { type: 'Polygon', coordinates: [[[0, 0]]] }
+    const bufferGeom = { type: 'Polygon', coordinates: [[[1, 1]]] }
+    const pass1 = queryAreaResponse()
+    pass1.data.census_datasets[0]!.geographies[0]!.intersection_geometry = queryAreaGeom as any
+    const { query: with_, geographies } = await runPhase(
+      baseConfig({ stopIds: [1, 2], stopBufferRadius: 400, includeIntersectionGeometry: true }),
+      [pass1, {
+        data: {
+          census_datasets: [{
+            id: 1,
+            geographies: [{ geoid: 'served', intersection_area: 250, intersection_geometry: bufferGeom }],
+          }],
+        },
+      }],
+    )
+    expect(with_.mock.calls[0]![1].includeIntersectionGeometry).toBe(true)
+    expect(with_.mock.calls[1]![1].includeGeometry).toBe(true)
+
+    const served = geographies.get('served')!
+    expect(served.intersectionGeometry).toEqual(queryAreaGeom)
+    expect(served.bufferIntersectionGeometry).toEqual(bufferGeom)
+    // Reached by no buffer: still zero area, and no outline to draw.
+    expect(geographies.get('unserved')!.bufferIntersectionGeometry).toBeUndefined()
   })
 
   // Pass 1's values must survive a failing clip: the clip is an enhancement,

--- a/src/scenario/phases/census-values.test.ts
+++ b/src/scenario/phases/census-values.test.ts
@@ -152,14 +152,17 @@ describe('runCensusValuesPhase stop-buffer clipping', () => {
     expect(geographies.get('unserved')!.intersectionRatio).toBe(1)
   })
 
-  // Both passes clip against the same padded bbox, so their two areas stay
-  // comparable. That the padding is there at all overstates both — #442.
-  it('clips both passes against the same bbox', async () => {
+  // Both passes once clipped against a bbox widened by the radius, which
+  // measured every intersection against an area the user never drew and
+  // returned geographies that don't touch the query at all.
+  it('clips against the bbox as drawn, not one widened by the radius', async () => {
     const { query } = await runPhase(
       baseConfig({ within: undefined, stopIds: [1, 2], stopBufferRadius: 400 }),
       [queryAreaResponse(), clipResponse()],
     )
-    expect(query.mock.calls[1]![1].bbox).toEqual(query.mock.calls[0]![1].bbox)
+    const drawn = { min_lon: -122.7, min_lat: 45.5, max_lon: -122.6, max_lat: 45.6 }
+    expect(query.mock.calls[0]![1].bbox).toEqual(drawn)
+    expect(query.mock.calls[1]![1].bbox).toEqual(drawn)
   })
 
   // The backend composes a bbox with a stop buffer, so a bbox-only scenario

--- a/src/scenario/phases/census-values.ts
+++ b/src/scenario/phases/census-values.ts
@@ -9,7 +9,7 @@ import {
   type CensusGeographyData,
   type GraphQLClient,
 } from '~~/src/core'
-import { fetchCensusIntersection, fetchClipIntersections } from '~~/src/tl'
+import { fetchCensusIntersection, fetchClipIntersections, type ClipIntersection } from '~~/src/tl'
 import { resolveGeographyContext } from './feed-versions'
 import { phaseDone, type PhaseEmit } from './common'
 
@@ -25,12 +25,17 @@ export interface CensusValuesPhaseConfig {
   // ACS dataset (e.g. `acsdt5y2021`).
   tableDatasetName: string
   aggregateLayer: string
-  // Bbox is padded by the radius so edge-crossing buffers can apportion
-  // against the right tracts.
+  // Widens the fetch bbox so the aggregation report still gets a row for
+  // geographies just outside the query area that a stop buffer reaches. It
+  // also widens the clip, which overstates every intersection — see #442.
   stopBufferRadius?: number
   // With a radius and a `within` polygon, a second pass narrows each
   // geography's intersection to the query area AND the stop buffers.
   stopIds?: number[]
+  // Also fetch the clipped outlines, for drawing the choropleth as the
+  // analyzed footprint rather than whole geographies. Off by default: the
+  // outlines cost roughly as much as the values.
+  includeIntersectionGeometry?: boolean
 }
 
 export async function runCensusValuesPhase (
@@ -68,6 +73,7 @@ export async function runCensusValuesPhase (
     tableNames: REQUIRED_ACS_TABLES,
     bbox: paddedBbox,
     within,
+    includeIntersectionGeometry: config.includeIntersectionGeometry,
   })
 
   // Second pass: intersection with the query area AND the stop buffers. The
@@ -80,7 +86,7 @@ export async function runCensusValuesPhase (
   // already fetched, so it degrades to query-area-only rather than failing
   // the scenario.
   const stopIds = config.stopIds || []
-  let clips: Map<string, number> | null = null
+  let clips: Map<string, ClipIntersection> | null = null
   if (radius > 0 && stopIds.length > 0) {
     try {
       clips = await fetchClipIntersections({
@@ -91,20 +97,22 @@ export async function runCensusValuesPhase (
         within,
         stopIds,
         stopBufferRadius: radius,
+        includeGeometry: config.includeIntersectionGeometry,
       })
     } catch (err) {
       console.warn('[CensusValues] Stop buffer clip failed; keeping query-area intersections', err)
     }
   }
   if (clips) {
-    console.log(`[CensusValues] Clipped to stop buffers (radius=${radius}m, ${stopIds.length} stops): ${clips.size}/${features.length} geographies overlap`)
+    console.log(`[CensusValues] Clipped to query area + stop buffers (radius=${radius}m, ${stopIds.length} stops): ${clips.size}/${features.length} geographies overlap`)
   }
 
   const entries: [string, CensusGeographyData][] = features.map((f) => {
     const geometryArea = f.properties.geometry_area
     // Both clips are kept: the choropleth mode picks between them at display
     // time, so switching never needs a refetch.
-    const bufferArea = clips ? (clips.get(f.properties.geoid) ?? 0) : undefined
+    const clip = clips?.get(f.properties.geoid)
+    const bufferArea = clips ? (clip?.area ?? 0) : undefined
     return [
       f.properties.geoid,
       {
@@ -114,10 +122,12 @@ export async function runCensusValuesPhase (
         intersectionRatio: f.properties.intersection_ratio,
         geometryArea,
         intersectionArea: f.properties.intersection_area,
+        intersectionGeometry: f.geometry ?? undefined,
         bufferIntersectionArea: bufferArea,
         bufferIntersectionRatio: bufferArea == null
           ? undefined
           : (geometryArea > 0 ? Math.min(bufferArea / geometryArea, 1.0) : 0),
+        bufferIntersectionGeometry: clip?.geometry,
         layer: config.aggregateLayer,
       },
     ]

--- a/src/scenario/phases/census-values.ts
+++ b/src/scenario/phases/census-values.ts
@@ -3,7 +3,6 @@
 // intersection is narrowed to the stop buffers.
 
 import {
-  padBboxMeters,
   REQUIRED_ACS_TABLES,
   type Bbox,
   type CensusGeographyData,
@@ -25,9 +24,6 @@ export interface CensusValuesPhaseConfig {
   // ACS dataset (e.g. `acsdt5y2021`).
   tableDatasetName: string
   aggregateLayer: string
-  // Widens the fetch bbox so the aggregation report still gets a row for
-  // geographies just outside the query area that a stop buffer reaches. It
-  // also widens the clip, which overstates every intersection — see #442.
   stopBufferRadius?: number
   // With a radius and a `within` polygon, a second pass narrows each
   // geography's intersection to the query area AND the stop buffers.
@@ -63,15 +59,14 @@ export async function runCensusValuesPhase (
   const radius = config.stopBufferRadius && config.stopBufferRadius > 0
     ? config.stopBufferRadius
     : 0
-  const paddedBbox = radius > 0 ? padBboxMeters(fetchBbox, radius) : fetchBbox
-  console.log(`[CensusValues] Fetching ${REQUIRED_ACS_TABLES.length} ACS tables for layer=${config.aggregateLayer} (radius padding=${radius}m)`)
+  console.log(`[CensusValues] Fetching ${REQUIRED_ACS_TABLES.length} ACS tables for layer=${config.aggregateLayer}`)
   const features = await fetchCensusIntersection({
     client,
     geoDatasetName: config.geoDatasetName,
     geoDatasetLayer: config.aggregateLayer,
     tableDatasetName: config.tableDatasetName,
     tableNames: REQUIRED_ACS_TABLES,
-    bbox: paddedBbox,
+    bbox: fetchBbox,
     within,
     includeIntersectionGeometry: config.includeIntersectionGeometry,
   })
@@ -93,7 +88,7 @@ export async function runCensusValuesPhase (
         client,
         geoDatasetName: config.geoDatasetName,
         geoDatasetLayer: config.aggregateLayer,
-        bbox: paddedBbox,
+        bbox: fetchBbox,
         within,
         stopIds,
         stopBufferRadius: radius,

--- a/src/scenario/phases/census-values.ts
+++ b/src/scenario/phases/census-values.ts
@@ -72,10 +72,10 @@ export async function runCensusValuesPhase (
   })
 
   // Second pass: intersection with the query area AND the stop buffers. The
-  // first pass stays the row universe, so geographies the buffers don't reach
-  // are kept and reported at zero rather than dropped by the server's clip.
-  // Clips against the same query area pass 1 used, so the two areas stay
-  // comparable.
+  // first pass stays the row universe, so a geography the buffers don't reach
+  // is reported at zero rather than dropped by the server's clip — display
+  // decides whether to draw it. Clips against the same query area pass 1 used,
+  // so the two areas stay comparable.
   //
   // Optional by design: a failure here must not lose the ACS values pass 1
   // already fetched, so it degrades to query-area-only rather than failing

--- a/src/scenario/scenario-census.test.ts
+++ b/src/scenario/scenario-census.test.ts
@@ -148,7 +148,7 @@ describe('scenario census pipeline (hermetic)', () => {
 
       // 4) Buffer apportionment (the stopBufferRadius>0 report path): the additive value
       //    scales by the intersection ratio, while median income is non-additive => null.
-      const apportioned = apportionBuffer(censusGeographyMapToEntries(data.censusGeographies))
+      const apportioned = apportionBuffer(censusGeographyMapToEntries(data.censusGeographies, 'queryArea'))
       expect(apportioned.values.total_population).toBeCloseTo(c.pop * 0.5, 6)
       expect(apportioned.pctCoverage).toBeCloseTo(0.5, 6)
       expect(apportioned.values.median_household_income).toBeNull()

--- a/src/scenario/scenario.ts
+++ b/src/scenario/scenario.ts
@@ -77,6 +77,10 @@ export interface ScenarioConfig {
    * Defaults to true.
    */
   includeCensus?: boolean
+  // Also fetch the clipped outlines of each census geography. Set from the
+  // display so a run started in a clipped mode arrives ready to draw, rather
+  // than needing a follow-up recompute.
+  includeIntersectionGeometry?: boolean
   // Picker overrides: onestop_id → fv_id. Record (not Map) for BFF JSON.
   feedVersionOverrides?: Record<string, number>
   // Picker-excluded onestop_ids. Dropped before any stop/route fetch.
@@ -477,6 +481,7 @@ export class ScenarioFetcher {
       aggregateLayer,
       stopBufferRadius: this.config.stopBufferRadius,
       stopIds,
+      includeIntersectionGeometry: this.config.includeIntersectionGeometry,
     }, this.client, p => this.emitProgress(p))
   }
 

--- a/src/tl/census-intersection.test.ts
+++ b/src/tl/census-intersection.test.ts
@@ -101,14 +101,30 @@ describe('fetchClipIntersections', () => {
       { geoid: 'A', intersection_area: 50 },
     ]))
     const clips = await fetchClipIntersections({ ...base, client, stopIds: [1], stopBufferRadius: 400 })
-    expect(clips.get('A')).toBe(150)
-    expect(clips.get('B')).toBe(250)
+    expect(clips.get('A')?.area).toBe(150)
+    expect(clips.get('B')?.area).toBe(250)
     expect(clips.has('C')).toBe(false)
   })
 
   it('treats a null intersection_area as zero', async () => {
     const { client } = mockClient(geographiesResponse([{ geoid: 'A', intersection_area: null }]))
     const clips = await fetchClipIntersections({ ...base, client, stopIds: [1], stopBufferRadius: 400 })
-    expect(clips.get('A')).toBe(0)
+    expect(clips.get('A')?.area).toBe(0)
+  })
+
+  it('asks for the clipped outline only when the caller wants it', async () => {
+    const { client, query } = mockClient(geographiesResponse([{ geoid: 'A', intersection_area: 100 }]))
+    await fetchClipIntersections({ ...base, client, stopIds: [1], stopBufferRadius: 400 })
+    expect(query.mock.calls[0]![1].includeGeometry).toBe(false)
+
+    const geometry = { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] }
+    const withGeom = mockClient(geographiesResponse([
+      { geoid: 'A', intersection_area: 100, intersection_geometry: geometry },
+    ]))
+    const clips = await fetchClipIntersections({
+      ...base, client: withGeom.client, stopIds: [1], stopBufferRadius: 400, includeGeometry: true,
+    })
+    expect(withGeom.query.mock.calls[0]![1].includeGeometry).toBe(true)
+    expect(clips.get('A')?.geometry).toEqual(geometry)
   })
 })

--- a/src/tl/census-intersection.ts
+++ b/src/tl/census-intersection.ts
@@ -132,11 +132,20 @@ export interface FetchClipIntersectionsConfig {
   within?: GeoJSON.Polygon
   stopIds: Iterable<number>
   stopBufferRadius: number
+  // Roughly doubles the response size, so callers ask only when the clipped
+  // outline is actually being drawn.
+  includeGeometry?: boolean
 }
 
-// Areas only — the query-area pass already carries the ACS values. The
-// backend clips to the intersection of the query area and the stop-buffer
-// union, so a geography absent from the result has no overlap with both.
+export interface ClipIntersection {
+  area: number
+  geometry?: Geometry
+}
+
+// The query area ∩ stop buffers clip. Values come from the query-area pass, so
+// this fetches areas only unless the caller wants the outline too. The backend
+// clips to the intersection of both, so a geography absent from the result
+// overlaps neither.
 export const clipIntersectionQuery = gql`
 query (
   $geoDatasetName: String,
@@ -144,7 +153,8 @@ query (
   $bbox: BoundingBox,
   $within: Polygon,
   $stopIds: [Int!],
-  $stopBufferRadius: Float
+  $stopBufferRadius: Float,
+  $includeGeometry: Boolean = false
 ) {
   census_datasets(where: {name: $geoDatasetName}) {
     id
@@ -162,25 +172,32 @@ query (
     ) {
       geoid
       intersection_area
+      intersection_geometry @include(if: $includeGeometry)
     }
   }
 }
 `
 
-// Intersection area of each geography with the query area AND the stop
-// buffers, keyed by geoid. Geographies the buffers don't reach are omitted by
-// the server; callers should treat a missing key as zero overlap.
+// Intersection of each geography with the query area AND the stop buffers,
+// keyed by geoid. Geographies the buffers don't reach are omitted by the
+// server; callers should treat a missing key as zero overlap.
 export async function fetchClipIntersections (
   config: FetchClipIntersectionsConfig,
-): Promise<Map<string, number>> {
+): Promise<Map<string, ClipIntersection>> {
   const stopIds = Array.from(config.stopIds)
-  const out = new Map<string, number>()
+  const out = new Map<string, ClipIntersection>()
   const clipArea = config.within || config.bbox
   if (!clipArea || stopIds.length === 0 || !(config.stopBufferRadius > 0)) {
     return out
   }
   const result = await config.client.query<{
-    census_datasets: { geographies: { geoid: string, intersection_area: number | null }[] }[]
+    census_datasets: {
+      geographies: {
+        geoid: string
+        intersection_area: number | null
+        intersection_geometry?: Geometry | null
+      }[]
+    }[]
   }>(clipIntersectionQuery, {
     geoDatasetName: config.geoDatasetName,
     layer: config.geoDatasetLayer,
@@ -188,12 +205,18 @@ export async function fetchClipIntersections (
     within: config.within,
     stopIds,
     stopBufferRadius: config.stopBufferRadius,
+    includeGeometry: config.includeGeometry || false,
   })
   for (const geoDataset of result.data?.census_datasets || []) {
     for (const geography of geoDataset.geographies || []) {
       // Multiple rows per geoid are possible in other backend clip modes;
-      // sum so a split clip isn't silently reduced to one part.
-      out.set(geography.geoid, (out.get(geography.geoid) || 0) + (geography.intersection_area || 0))
+      // sum so a split clip isn't silently reduced to one part. The composed
+      // clip we use yields one row, so the first geometry is the whole clip.
+      const prev = out.get(geography.geoid)
+      out.set(geography.geoid, {
+        area: (prev?.area || 0) + (geography.intersection_area || 0),
+        geometry: prev?.geometry ?? geography.intersection_geometry ?? undefined,
+      })
     }
   }
   return out

--- a/src/tl/stop-buffer.ts
+++ b/src/tl/stop-buffer.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-tag'
-import type { CensusValues, Geometry, GraphQLClient } from '~~/src/core'
+import type { CensusValues, GraphQLClient } from '~~/src/core'
 import { parseAcsValues } from './census'
 
 // #315 — per-entity buffer ∩ census intersections + inline ACS values.
@@ -212,23 +212,4 @@ export async function fetchEntityBufferGeographies (
     }
     return [ent.id, geographies]
   })
-}
-
-// Union of circles of `radius` around each of a route's stops, computed
-// server-side. Independent of census data, so it renders in any query mode.
-export const routeStopBufferQuery = gql`
-  query ($ids: [Int!], $radius: Float, $limit: Int) {
-    routes(ids: $ids, limit: $limit) {
-      id
-      route_stop_buffer(radius: $radius) {
-        stop_buffer
-      }
-    }
-  }
-`
-
-// Raw GraphQL shape for one route in the stop-buffer query response.
-export interface RouteStopBufferResponse {
-  id: number
-  route_stop_buffer?: { stop_buffer?: Geometry }
 }

--- a/src/tl/stop-buffer.ts
+++ b/src/tl/stop-buffer.ts
@@ -10,6 +10,7 @@ export type BufferEntityKind = 'stops' | 'routes' | 'agencies'
 export interface BufferGeographyIntersection {
   geoid: string
   layer: string
+  name?: string
   geometryArea: number
   intersectionArea: number
   values: CensusValues

--- a/src/tl/stop-buffer.ts
+++ b/src/tl/stop-buffer.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-tag'
-import type { CensusValues, GraphQLClient } from '~~/src/core'
+import type { CensusValues, Geometry, GraphQLClient } from '~~/src/core'
 import { parseAcsValues } from './census'
 
 // #315 — per-entity buffer ∩ census intersections + inline ACS values.
@@ -212,4 +212,23 @@ export async function fetchEntityBufferGeographies (
     }
     return [ent.id, geographies]
   })
+}
+
+// Union of circles of `radius` around each of a route's stops, computed
+// server-side. Independent of census data, so it renders in any query mode.
+export const routeStopBufferQuery = gql`
+  query ($ids: [Int!], $radius: Float, $limit: Int) {
+    routes(ids: $ids, limit: $limit) {
+      id
+      route_stop_buffer(radius: $radius) {
+        stop_buffer
+      }
+    }
+  }
+`
+
+// Raw GraphQL shape for one route in the stop-buffer query response.
+export interface RouteStopBufferResponse {
+  id: number
+  route_stop_buffer?: { stop_buffer?: Geometry }
 }

--- a/src/tl/stop.test.ts
+++ b/src/tl/stop.test.ts
@@ -211,4 +211,50 @@ describe('stopGeoAggregateCsv', () => {
     const result = stopGeoAggregateCsv([stop], 'tract')
     expect(result[0]?.visit_count_total).toBe(0)
   })
+
+  // A stop buffer reaches past the query area, so the buffer pass returns
+  // geographies the query-area pass never saw. Without a row seeded for them
+  // their demographics are dropped from the table entirely.
+  describe('buffer-reached geographies', () => {
+    const censusGeographies = new Map([
+      ['41051000100', {
+        id: 1, name: 'Tract 1', values: {}, intersectionRatio: 1,
+        geometryArea: 1000, intersectionArea: 1000,
+      }],
+    ])
+    const bufferGeographies = [
+      { geoid: '41051000100', layer: 'tract', name: 'Tract 1', geometryArea: 1000, intersectionArea: 500, values: { b01003_001: 800 } },
+      // Outside the query area — only the buffer reaches it.
+      { geoid: '41051000200', layer: 'tract', name: 'Tract 2', geometryArea: 1000, intersectionArea: 250, values: { b01003_001: 400 } },
+    ]
+
+    it('seeds a row for a geography only the buffer reaches', () => {
+      const rows = stopGeoAggregateCsv([], 'tract', censusGeographies, {
+        aggregationBufferGeographies: bufferGeographies,
+      })
+      const byGeoid = new Map(rows.map(r => [r.geoid, r]))
+      expect([...byGeoid.keys()].sort()).toEqual(['41051000100', '41051000200'])
+      // Named from the buffer pass, and apportioned by its own coverage.
+      expect(byGeoid.get('41051000200')?.name).toBe('Tract 2')
+      expect(byGeoid.get('41051000200')?.total_population).toBeCloseTo(100)
+      expect(byGeoid.get('41051000200')?.stops_count).toBe(0)
+    })
+
+    it('only seeds at the aggregation layer — finer ones roll up by FIPS prefix', () => {
+      const rows = stopGeoAggregateCsv([], 'county', new Map(), {
+        aggregationBufferGeographies: [
+          { geoid: '1400000US41051000200', layer: 'tract', name: 'Tract 2', geometryArea: 1000, intersectionArea: 250, values: {} },
+        ],
+      })
+      expect(rows).toHaveLength(0)
+    })
+
+    it('respects onlyWithStops', () => {
+      const rows = stopGeoAggregateCsv([], 'tract', censusGeographies, {
+        onlyWithStops: true,
+        aggregationBufferGeographies: bufferGeographies,
+      })
+      expect(rows).toHaveLength(0)
+    })
+  })
 })

--- a/src/tl/stop.ts
+++ b/src/tl/stop.ts
@@ -178,6 +178,30 @@ export type Stop = StopGql & StopDerived
 //     HIERARCHICAL_TIGER_LAYERS. FIPS-prefix rollup + apportionBuffer().
 //   - Pass A (bbox-clipped) otherwise — non-hierarchical layers can't roll
 //     up by string match (needs server-side geometric containment, #370).
+interface StopGeoAggregateRow {
+  geoid: string
+  layer_name: string
+  name: string
+  visits_count?: number
+  stops_count: Set<number>
+  routes_count: Set<number>
+  routes_modes: Set<number>
+  agencies_count: Set<number>
+}
+
+function seedAggregateRow (geoid: string, layerName: string, name: string): StopGeoAggregateRow {
+  return {
+    geoid,
+    layer_name: layerName,
+    name,
+    visits_count: 0,
+    stops_count: new Set<number>(),
+    routes_count: new Set<number>(),
+    routes_modes: new Set<number>(),
+    agencies_count: new Set<number>(),
+  }
+}
+
 export function stopGeoAggregateCsv (
   stops: Stop[],
   aggregationKey: string,
@@ -187,47 +211,32 @@ export function stopGeoAggregateCsv (
   const bufferGeographies = options?.aggregationBufferGeographies
   const useBuffer = !!(bufferGeographies && bufferGeographies.length > 0
     && HIERARCHICAL_TIGER_LAYERS.has(aggregationKey))
-  const stopAgg = new Map<string, {
-    geoid: string
-    layer_name: string
-    name: string
-    visits_count?: number
-    stops_count: Set<number>
-    routes_count: Set<number>
-    routes_modes: Set<number>
-    agencies_count: Set<number>
-  }>()
+  const stopAgg = new Map<string, StopGeoAggregateRow>()
 
   // Seed every geography so stop-less tracts still produce a row. Skipped
   // when the caller only wants stop-touched rows.
-  if (censusGeographies && !options?.onlyWithStops) {
-    for (const [geoid, geo] of censusGeographies) {
-      stopAgg.set(geoid, {
-        geoid,
-        layer_name: aggregationKey,
-        name: geo.name,
-        visits_count: 0,
-        stops_count: new Set<number>(),
-        routes_count: new Set<number>(),
-        routes_modes: new Set<number>(),
-        agencies_count: new Set<number>(),
-      })
+  if (!options?.onlyWithStops) {
+    for (const [geoid, geo] of censusGeographies || []) {
+      stopAgg.set(geoid, seedAggregateRow(geoid, aggregationKey, geo.name))
+    }
+    // A stop buffer reaches geographies the query area doesn't cover, and
+    // their demographics belong in this table. Seeded from the buffer
+    // footprint itself, since the query area by definition doesn't include
+    // them. Only at the aggregation layer — finer ones roll up by FIPS
+    // prefix into a row that already exists.
+    if (useBuffer) {
+      for (const geo of bufferGeographies!) {
+        if (geo.layer === aggregationKey && !stopAgg.has(geo.geoid)) {
+          stopAgg.set(geo.geoid, seedAggregateRow(geo.geoid, aggregationKey, geo.name || ''))
+        }
+      }
     }
   }
 
   for (const stop of stops) {
     const geogs = (stop.census_geographies || []).filter(g => g.layer_name === aggregationKey)
     for (const geog of geogs) {
-      const a = stopAgg.get(geog.geoid) || {
-        geoid: geog.geoid,
-        layer_name: geog.layer_name,
-        name: geog.name,
-        visits_count: 0,
-        stops_count: new Set<number>(),
-        routes_count: new Set<number>(),
-        routes_modes: new Set<number>(),
-        agencies_count: new Set<number>(),
-      }
+      const a = stopAgg.get(geog.geoid) || seedAggregateRow(geog.geoid, geog.layer_name, geog.name)
       a.stops_count.add(stop.id)
       a.visits_count = (a.visits_count || 0) + (stop.visits?.total?.visit_count || 0)
       for (const rstop of stop.route_stops) {

--- a/test/browser/choropleth.test.ts
+++ b/test/browser/choropleth.test.ts
@@ -43,29 +43,45 @@ test.describe('Choropleth aggregation overlay', () => {
 
     // "Aggregation" section should be visible
     await expect(page.getByText('Aggregation')).toBeVisible()
-    await expect(page.getByText('Show agg. areas')).toBeVisible()
+    await expect(page.getByText('Show Agg. Areas')).toBeVisible()
+    await expect(page.getByText('Clipping mode')).toBeVisible()
     await expect(page.getByText('Aggregate by')).toBeVisible()
   })
 
-  test('agg. areas mode is hidden by default', async () => {
-    const select = page.locator('.cal-filter-sub').getByLabel('Show agg. areas')
-    await expect(select).toHaveValue('off')
+  test('Show Agg. Areas checkbox is unchecked by default', async () => {
+    const checkbox = page.locator('.cal-filter-sub').getByLabel('Show Agg. Areas')
+    await expect(checkbox).not.toBeChecked()
   })
 
-  test('Aggregate by dropdown is enabled regardless of the agg. areas mode', async () => {
-    // The dropdown should be enabled even when the overlay is hidden
+  test('clipping mode defaults to the query area', async () => {
+    const select = page.locator('.cal-filter-sub').getByLabel('Clipping mode')
+    await expect(select).toHaveValue('queryArea')
+  })
+
+  test('Aggregate by dropdown is enabled regardless of Show Agg. Areas', async () => {
+    // The dropdown should be enabled even when the checkbox is unchecked
     // (it also drives the Report tab aggregation, not just the map overlay)
     await openFilterSubtab(page, 'Map Display')
     const dropdown = page.locator('.cal-filter-sub').getByLabel('Aggregate by')
     await expect(dropdown).toBeEnabled({ timeout: 5000 })
   })
 
-  test('selecting an agg. areas mode persists in URL', async () => {
+  test('checking Show Agg. Areas persists in URL', async () => {
     await openFilterSubtab(page, 'Map Display')
-    const select = page.locator('.cal-filter-sub').getByLabel('Show agg. areas')
-    await select.selectOption('queryArea')
+    const checkbox = page.locator('.cal-filter-sub').getByLabel('Show Agg. Areas')
+    await checkbox.check()
+    await expect(checkbox).toBeChecked()
 
-    await expect(page).toHaveURL(/showAggAreas=queryArea/)
+    await expect(page).toHaveURL(/showAggAreas=true/)
+  })
+
+  // The default is omitted from the URL, so only a non-default clip appears.
+  test('a non-default clipping mode persists in URL', async () => {
+    await openFilterSubtab(page, 'Map Display')
+    const select = page.locator('.cal-filter-sub').getByLabel('Clipping mode')
+    await select.selectOption('unclipped')
+
+    await expect(page).toHaveURL(/aggClip=unclipped/)
   })
 
   test('legend shows choropleth section when aggregation is enabled (requires census data)', async () => {

--- a/test/browser/choropleth.test.ts
+++ b/test/browser/choropleth.test.ts
@@ -43,31 +43,29 @@ test.describe('Choropleth aggregation overlay', () => {
 
     // "Aggregation" section should be visible
     await expect(page.getByText('Aggregation')).toBeVisible()
-    await expect(page.getByText('Show Agg. Areas')).toBeVisible()
+    await expect(page.getByText('Show agg. areas')).toBeVisible()
     await expect(page.getByText('Aggregate by')).toBeVisible()
   })
 
-  test('Show Agg. Areas checkbox is unchecked by default', async () => {
-    const checkbox = page.locator('.cal-filter-sub').getByLabel('Show Agg. Areas')
-    await expect(checkbox).not.toBeChecked()
+  test('agg. areas mode is hidden by default', async () => {
+    const select = page.locator('.cal-filter-sub').getByLabel('Show agg. areas')
+    await expect(select).toHaveValue('off')
   })
 
-  test('Aggregate by dropdown is enabled regardless of Show Agg. Areas', async () => {
-    // The dropdown should be enabled even when the checkbox is unchecked
+  test('Aggregate by dropdown is enabled regardless of the agg. areas mode', async () => {
+    // The dropdown should be enabled even when the overlay is hidden
     // (it also drives the Report tab aggregation, not just the map overlay)
     await openFilterSubtab(page, 'Map Display')
     const dropdown = page.locator('.cal-filter-sub').getByLabel('Aggregate by')
     await expect(dropdown).toBeEnabled({ timeout: 5000 })
   })
 
-  test('checking Show Agg. Areas persists in URL', async () => {
+  test('selecting an agg. areas mode persists in URL', async () => {
     await openFilterSubtab(page, 'Map Display')
-    const checkbox = page.locator('.cal-filter-sub').getByLabel('Show Agg. Areas')
-    await checkbox.check()
-    await expect(checkbox).toBeChecked()
+    const select = page.locator('.cal-filter-sub').getByLabel('Show agg. areas')
+    await select.selectOption('queryArea')
 
-    // Verify URL contains showAggAreas=true
-    await expect(page).toHaveURL(/showAggAreas=true/)
+    await expect(page).toHaveURL(/showAggAreas=queryArea/)
   })
 
   test('legend shows choropleth section when aggregation is enabled (requires census data)', async () => {

--- a/test/browser/choropleth.test.ts
+++ b/test/browser/choropleth.test.ts
@@ -53,9 +53,9 @@ test.describe('Choropleth aggregation overlay', () => {
     await expect(checkbox).not.toBeChecked()
   })
 
-  test('clipping mode defaults to full geographies', async () => {
+  test('clipping mode defaults to query area + stop buffers', async () => {
     const select = page.locator('.cal-filter-sub').getByLabel('Clipping mode')
-    await expect(select).toHaveValue('unclipped')
+    await expect(select).toHaveValue('buffer')
   })
 
   test('Aggregate by dropdown is enabled regardless of Show Agg. Areas', async () => {

--- a/test/browser/choropleth.test.ts
+++ b/test/browser/choropleth.test.ts
@@ -53,9 +53,9 @@ test.describe('Choropleth aggregation overlay', () => {
     await expect(checkbox).not.toBeChecked()
   })
 
-  test('clipping mode defaults to the query area', async () => {
+  test('clipping mode defaults to full geographies', async () => {
     const select = page.locator('.cal-filter-sub').getByLabel('Clipping mode')
-    await expect(select).toHaveValue('queryArea')
+    await expect(select).toHaveValue('unclipped')
   })
 
   test('Aggregate by dropdown is enabled regardless of Show Agg. Areas', async () => {
@@ -79,9 +79,9 @@ test.describe('Choropleth aggregation overlay', () => {
   test('a non-default clipping mode persists in URL', async () => {
     await openFilterSubtab(page, 'Map Display')
     const select = page.locator('.cal-filter-sub').getByLabel('Clipping mode')
-    await select.selectOption('unclipped')
+    await select.selectOption('queryArea')
 
-    await expect(page).toHaveURL(/aggClip=unclipped/)
+    await expect(page).toHaveURL(/aggClip=queryArea/)
   })
 
   test('legend shows choropleth section when aggregation is enabled (requires census data)', async () => {

--- a/test/browser/stop-buffer-overlay.test.ts
+++ b/test/browser/stop-buffer-overlay.test.ts
@@ -1,10 +1,10 @@
 import { test, expect, type Page } from '@playwright/test'
-import { PORTLAND_BBOX, openFilterSubtab, waitForScenarioLoad } from './helpers'
+import { PORTLAND_BBOX, waitForScenarioLoad } from './helpers'
 
 // These tests run against a fixed test database (testdata/gtfs/calact_tlserver.dump).
-// They cover the "Show stop buffers" overlay: the Map Display control, its URL
-// round-trip, and that outlines actually reach the map — the last of which is
-// the only check that would catch the GraphQL field being renamed.
+// They cover the "Show stop buffers" overlay, which has no Map Display control
+// and is reached by URL: that outlines make it to the map, which is the only
+// check that would catch the GraphQL field being renamed.
 test.describe('Stop buffer overlay', () => {
   let page: Page
 
@@ -22,36 +22,8 @@ test.describe('Stop buffer overlay', () => {
     await page.close()
   })
 
-  test('Overlay section offers the stop buffer toggle, unchecked by default', async () => {
-    await page.locator('a[title="Filter"]').click()
-    await expect(page.locator('.cal-filter-summary-counts')).toBeVisible({ timeout: 5000 })
-    await openFilterSubtab(page, 'Map Display')
+  // The Map Display checkbox is gone; the overlay is URL-only now.
 
-    await expect(page.getByText('Overlay')).toBeVisible()
-    const checkbox = page.locator('.cal-filter-sub').getByLabel('Show stop buffers')
-    await expect(checkbox).toBeVisible()
-    await expect(checkbox).not.toBeChecked()
-  })
-
-  // The checkbox is deliberately never disabled: at radius 0 it simply draws
-  // nothing, and disabling it would leave a checked box the user can't clear.
-  test('toggle stays usable at radius 0 and round-trips through the URL', async () => {
-    await openFilterSubtab(page, 'Map Display')
-    const checkbox = page.locator('.cal-filter-sub').getByLabel('Show stop buffers')
-
-    await expect(checkbox).toBeEnabled()
-    await checkbox.check()
-    await expect(checkbox).toBeChecked()
-    await expect(page).toHaveURL(/showStopBuffer=true/)
-
-    await checkbox.uncheck()
-    await expect(checkbox).not.toBeChecked()
-    await expect(page).not.toHaveURL(/showStopBuffer=true/)
-  })
-
-  // Asserts on the request rather than the canvas: the map instance is not
-  // exposed to tests, and this is what breaks if the GraphQL field is renamed
-  // or the composable stops wiring the radius through.
   test('a stop buffer query is issued with the configured radius', async () => {
     const request = page.waitForRequest(req =>
       req.method() === 'POST' && (req.postData() || '').includes('route_stop_buffer'),


### PR DESCRIPTION
## Summary

Works on #422 by making the aggregation overlay state which area its numbers describe, and fixes #442 so that area is the one the user actually drew. The overlay previously had a single on/off switch, and the number behind it was always the geography's overlap with the query area — fine when the only thing shaded was stop counts, but the overlay now shades eleven ACS demographic columns, and "how much of this tract are we counting?" has three defensible answers. A new Clipping mode selector makes that choice explicit, and everything that reports a census figure — choropleth shading, the map's census panel, its totals column, and the Census Details tables — follows the selection. Separately, both census passes were clipping against a bounding box widened by the stop radius, which overstated every intersection; on a downtown Portland box 12 of 31 reported tracts didn't intersect the query at all and the worst reported 69% coverage where the truth was 12%.

## User-facing changes

### Aggregation clipping

- Show Agg. Areas stays a checkbox, off unless a URL parameter says otherwise. A new Clipping mode selector sits beneath it: None (full geographies), Query area, or Query area + stop buffers.
- Clipping mode defaults to Query area + stop buffers, so turning the overlay on answers what the transit service reaches. The less clipped modes remain available for context.
- In a clipped mode each geography is drawn as its clipped footprint rather than its whole outline, so a tract credited at 12% looks like 12%. Geographies the clip doesn't reach are not drawn.
- The census panel's Intersection row and column follow the selected clip. In unclipped mode there is no clip to report, so that column and the area line are hidden rather than restating the full geography.
- The panel's third column is renamed from Query Area Total to Analysis Area Total, since the query area is now one mode among several.
- A refresh icon beside Clipping mode recomputes the stop-buffer clip against the stops matching the current filters. The clip is a server-side calculation, so it is not redone automatically as filters change; once used, later layer or radius changes keep following the filters.
- Clear all now resets the Map Display settings, which it previously left behind.

### Corrected measurements

- Census intersections are measured against the bounding box as drawn. Previously a stop radius widened it, so intersection percentages, apportioned demographics and choropleth shading all described a rectangle up to the radius larger on every side, and geographies that never touched the query appeared in the results.
- The aggregated report table gains rows for geographies that only a stop buffer reaches, which the widened box had been supplying by accident.

### Map and overlay

- The geographic filter outline is drawn as a dashed line with no fill.
- The Show stop buffers checkbox is removed from Map Display. The overlay itself is unchanged and still reachable via the showStopBuffer URL parameter.

## Implementation details

### Clipping mode

- `AggClipMode` plus `censusApportionRatio` / `censusApportionArea` / `censusApportionGeometry` in `src/core/census-columns.ts` are the single seam between the selected mode and every consumer, so no call site branches on the mode itself. `buffer` falls back to the query-area clip when a scenario carries none.
- State is URL-backed in `useScenarioDisplay`: the existing `showAggAreas` boolean is unchanged, and a new `aggClip` key holds the mode. Only non-default values are written, so existing shared links keep working.
- Both clips arrive together from the census phase, so moving between modes needs no refetch.
- `pickChoroplethValue` takes the mode and apportions census columns by it. Density is deliberately exempt: a clip scales the value and the area it covers by the same ratio, so density is clip-invariant and always reports over the full geography. Stop-aggregation elements are exempt too, since they already count what the query returned.

### Clipped outlines

- `intersection_geometry` is requested behind an `@include` on both census passes and lands as `intersectionGeometry` / `bufferIntersectionGeometry` on each geography, so the outline always comes from the same query as the area it matches.
- Outlines roughly double the census response, so they are opt-in. `ScenarioConfig.includeIntersectionGeometry` is set from the display state, meaning a run started in a clipped mode arrives ready to draw; a latch in `useAggregateRefetch` covers turning a clipped mode on afterwards.
- `choroplethGeoIds` narrows the separate full-geometry query to geographies with no clipped outline, so both are not fetched for the same geography.

### Bbox padding

- `padBboxMeters` is deleted and both passes clip against the bbox as drawn. A test pins that on both passes.
- The padding was load-bearing for a second, undocumented reason: it seeded aggregation rows for geographies a stop buffer reaches. That job moves to the buffer results themselves in `stopGeoAggregateCsv`, which is a better fit than a rectangle approximating them — the rectangle both over- and under-covered. `BufferGeographyIntersection` carries `name` so those rows are labelled.
- The `within` path is untouched throughout; it never had padding, which is why bbox and admin-boundary queries over the same area used to disagree.

### Refetch

- The census clip is recomputed on aggregate layer changes, stop radius changes, and the manual refresh. The marked stop set is deliberately not watched: it churns while results stream in, so watching it fired a recompute mid-load that fought the main run for the loading modal and the receiver's census slice.
- `clearBeforeFetch` becomes a getter, so the choropleth is only blanked when the aggregation layer actually changed rather than on every recompute.

## User test plan

- Run a Portland query with the default 402 m stop radius, open Filter, Map Display, and tick Show Agg. Areas. Confirm the map shades clipped footprints rather than whole tracts, and that tracts no stop buffer reaches are not drawn.
- Cycle Clipping mode through all three values with a count column such as Total population selected under Shade map by. Shading should lighten from None to Query area to Query area + stop buffers, and the network tab should stay quiet after the first clipped selection.
- Click a shaded geography. The census panel's Intersection column and area line should track the selected mode, and should disappear entirely in None (full geographies).
- Switch to None and back; confirm no loading modal appears, since both clips are already loaded.
- Set the stop radius to 0 and re-run. The buffer option should read "(no stop radius set)", remain selectable, and fall back to query-area figures.
- With a scenario loaded, filter to a single agency, then click the refresh icon beside Clipping mode. The buffer coverage percentage in the panel should drop to reflect only that agency's stops. Change the aggregation layer afterwards and confirm the clip stays filtered.
- Compare a bbox query against the same area expressed as an administrative boundary. Intersection percentages should now agree; before this change the bbox path reported higher.
- Open Filter, Clear all, and confirm the Map Display settings return to their defaults along with the filters.
