### PR TITLE
Add stop latitude and longitude to Stops and Routes table & CSV

### DIFF
--- a/app/components/analysis/wsdot-stops-routes-viewer.vue
+++ b/app/components/analysis/wsdot-stops-routes-viewer.vue
@@ -73,6 +73,12 @@
                   max-width="100px"
                 />
               </template>
+              <template #column-stopLat="{ value }">
+                {{ formatCoordinate(value) }}
+              </template>
+              <template #column-stopLon="{ value }">
+                {{ formatCoordinate(value) }}
+              </template>
               <template #column-highestLevel="{ value }">
                 <span
                   :class="getFrequencyLevelClass(value)"
@@ -268,42 +274,6 @@ const stopFeatures = computed((): Feature[] => {
   }))
 })
 
-// Convert stops to table data for CSV download
-const _stopTableData = computed(() => {
-  return report.value.stops.map(stop => ({
-    // GTFS stop fields (using existing camelCase convention)
-    stopId: stop.stopId,
-    stopCode: stop.stopCode,
-    platformCode: stop.platformCode,
-    stopName: stop.stopName,
-    stopDesc: stop.stopDesc,
-    stopLat: stop.stopLat,
-    stopLon: stop.stopLon,
-    zoneId: stop.zoneId,
-    stopUrl: stop.stopUrl,
-    locationType: stop.locationType,
-    parentStation: stop.parentStation,
-    wheelchairBoarding: stop.wheelchairBoarding,
-    ttsStopName: stop.ttsStopName,
-    stopTimezone: stop.stopTimezone,
-
-    // Service level columns
-    level6: stop.level6,
-    level5: stop.level5,
-    level4: stop.level4,
-    level3: stop.level3,
-    level2: stop.level2,
-    level1: stop.level1,
-    levelNights: stop.levelNights,
-
-    // Additional fields for our internal use
-    agencyId: stop.agencyId,
-    agencyName: agencyLookup.value.get(stop.agencyId) || 'Unknown',
-    feedOnestopId: stop.feedOnestopId,
-    feedVersionSha1: stop.feedVersionSha1,
-  }))
-})
-
 // Convert routes to GeoJSON features for download
 const routeFeatures = computed((): Feature[] => {
   return report.value.routes.map(route => ({
@@ -333,29 +303,13 @@ const routeFeatures = computed((): Feature[] => {
   }))
 })
 
-// Convert routes to table data for CSV download
-const _routeTableData = computed(() => {
-  return report.value.routes.map(route => ({
-    // GTFS route fields (using existing camelCase convention)
-    routeId: route.routeId,
-    routeShortName: route.routeShortName,
-    routeLongName: route.routeLongName,
-    routeDesc: route.routeDesc,
-    routeType: route.routeType,
-    routeUrl: route.routeUrl,
-    routeColor: route.routeColor,
-    routeTextColor: route.routeTextColor,
-    routeSortOrder: route.routeSortOrder,
-    continuousPickup: route.continuousPickup,
-    continuousDropOff: route.continuousDropOff,
-
-    // Additional fields for our internal use
-    agencyId: route.agencyId,
-    agencyName: agencyLookup.value.get(route.agencyId) || 'Unknown',
-    feedOnestopId: route.feedOnestopId,
-    feedVersionSha1: route.feedVersionSha1,
-  }))
-})
+// Coordinates are shown at 6 decimal places (~0.1 m) so the table stays
+// readable. The underlying row values (and therefore the CSV and GeoJSON
+// exports) keep the full precision returned by the API.
+const formatCoordinate = (value: unknown): string => {
+  const n = Number(value)
+  return Number.isFinite(n) ? n.toFixed(6) : ''
+}
 
 // Helper function to determine the highest service level for a stop (matching WSDOT viewer)
 const getHighestServiceLevel = (stop: any): string => {
@@ -387,6 +341,10 @@ const stopDatagrid = computed((): TableReport => {
     id: stop.stopId,
     stopId: stop.stopId,
     stopName: stop.stopName,
+    // Full precision here so the CSV export matches the GeoJSON export; the
+    // table cells round for display.
+    stopLat: stop.stopLat,
+    stopLon: stop.stopLon,
     stopCode: stop.stopCode,
     platformCode: stop.platformCode,
     stopDesc: stop.stopDesc,
@@ -416,6 +374,8 @@ const stopDatagrid = computed((): TableReport => {
   const columns: TableColumn[] = [
     { key: 'stopId', label: 'Stop ID', sortable: true },
     { key: 'stopName', label: 'Stop Name', sortable: true },
+    { key: 'stopLat', label: 'Stop Latitude', sortable: true, numeric: true },
+    { key: 'stopLon', label: 'Stop Longitude', sortable: true, numeric: true },
     { key: 'highestLevel', label: 'Highest Level', sortable: true },
     { key: 'level1', label: 'Level 1', sortable: true },
     { key: 'level2', label: 'Level 2', sortable: true },

--- a/app/components/cal/datagrid.vue
+++ b/app/components/cal/datagrid.vue
@@ -186,7 +186,7 @@ const sortedData = computed(() => {
     return base
   }
   const col = tableReport.value?.columns.find(c => c.key === key)
-  const numeric = col?.format !== undefined
+  const numeric = col?.numeric === true || col?.format !== undefined
   const sign = dir === 'asc' ? 1 : -1
   return [...base].sort((a, b) => {
     const va = a[key]

--- a/src/core/table.ts
+++ b/src/core/table.ts
@@ -10,6 +10,10 @@ export interface TableColumn {
   tooltip?: string
   // When set, the default cell renderer routes the value through formatCensusValue.
   format?: CensusFormat
+  // Sort this column numerically. Implied by `format`; set explicitly for
+  // numeric columns rendered through a slot rather than formatCensusValue,
+  // where string collation would order negative values incorrectly.
+  numeric?: boolean
 }
 
 export interface TableReport {


### PR DESCRIPTION
Closes #431

## Summary

The WSDOT Transit Stops and Routes report already had stop coordinates, but only in the GeoJSON export. The Transit Stops table did not show them, and the CSV export did not contain them, so anyone building GIS layers from the CSV had to join the coordinates back in by hand. This adds Stop Latitude and Stop Longitude as columns on the Transit Stops table, which also puts them in the CSV, since that export is generated from the table's row objects rather than from the visible columns.

No new data is fetched. `stopLat` / `stopLon` were already on `WSDOTStopResult`, populated from the stop geometry in `processWsdotStopsRoutesReport`; they simply were not passed through to the datagrid.

## User-facing changes

### Transit Stops table

- Two new columns, Stop Latitude and Stop Longitude, immediately after Stop Name.
- Values render at 6 decimal places (~0.1 m), so the cells stay readable rather than showing the full float (`45.6906915250296`).
- Both columns are sortable, and sort numerically.

### CSV export

- The Transit Stops CSV now carries `stopLat` and `stopLon` columns, positioned after `stopName`.
- The CSV values keep the full precision returned by the API, so they match the GeoJSON export exactly rather than being rounded to what the table displays.

## Implementation details

### Coordinates into the datagrid

`stopLat` / `stopLon` are added to the row objects built in `stopDatagrid`, placed after `stopName`. Row-key order is what determines CSV column order, since `cal-csv-download` takes the keys of the first row, so this positions them near the front of the export as well as in the table.

The raw, unrounded values go into the rows. Display rounding happens in `#column-stopLat` / `#column-stopLon` slot templates via a local `formatCoordinate` helper, so the export and the display can differ: full precision in the CSV, 6 decimals on screen.

### Numeric sorting

`TableColumn` gains an optional `numeric` flag, and `cal-datagrid`'s sort comparator now treats a column as numeric when either `numeric` is set or `format` is set (previously `format` alone).

Longitude is the reason. Without it the comparator falls back to `localeCompare(..., { numeric: true })`, which orders `-121.9` before `-122.663733`: wrong for every West Coast longitude in the table. The existing way to get a numeric sort is to set `format`, but `format` also routes the cell through `formatCensusValue`, whose `decimal` case is `toFixed(2)`, far too coarse for coordinates, and it would fight the slot rendering. `numeric` separates "sort this as a number" from "render this a particular way." The change to the comparator is a strict superset of the old behavior; no existing column's sort changes.

### Dead code removed

`_stopTableData` and `_routeTableData` are deleted. They were unused computeds, with no template or script reference, commented as "Convert stops/routes to table data for CSV download," and the stops one already listed `stopLat` / `stopLon`. Reading the file, they look like the CSV's source when it is actually `stopDatagrid`. Leaving them would make this change look already-done to the next person in the file.

## User test plan

- Advanced Analysis, then WSDOT Transit Stops and Routes, run an analysis, then the Transit Stops tab. Confirm Stop Latitude and Stop Longitude appear after Stop Name, showing 6 decimal places.
- Click each coordinate header and confirm the sort is numeric in both directions, in particular that longitudes sort as a normal number line (`-122.7` before `-122.6`), not as strings.
- Download as CSV. Confirm `stopLat` and `stopLon` columns are present after `stopName`, and that they carry more precision than the table shows.
- Download as GeoJSON for the same result set and confirm the CSV coordinates match the GeoJSON `stopLat` / `stopLon` values exactly for a few stops.
- Spot-check one stop against the map to confirm the coordinates land where the stop is.
- Check the Transit Routes and Agencies tabs are unchanged, and confirm sorting still behaves on another table with numeric columns (for example the census/aggregation tables on the main Report view), since the datagrid comparator was touched.
