### PR TITLE
Consolidate scenario and phases files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 TRANSITLAND_API_BASE="https://api.transit.land/api/v2" # cli
 NUXT_TLV2_PROXY_BASE_DEFAULT="https://api.transit.land/api/v2"
 
+# Diagnostics (server-side / CLI only)
+# TL_LOG=trace       # one line per GraphQL request: operation, elapsed, response size
+# DEBUG_MEMORY=1     # heap/rss at each scenario phase boundary
+
 # Map tiles
 NUXT_PUBLIC_TLV2_PROTOMAPS_APIKEY=$PROTOMAPS_APIKEY
 

--- a/app/components/cal/scenario-loading.vue
+++ b/app/components/cal/scenario-loading.vue
@@ -145,7 +145,9 @@ function formatStage (stage: ScenarioProgress['currentStage'], stageText: string
   if (stageText) {
     return stageText
   }
-  const stageLabels: Record<string, string> = {
+  // Exhaustive over the stage union, so a new stage can't silently fall back
+  // to a generic "Loading...".
+  const stageLabels: Record<ScenarioProgress['currentStage'], string> = {
     'feed-versions': 'Loading feed versions...',
     'stops': 'Loading stops...',
     'routes': 'Loading routes...',
@@ -156,6 +158,10 @@ function formatStage (stage: ScenarioProgress['currentStage'], stageText: string
     'route-buffer-geographies': 'Loading per-route buffer demographics...',
     'agency-buffer-geographies': 'Loading per-agency buffer demographics...',
     'aggregation-buffer-geographies': 'Loading aggregation buffer demographics...',
+    'stop-clusters': 'Loading transfer hub clusters...',
+    // Analyses emit 'extra' with their own message, so this is only the
+    // fallback for one that doesn't set it.
+    'extra': 'Processing...',
     'complete': 'Complete',
     'ready': 'Ready',
   }

--- a/src/core/debug.ts
+++ b/src/core/debug.ts
@@ -14,3 +14,40 @@ export function logMemory (label: string): void {
     console.log(`[MEM ${label}] heap: ${heapMB}MB, rss: ${rssMB}MB`)
   }
 }
+
+/**
+ * Whether per-query GraphQL tracing is on (`TL_LOG=trace`). Tracing costs an
+ * extra read of the response body, so callers check this before paying for it.
+ * Server-side only — in the browser, use the network panel.
+ */
+export function graphqlTraceEnabled (): boolean {
+  return process.env.TL_LOG === 'trace'
+}
+
+export interface GraphqlTrace {
+  /** Operation name, or the root field names when the document is anonymous. */
+  operation: string
+  query: string
+  variables?: unknown
+  elapsedMs: number
+  responseBytes: number
+  /** Retries consumed before this attempt succeeded. */
+  attempts: number
+  error?: unknown
+}
+
+/**
+ * A summary line followed by the full request: the query as sent and every
+ * variable, unabridged. Nothing is elided — a variable list you can't read in
+ * full is a variable list you can't reproduce the request from.
+ */
+export function logGraphqlTrace (t: GraphqlTrace): void {
+  const kib = (t.responseBytes / 1024).toFixed(1)
+  const retried = t.attempts > 1 ? ` retries=${t.attempts - 1}` : ''
+  const status = t.error ? ` FAILED: ${t.error}` : ''
+  console.log(`[GQL ${t.operation}] ${t.elapsedMs}ms ${kib}KiB${retried}${status}`)
+  console.log(t.query.trim())
+  // Compact, not pretty-printed: a 1000-element id array would otherwise take
+  // 1000 lines and bury the query above it.
+  console.log(`variables: ${JSON.stringify(t.variables ?? {})}`)
+}

--- a/src/core/graphql.ts
+++ b/src/core/graphql.ts
@@ -1,9 +1,23 @@
 import { print } from 'graphql'
+import { graphqlTraceEnabled, logGraphqlTrace } from './debug'
 
 /**
  * GraphQL client implementations
  *
  */
+
+// Label for a traced request. Almost every document in this codebase is
+// anonymous, so the root field names are what usually identify it.
+function operationLabel (query: any): string {
+  const def = query?.definitions?.[0]
+  if (def?.name?.value) {
+    return def.name.value
+  }
+  const fields: string[] = (def?.selectionSet?.selections || [])
+    .map((s: any) => s?.name?.value)
+    .filter(Boolean)
+  return fields.length > 0 ? fields.join(',') : 'query'
+}
 
 /**
  * Interface for GraphQL client
@@ -45,7 +59,10 @@ export class BasicGraphQLClient implements GraphQLClient {
       query: queryString,
       variables,
     }
-    // console.log('GraphQL request:', JSON.stringify(requestBody))
+
+    const trace = graphqlTraceEnabled()
+    const startedAt = trace ? Date.now() : 0
+    let responseBytes = 0
 
     let lastError: Error | null = null
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
@@ -59,10 +76,30 @@ export class BasicGraphQLClient implements GraphQLClient {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`)
         }
 
-        const result = await response.json()
+        // Responses are chunked, so Content-Length isn't set; the body has to
+        // be read as text to be measured. Only when tracing — it's an extra
+        // copy of a payload that can run to megabytes.
+        let result: any
+        if (trace) {
+          const text = await response.text()
+          responseBytes = new TextEncoder().encode(text).length
+          result = JSON.parse(text)
+        } else {
+          result = await response.json()
+        }
 
         if (result.errors) {
           throw new Error(`GraphQL errors: ${result.errors.map((e: any) => e.message).join(', ')}`)
+        }
+        if (trace) {
+          logGraphqlTrace({
+            operation: operationLabel(query),
+            query: queryString,
+            variables,
+            elapsedMs: Date.now() - startedAt,
+            responseBytes,
+            attempts: attempt + 1,
+          })
         }
         return result
       } catch (error) {
@@ -73,6 +110,17 @@ export class BasicGraphQLClient implements GraphQLClient {
           console.warn(`GraphQL request failed (attempt ${attempt + 1}/${this.maxRetries + 1}), retrying in ${this.retryDelay}ms:`, error)
           await this.delay(this.retryDelay)
         } else {
+          if (trace) {
+            logGraphqlTrace({
+              operation: operationLabel(query),
+              query: queryString,
+              variables,
+              elapsedMs: Date.now() - startedAt,
+              responseBytes,
+              attempts: attempt + 1,
+              error,
+            })
+          }
           console.error('GraphQL request failed after all retry attempts:', error)
         }
       }

--- a/src/scenario/index.ts
+++ b/src/scenario/index.ts
@@ -1,6 +1,5 @@
 export * from './scenario'
 export * from './scenario-filter'
-export * from './buffer-passes'
 export * from './stop-clusters'
 export * from './phases'
 export * from './report'

--- a/src/scenario/phases/buffer-passes.test.ts
+++ b/src/scenario/phases/buffer-passes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { gql } from 'graphql-tag'
 import { apiFetch, BasicGraphQLClient, SCENARIO_DEFAULTS } from '~~/src/core'
 import { runBufferPasses } from './buffer-passes'
-import type { ScenarioProgress } from './scenario'
+import type { ScenarioProgress } from '../scenario'
 
 // Integration tests for the buffer-only fetch path (#315 Passes C/D/E/F).
 // Hits a live transitland-server connected to the test DB. Gate is opt-in so

--- a/src/scenario/phases/buffer-passes.ts
+++ b/src/scenario/phases/buffer-passes.ts
@@ -13,8 +13,8 @@ import {
   type BufferEntityKind,
   type BufferGeographyIntersection,
 } from '~~/src/tl'
-import type { ScenarioProgress } from './scenario'
-import { phaseDone } from './phases/common'
+import type { ScenarioProgress } from '../scenario'
+import { phaseDone } from './common'
 
 // Smaller than the stop batch because each route/agency expands to its full
 // stop set server-side, multiplying per-request cost.

--- a/src/scenario/phases/census-values.ts
+++ b/src/scenario/phases/census-values.ts
@@ -51,6 +51,7 @@ export async function runCensusValuesPhase (
     return
   }
 
+  // First pass: fetching ACS values
   emit({
     isLoading: true,
     currentStage: 'census-values',

--- a/src/scenario/phases/common.ts
+++ b/src/scenario/phases/common.ts
@@ -3,7 +3,7 @@
 // standalone via its own server endpoint, emitting the same ScenarioProgress
 // NDJSON envelope either way (the pattern established by buffer-passes).
 
-import type { ScenarioProgress } from '../scenario'
+import type { ScenarioConfig, ScenarioProgress } from '../scenario'
 
 // Phases report progress (and stream partial data) through this callback.
 export type PhaseEmit = (progress: ScenarioProgress) => void
@@ -18,28 +18,54 @@ export interface PhaseOpts {
 // Concurrent GraphQL requests per phase queue.
 export const PHASE_MAX_CONCURRENT_REQUESTS = 8
 
-// Phase identities for the progress plan and weights. 'buffers' covers all
-// four buffer passes as a single slice. 'stop-clusters' is the transfer-hub
-// pass (a separate stop query with nearby_stops neighbors).
-export type ScenarioPhaseName = 'feed-versions' | 'stops' | 'routes' | 'departures' | 'buffers' | 'stop-clusters' | 'flex-areas' | 'census-values'
+// The scenario phase registry: one entry per phase, in pipeline order. Adding
+// a phase is a single edit here — the name union, the order, the progress
+// weight, and the plan all derive from this array.
+//
+// `enabled` is the single source of truth for whether a config includes the
+// phase, driving both the emitted plan and fetchMain's execution gating, so the
+// two cannot drift. Routes, departures, and buffers execute inside the stops
+// block (they consume its ids), so their predicates must imply the stops
+// predicate. 'buffers' covers all four buffer passes as one slice;
+// 'stop-clusters' is the transfer-hub pass.
+//
+// Weights are relative progress-bar slices, normalized by the consumer over the
+// run's enabled phases. Rough cost ratios — tune from stage timings.
+const SCENARIO_PHASES = [
+  { name: 'feed-versions', weight: 1, enabled: () => true },
+  { name: 'stops', weight: 2, enabled: (c: ScenarioConfig) => c.includeFixedRoute !== false },
+  { name: 'routes', weight: 1, enabled: (c: ScenarioConfig) => c.includeFixedRoute !== false },
+  { name: 'departures', weight: 10, enabled: (c: ScenarioConfig) => c.includeFixedRoute !== false
+    && c.includeDepartures !== false },
+  { name: 'buffers', weight: 3, enabled: (c: ScenarioConfig) => c.includeFixedRoute !== false
+    && c.includeCensus !== false
+    && (c.stopBufferRadius ?? 0) > 0
+    && !!c.tableDatasetName },
+  { name: 'stop-clusters', weight: 2, enabled: (c: ScenarioConfig) => c.includeFixedRoute !== false
+    && (c.stopClusterDistance ?? 0) > 0 },
+  { name: 'flex-areas', weight: 1, enabled: (c: ScenarioConfig) => c.includeFlexAreas !== false },
+  { name: 'census-values', weight: 1, enabled: (c: ScenarioConfig) => c.includeCensus !== false
+    && !!c.tableDatasetName
+    && !!c.aggregateLayer },
+] as const satisfies readonly {
+  name: string
+  weight: number
+  enabled: (config: ScenarioConfig) => boolean
+}[]
+
+export type ScenarioPhaseName = typeof SCENARIO_PHASES[number]['name']
 
 // Pipeline ordering for phase plans and progress display.
-export const SCENARIO_PHASE_ORDER: ScenarioPhaseName[] = [
-  'feed-versions', 'stops', 'routes', 'departures', 'buffers', 'stop-clusters', 'flex-areas', 'census-values',
-]
+export const SCENARIO_PHASE_ORDER: ScenarioPhaseName[] = SCENARIO_PHASES.map(p => p.name)
 
-// Relative progress-bar weight per phase; the consumer normalizes over the
-// run's enabled plan. Rough cost ratios — tune from stage timings as data
-// accumulates. Equal weighting is the special case of all-1s.
-export const SCENARIO_PHASE_WEIGHTS: Record<ScenarioPhaseName, number> = {
-  'feed-versions': 1,
-  'stops': 2,
-  'routes': 1,
-  'departures': 10,
-  'buffers': 3,
-  'stop-clusters': 2,
-  'flex-areas': 1,
-  'census-values': 1,
+// `Object.fromEntries` widens its key type, so the cast restores exhaustiveness.
+export const SCENARIO_PHASE_WEIGHTS = Object.fromEntries(
+  SCENARIO_PHASES.map(p => [p.name, p.weight]),
+) as Record<ScenarioPhaseName, number>
+
+// The enabled phases for a scenario config, in pipeline order.
+export function scenarioPhasePlan (config: ScenarioConfig): ScenarioPhaseName[] {
+  return SCENARIO_PHASES.filter(p => p.enabled(config)).map(p => p.name)
 }
 
 // Final tick for a phase's progress slice. Also covers phases whose queue

--- a/src/scenario/phases/index.ts
+++ b/src/scenario/phases/index.ts
@@ -2,13 +2,13 @@
 // config + GraphQL client + emit callback, streams ScenarioProgress events,
 // and returns the ids/context downstream phases need. ScenarioFetcher
 // composes them inline; server/api/scenario/* exposes each standalone.
-// (buffer-passes.ts is the seventh phase; it predates this directory.)
 
 // Re-export only common's public surface. The phase-contract plumbing
 // (PhaseEmit, PhaseOpts, phaseDone, PHASE_MAX_CONCURRENT_REQUESTS) stays
 // internal — phase modules import it directly from './common'.
 export {
   getSelectedDateRange,
+  scenarioPhasePlan,
   SCENARIO_PHASE_ORDER,
   SCENARIO_PHASE_WEIGHTS,
   type ScenarioPhaseName,
@@ -20,3 +20,5 @@ export * from './routes'
 export * from './departures'
 export * from './flex'
 export * from './census-values'
+export * from './buffer-passes'
+export * from './stop-clusters'

--- a/src/scenario/phases/stop-clusters.ts
+++ b/src/scenario/phases/stop-clusters.ts
@@ -1,0 +1,164 @@
+// Phase: cross-agency transfer-hub clusters. Paginates the scenario's stops
+// with their PostGIS `nearby_stops` neighbors, then derives clusters from those
+// proximity edges. The clustering algorithm itself lives in
+// `src/scenario/stop-clusters.ts` alongside the client-side transfer-time prune.
+
+import {
+  convertBbox,
+  TaskQueue,
+  type Bbox,
+  type GraphQLClient,
+} from '~~/src/core'
+import { stopClusterQuery, type StopClusterStopResponse } from '~~/src/tl'
+import {
+  deriveStopClusters,
+  type ClusterInputStop,
+  type StopCluster,
+} from '../stop-clusters'
+import type { ScenarioProgress } from '../scenario'
+import {
+  PHASE_MAX_CONCURRENT_REQUESTS,
+  phaseDone,
+  type FeedVersionRef,
+  type PhaseEmit,
+  type PhaseOpts,
+} from './common'
+
+// Cap on neighbors returned per stop by nearby_stops. The radius is the real
+// constraint on cluster membership; this is just a high safety bound so a
+// pathologically dense area can't return an unbounded neighbor list per stop.
+const NEARBY_STOPS_LIMIT = 1000
+
+// Config for the clustering phase / standalone refetch. JSON-serializable so it
+// crosses the BFF boundary (mirrors BufferFetchConfig).
+export interface StopClusterFetchConfig {
+  feedVersions: FeedVersionRef[]
+  bbox?: Bbox
+  geographyIds?: number[]
+  geoDatasetName: string
+  // The PostGIS nearby_stops radius (meters) — the cluster max distance.
+  maxDistanceMeters: number
+  // GraphQL page size; pagination continues until a short page.
+  stopLimit?: number
+}
+
+interface StopClusterFetchTask {
+  after: number
+  feedOnestopId: string
+  feedVersionSha1: string
+}
+
+// Map a raw GraphQL stop into the minimal ClusterInputStop the algorithm needs.
+function toClusterInputStop (stop: StopClusterStopResponse): ClusterInputStop {
+  const agencyIds = new Set<number>()
+  const routeIds = new Set<number>()
+  for (const rs of stop.route_stops || []) {
+    const route = rs.route
+    if (route?.id != null) {
+      routeIds.add(route.id)
+    }
+    if (route?.agency?.id != null) {
+      agencyIds.add(route.agency.id)
+    }
+  }
+  return {
+    id: stop.id,
+    agencyIds: [...agencyIds],
+    routeIds: [...routeIds],
+    neighborIds: (stop.nearby_stops || []).map(n => n.id),
+  }
+}
+
+// Paginate the scenario's stops (with their in-radius neighbors) and return the
+// complete ClusterInputStop set. Mirrors runStopsPhase's pagination.
+async function fetchStopClusterInputs (
+  config: StopClusterFetchConfig,
+  client: GraphQLClient,
+  emit: PhaseEmit,
+  opts: PhaseOpts = {},
+): Promise<ClusterInputStop[]> {
+  const stopLimit = config.stopLimit ?? 1000
+  const inputs: ClusterInputStop[] = []
+
+  function progressEvent (): ScenarioProgress {
+    const p = queue.getProgress()
+    return {
+      isLoading: true,
+      currentStage: 'stop-clusters',
+      phaseProgress: { phase: 'stop-clusters', completed: p.completed, total: p.total },
+    }
+  }
+
+  async function fetchPage (task: StopClusterFetchTask): Promise<void> {
+    const geoIds = config.geographyIds || []
+    const b = geoIds.length > 0 ? null : convertBbox(config.bbox)
+    const variables = {
+      after: task.after,
+      limit: stopLimit,
+      radius: config.maxDistanceMeters,
+      nearbyLimit: NEARBY_STOPS_LIMIT,
+      where: {
+        location_type: 0,
+        feed_version_sha1: task.feedVersionSha1,
+        location: {
+          bbox: geoIds.length > 0 ? null : b,
+          geography_ids: geoIds.length > 0 ? geoIds : null,
+        },
+      },
+    }
+    const response = await client.query<{ stops: StopClusterStopResponse[] }>(stopClusterQuery, variables)
+    const stops = response.data?.stops || []
+    for (const stop of stops) {
+      inputs.push(toClusterInputStop(stop))
+    }
+    const lastStopId = stops[stops.length - 1]?.id
+    if (stops.length >= stopLimit && lastStopId !== undefined) {
+      queue.enqueueOne({
+        after: lastStopId,
+        feedOnestopId: task.feedOnestopId,
+        feedVersionSha1: task.feedVersionSha1,
+      })
+    }
+  }
+
+  const queue: TaskQueue<StopClusterFetchTask> = new TaskQueue<StopClusterFetchTask>(
+    PHASE_MAX_CONCURRENT_REQUESTS,
+    task => fetchPage(task),
+    {
+      onProgress: () => { emit(progressEvent()) },
+      onError: error => opts.onError?.(error),
+    },
+  )
+
+  for (const fv of config.feedVersions) {
+    queue.enqueueOne({
+      after: 0,
+      feedOnestopId: fv.feedOnestopId,
+      feedVersionSha1: fv.feedVersionSha1,
+    })
+  }
+  await queue.run()
+  return inputs
+}
+
+/**
+ * The `stop-clusters` scenario phase: fetch proximity edges from PostGIS, derive
+ * clusters, and emit them. Pure over its inputs; callers wrap `emit` with either
+ * a stream sender (main scenario / standalone endpoint) or an accumulator.
+ */
+export async function runStopClustersPhase (
+  config: StopClusterFetchConfig,
+  client: GraphQLClient,
+  emit: PhaseEmit,
+  opts: PhaseOpts = {},
+): Promise<StopCluster[]> {
+  const inputs = await fetchStopClusterInputs(config, client, emit, opts)
+  const clusters = deriveStopClusters(inputs, config.maxDistanceMeters)
+  emit({
+    isLoading: true,
+    currentStage: 'stop-clusters',
+    partialData: { stopClusters: clusters },
+    phaseProgress: phaseDone('stop-clusters'),
+  })
+  return clusters
+}

--- a/src/scenario/scenario.test.ts
+++ b/src/scenario/scenario.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, type Mock } from 'vitest'
 import type { ScenarioConfig } from './scenario'
-import { ScenarioFetcher, scenarioPhasePlan } from './scenario'
+import { ScenarioFetcher } from './scenario'
+import { scenarioPhasePlan } from './phases'
 import { parseDate, type Bbox, type GraphQLClient, SCENARIO_DEFAULTS } from '~~/src/core'
 import type { FeedGql, FlexLocationGql } from '~~/src/tl'
 
@@ -309,7 +310,7 @@ describe('ScenarioFetcher', () => {
   })
 
   describe('scenarioPhasePlan', () => {
-    // The plan is also the execution gate (PHASE_ENABLED), so these
+    // The plan is also the execution gate (the phase registry), so these
     // permutations pin which phases run for a given config.
     const fullConfig: ScenarioConfig = {
       ...config,

--- a/src/scenario/scenario.ts
+++ b/src/scenario/scenario.ts
@@ -20,8 +20,7 @@ import type {
   BufferGeographyIntersection,
 } from '~~/src/tl'
 import { StopDepartureCache, FlexDepartureCache } from '~~/src/tl'
-import { runBufferPasses } from './buffer-passes'
-import { runStopClustersPhase, type StopCluster } from './stop-clusters'
+import type { StopCluster } from './stop-clusters'
 import {
   runFeedVersionsPhase,
   runStopsPhase,
@@ -29,9 +28,11 @@ import {
   runDeparturesPhase,
   runFlexPhase,
   runCensusValuesPhase,
+  runBufferPasses,
+  runStopClustersPhase,
+  scenarioPhasePlan,
   StopDepartureTuple,
   FlexDepartureTuple,
-  SCENARIO_PHASE_ORDER,
   type FeedVersionRef,
   type ResolvedGeographyContext,
   type ScenarioPhaseName,
@@ -92,34 +93,6 @@ export interface ScenarioConfig {
   // Stop clustering. > 0 (meters) enables the stop-clusters phase; 0/unset disables.
   // The max-transfer-time filter is client-side, so it's not part of the fetch config.
   stopClusterDistance?: number
-}
-
-// Single source of truth for which phases a config enables. Drives both the
-// emitted phase plan and fetchMain's execution gating, so the two cannot
-// drift: a phase runs if and only if it is in the plan. Routes, departures,
-// and buffers execute inside the stops block (they consume its ids), so
-// their predicates must imply the stops predicate.
-const PHASE_ENABLED: Record<ScenarioPhaseName, (config: ScenarioConfig) => boolean> = {
-  'feed-versions': () => true,
-  'stops': config => config.includeFixedRoute !== false,
-  'routes': config => config.includeFixedRoute !== false,
-  'departures': config => config.includeFixedRoute !== false
-    && config.includeDepartures !== false,
-  'buffers': config => config.includeFixedRoute !== false
-    && config.includeCensus !== false
-    && (config.stopBufferRadius ?? 0) > 0
-    && !!config.tableDatasetName,
-  'stop-clusters': config => config.includeFixedRoute !== false
-    && (config.stopClusterDistance ?? 0) > 0,
-  'flex-areas': config => config.includeFlexAreas !== false,
-  'census-values': config => config.includeCensus !== false
-    && !!config.tableDatasetName
-    && !!config.aggregateLayer,
-}
-
-// The enabled phases for a scenario config, in pipeline order.
-export function scenarioPhasePlan (config: ScenarioConfig): ScenarioPhaseName[] {
-  return SCENARIO_PHASE_ORDER.filter(phase => PHASE_ENABLED[phase](config))
 }
 
 export interface ScenarioFilter {
@@ -465,7 +438,7 @@ export class ScenarioFetcher {
 
   // Config projection around the census-values phase; the inline path passes
   // the already-resolved geography so the phase doesn't re-query. Gating is
-  // the plan's job (PHASE_ENABLED) — this guard exists for type narrowing
+  // the plan's job (the phase registry) — this guard exists for type narrowing
   // and would only fire on a plan/config inconsistency bug.
   private async fetchCensusValues (resolved: ResolvedGeographyContext, stopIds: number[]): Promise<void> {
     const { tableDatasetName, aggregateLayer, geoDatasetName } = this.config
@@ -487,7 +460,7 @@ export class ScenarioFetcher {
 
   // Delegates to `runBufferPasses` so the same logic runs standalone via
   // /api/buffer-geographies on radius/layer changes. Gating is the plan's
-  // job (PHASE_ENABLED) — this guard exists for type narrowing and would
+  // job (the phase registry) — this guard exists for type narrowing and would
   // only fire on a plan/config inconsistency bug.
   private async fetchBufferData (stopIds: number[], routeIds: number[], agencyIds: number[]): Promise<void> {
     const { tableDatasetName, geoDatasetName } = this.config
@@ -513,7 +486,7 @@ export class ScenarioFetcher {
 
   // Delegates to `runStopClustersPhase` so the same logic runs standalone via
   // /api/stop-clusters on distance changes. Gating is the plan's job
-  // (PHASE_ENABLED) — this guard only fires on a plan/config inconsistency bug.
+  // (the phase registry) — this guard only fires on a plan/config inconsistency bug.
   private async fetchStopClusters (fvRefs: FeedVersionRef[]): Promise<void> {
     const distance = this.config.stopClusterDistance ?? 0
     if (distance <= 0) {

--- a/src/scenario/stop-clusters.ts
+++ b/src/scenario/stop-clusters.ts
@@ -6,38 +6,28 @@
  * three pieces:
  *
  *   1. deriveStopClusters() — pure graph/assignment over proximity edges. Runs
- *      SERVER-SIDE in runStopClustersPhase(). Does NO geometry itself: the edges
- *      (from PostGIS Stop.nearby_stops) already encode "within max distance".
+ *      SERVER-SIDE from the stop-clusters phase. Does NO geometry itself: the
+ *      edges (from PostGIS Stop.nearby_stops) already encode "within max
+ *      distance".
  *
- *   2. runStopClustersPhase() / fetchStopClusterInputs() — the server-side
- *      scenario phase: paginate the scenario stops with their nearby_stops
- *      neighbors, then run deriveStopClusters and emit the result.
- *
- *   3. applyClusterTransferTime() — runs CLIENT-SIDE in applyScenarioResultFilter,
+ *   2. applyClusterTransferTime() — runs CLIENT-SIDE in applyScenarioResultFilter,
  *      pruning members that lack a temporally-adjacent partner using the
  *      already-loaded departure times. Pure time arithmetic.
+ *
+ *   3. stopClusterCsv() — flattens a cluster into a report row.
+ *
+ * The phase that fetches the proximity edges and calls deriveStopClusters lives
+ * in `phases/stop-clusters.ts`.
  */
 
 import { format } from 'date-fns'
 import {
-  convertBbox,
   parseHMS,
   routeTypeNames,
-  TaskQueue,
   WEEKDAY_BY_GETDAY,
-  type Bbox,
-  type GraphQLClient,
   type Weekday,
 } from '~~/src/core'
-import { stopClusterQuery, type Stop, type StopClusterStopResponse, type StopDepartureCache } from '~~/src/tl'
-import {
-  PHASE_MAX_CONCURRENT_REQUESTS,
-  phaseDone,
-  type FeedVersionRef,
-  type PhaseEmit,
-  type PhaseOpts,
-} from './phases/common'
-import type { ScenarioProgress } from './scenario'
+import type { Stop, StopDepartureCache } from '~~/src/tl'
 
 /** Minimal per-stop input for clustering, decoupled from GraphQL types. */
 export interface ClusterInputStop {
@@ -405,149 +395,6 @@ export function deriveFilteredStopClusters (
     stopMeta.set(id, { agencyIds: [...agencyIds], routeIds: [...routeIds] })
   }
   return applyClusterTransferTime(clusters, maxTransferMinutes, departureSecondsByStop, stopMeta)
-}
-
-// ============================================================================
-// SERVER-SIDE PHASE — fetch proximity edges (PostGIS) and derive clusters
-// ============================================================================
-
-// Cap on neighbors returned per stop by nearby_stops. The radius is the real
-// constraint on cluster membership; this is just a high safety bound so a
-// pathologically dense area can't return an unbounded neighbor list per stop.
-const NEARBY_STOPS_LIMIT = 1000
-
-// Config for the clustering phase / standalone refetch. JSON-serializable so it
-// crosses the BFF boundary (mirrors BufferFetchConfig).
-export interface StopClusterFetchConfig {
-  feedVersions: FeedVersionRef[]
-  bbox?: Bbox
-  geographyIds?: number[]
-  geoDatasetName: string
-  // The PostGIS nearby_stops radius (meters) — the cluster max distance.
-  maxDistanceMeters: number
-  // GraphQL page size; pagination continues until a short page.
-  stopLimit?: number
-}
-
-interface StopClusterFetchTask {
-  after: number
-  feedOnestopId: string
-  feedVersionSha1: string
-}
-
-// Map a raw GraphQL stop into the minimal ClusterInputStop the algorithm needs.
-function toClusterInputStop (stop: StopClusterStopResponse): ClusterInputStop {
-  const agencyIds = new Set<number>()
-  const routeIds = new Set<number>()
-  for (const rs of stop.route_stops || []) {
-    const route = rs.route
-    if (route?.id != null) {
-      routeIds.add(route.id)
-    }
-    if (route?.agency?.id != null) {
-      agencyIds.add(route.agency.id)
-    }
-  }
-  return {
-    id: stop.id,
-    agencyIds: [...agencyIds],
-    routeIds: [...routeIds],
-    neighborIds: (stop.nearby_stops || []).map(n => n.id),
-  }
-}
-
-// Paginate the scenario's stops (with their in-radius neighbors) and return the
-// complete ClusterInputStop set. Mirrors runStopsPhase's pagination.
-async function fetchStopClusterInputs (
-  config: StopClusterFetchConfig,
-  client: GraphQLClient,
-  emit: PhaseEmit,
-  opts: PhaseOpts = {},
-): Promise<ClusterInputStop[]> {
-  const stopLimit = config.stopLimit ?? 1000
-  const inputs: ClusterInputStop[] = []
-
-  function progressEvent (): ScenarioProgress {
-    const p = queue.getProgress()
-    return {
-      isLoading: true,
-      currentStage: 'stop-clusters',
-      phaseProgress: { phase: 'stop-clusters', completed: p.completed, total: p.total },
-    }
-  }
-
-  async function fetchPage (task: StopClusterFetchTask): Promise<void> {
-    const geoIds = config.geographyIds || []
-    const b = geoIds.length > 0 ? null : convertBbox(config.bbox)
-    const variables = {
-      after: task.after,
-      limit: stopLimit,
-      radius: config.maxDistanceMeters,
-      nearbyLimit: NEARBY_STOPS_LIMIT,
-      where: {
-        location_type: 0,
-        feed_version_sha1: task.feedVersionSha1,
-        location: {
-          bbox: geoIds.length > 0 ? null : b,
-          geography_ids: geoIds.length > 0 ? geoIds : null,
-        },
-      },
-    }
-    const response = await client.query<{ stops: StopClusterStopResponse[] }>(stopClusterQuery, variables)
-    const stops = response.data?.stops || []
-    for (const stop of stops) {
-      inputs.push(toClusterInputStop(stop))
-    }
-    const lastStopId = stops[stops.length - 1]?.id
-    if (stops.length >= stopLimit && lastStopId !== undefined) {
-      queue.enqueueOne({
-        after: lastStopId,
-        feedOnestopId: task.feedOnestopId,
-        feedVersionSha1: task.feedVersionSha1,
-      })
-    }
-  }
-
-  const queue: TaskQueue<StopClusterFetchTask> = new TaskQueue<StopClusterFetchTask>(
-    PHASE_MAX_CONCURRENT_REQUESTS,
-    task => fetchPage(task),
-    {
-      onProgress: () => { emit(progressEvent()) },
-      onError: error => opts.onError?.(error),
-    },
-  )
-
-  for (const fv of config.feedVersions) {
-    queue.enqueueOne({
-      after: 0,
-      feedOnestopId: fv.feedOnestopId,
-      feedVersionSha1: fv.feedVersionSha1,
-    })
-  }
-  await queue.run()
-  return inputs
-}
-
-/**
- * The `stop-clusters` scenario phase: fetch proximity edges from PostGIS, derive
- * clusters, and emit them. Pure over its inputs; callers wrap `emit` with either
- * a stream sender (main scenario / standalone endpoint) or an accumulator.
- */
-export async function runStopClustersPhase (
-  config: StopClusterFetchConfig,
-  client: GraphQLClient,
-  emit: PhaseEmit,
-  opts: PhaseOpts = {},
-): Promise<StopCluster[]> {
-  const inputs = await fetchStopClusterInputs(config, client, emit, opts)
-  const clusters = deriveStopClusters(inputs, config.maxDistanceMeters)
-  emit({
-    isLoading: true,
-    currentStage: 'stop-clusters',
-    partialData: { stopClusters: clusters },
-    phaseProgress: phaseDone('stop-clusters'),
-  })
-  return clusters
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Moves the two scenario phases that lived outside `src/scenario/phases/` into it, and collapses the phase registry — name, pipeline order, progress weight, and enablement predicate — from four parallel structures spread across two directories into one table. Adding a phase was previously six edits in three files, two of which were unchecked; it is now one entry in one array plus a label. Along the way the loading modal's stage-label map becomes exhaustive over the stage union, which surfaced and fixed a missing label for the stop-clusters phase. Also adds `TL_LOG=trace`, a server-side GraphQL request log giving per-query timing and response size, which is what the phase weights should be tuned from and what the codebase previously had no way to measure. No behavior changes beyond the stage label; tracing is off unless the variable is set.

## User-facing changes

This is a refactor and carries one visible fix.

### Loading modal

- The stop clustering phase now reports "Loading transfer hub clusters..." in the loading modal. It previously fell through to a generic "Loading...", since the stage-label map had no entry for it while every other phase did.

## Implementation details

### Phase modules

- `buffer-passes.ts` moves to `phases/buffer-passes.ts` unchanged apart from two relative imports. It was already a phase in every respect — listed in the phase order, gated by the enablement predicates, exposed at its own endpoint — and the phases barrel carried a comment acknowledging that it "predates this directory." That comment is now gone.
- `stop-clusters.ts` is split rather than moved. The file held three concerns: the pure clustering algorithm, the server-side fetch phase, and the report CSV builder. Only the middle one is a phase, and it was already fenced off behind a `SERVER-SIDE PHASE` banner. `StopClusterFetchConfig`, `fetchStopClusterInputs`, `toClusterInputStop`, and `runStopClustersPhase` move to `phases/stop-clusters.ts`; `deriveStopClusters`, `applyClusterTransferTime`, `deriveFilteredStopClusters`, and `stopClusterCsv` stay put. Eight imports fell out of the remaining file as a result, which is a reasonable signal the seam was real.
- The phase imports `deriveStopClusters` from the algorithm module, matching the direction the other phases already depend on `src/tl` — phase depends on logic, not the reverse.
- `buffer-fetcher.test.ts` is renamed to `phases/buffer-passes.test.ts` so it prefixes the implementation file it covers. `stop-clusters.test.ts` stays where it is; it only exercises the algorithm and the CSV builder, neither of which moved.

### Phase registry

- `phases/common.ts` now holds a single ordered `SCENARIO_PHASES` array with `name`, `weight`, and `enabled` per phase. `ScenarioPhaseName`, `SCENARIO_PHASE_ORDER`, `SCENARIO_PHASE_WEIGHTS`, and `scenarioPhasePlan` all derive from it.
- The array uses `as const satisfies readonly {...}[]`, so each entry is shape-checked while the name literals stay narrow and `ScenarioPhaseName` still derives as a proper union rather than widening to `string`.
- `PHASE_ENABLED` and `scenarioPhasePlan` move out of `scenario.ts`, which drops 27 lines and now pulls all eight phase entry points from one `./phases` import instead of two arriving sideways. `common.ts` gains a type-only import of `ScenarioConfig`, following the `ScenarioProgress` import already there — erased at runtime, no cycle.
- The exported surface is unchanged: `SCENARIO_PHASE_ORDER` and `SCENARIO_PHASE_WEIGHTS` keep the same names and types, so no consumer needed editing. One cast survives, since `Object.fromEntries` widens its key type and the weights map needs `as Record<ScenarioPhaseName, number>` to stay exhaustive.
- Three stale comments in `scenario.ts` and one in `scenario.test.ts` referenced `PHASE_ENABLED` by name and now say "the phase registry".

### GraphQL request tracing

- `TL_LOG=trace` makes `BasicGraphQLClient` log one entry per request: operation, elapsed milliseconds, response size, retry count, then the full query as sent and every variable. Nothing is truncated — a request you can't read in full is one you can't reproduce.
- Scoped to `BasicGraphQLClient` deliberately, which covers the CLI and every server-side phase. The browser's Apollo path is not instrumented; devtools already cover it better.
- Response size needs the body read as text, since responses are chunked and carry no `Content-Length`. That read only happens when tracing is on, so the untraced path is unchanged.
- Operation labels fall back to the root field names, because nearly every document in the codebase is anonymous. Failures are logged too, after retries are exhausted.
- Replaces the commented-out `console.log('GraphQL request: ...')` stub that had been sitting in `graphql.ts`. Helpers live in `debug.ts` next to `logMemory`, and `.env.example` now documents both `TL_LOG` and the previously undocumented `DEBUG_MEMORY`.

### Loading stage labels

- `stageLabels` in `scenario-loading.vue` is typed `Record<ScenarioProgress['currentStage'], string>` instead of `Record<string, string>`, so a stage without a label is a compile error rather than a silent fallback.
- That demanded the two missing keys: `stop-clusters` (the live bug) and `extra`. The latter is only a fallback, since analyses that emit `extra` set `currentStageMessage`, which short-circuits earlier in the function.
- The trailing `|| 'Loading...'` stays, since `formatStage` can still receive an out-of-union value from an old saved stream.
- `currentStage` is deliberately left as its own union rather than merged into `ScenarioPhaseName`. It carries the four buffer sub-stages plus `complete`, `ready`, and `extra`, none of which are phases.

## User test plan

- Run a Browse query with the default settings and watch the loading modal. Confirm the phase list and the weighted progress bar behave as before, and that each phase still shows its own message.
- Run a query with a stop cluster distance set. The modal should read "Loading transfer hub clusters..." during that phase rather than a bare "Loading...".
- Run a query with a stop statistical radius set and confirm the four buffer sub-stage messages still appear (per-stop, per-route, per-agency, aggregation).
- With a scenario loaded, change the stop buffer radius and confirm the standalone buffer refetch still fires and repopulates the Stops, Routes, and Agencies demographic columns.
- With a scenario loaded, change the stop cluster distance and confirm the standalone cluster refetch still fires and the Stop Clusters report tab updates.
- Uncheck census, departures, or fixed-route in the query form and confirm the phase plan shortens accordingly in the loading modal.
- Run the CLI or a scenario endpoint with `TL_LOG=trace` set and confirm one log entry per GraphQL request, each carrying a timing, a response size, and the complete query and variables. Confirm the log is silent with the variable unset.
